### PR TITLE
Fix trendChart destroy

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
 let epicForecastResults = {};
 let historicData = [];
 let storyFilters = { current:true, previous:true, new:true, open:true, removed:true };
+let trendChart = null;
 
     function loadHistoricData() {
       try { historicData = JSON.parse(localStorage.getItem('mc_hist')) || []; }
@@ -348,8 +349,8 @@ let storyFilters = { current:true, previous:true, new:true, open:true, removed:t
       const ctx = document.getElementById('trendChart').getContext('2d');
       const labels = historicData.map(h=>h.sprint);
       const data = historicData.map(h=>h.backlog);
-      if (window.trendChart) window.trendChart.destroy();
-      window.trendChart = new Chart(ctx, {
+      if (trendChart && typeof trendChart.destroy === 'function') trendChart.destroy();
+      trendChart = new Chart(ctx, {
         type:'line',
         data:{ labels, datasets:[{ label:'Backlog', data, borderColor:'#6366f1', fill:false }] },
         options:{ scales:{ y:{ beginAtZero:true } } }


### PR DESCRIPTION
## Summary
- use dedicated variable `trendChart` to hold chart instance
- guard destroy call by checking the function

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e5bca6d0483258aa405f30892c5c1