### PR TITLE
Display needed story points for required allocation

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
 let jiraDomain = '', boardNum = '', sprints = [], closedSprintsSorted = [];
 let allEpics = {}, epicStories = {}, epicStoriesBaseline = {};
 let velocityArr = [];
+let avgVelocity = 0;
 let selectedSprintId = '', selectedSprintName = '', targetSprints = 4;
 let baselineSprintId = '', baselineIsFirstPI = false;
 let epicAllocations = {}, epicBacklogs = {}, epicRequiredAlloc = {};
@@ -471,6 +472,7 @@ let boardTeams = [];
         document.getElementById('epicSummary').innerHTML = '<div class="warn">Please set at least 3 recent velocity values.</div>';
         return;
       }
+      avgVelocity = velocity.reduce((a,b)=>a+b,0)/velocity.length;
       epicBacklogs = {};
       let totalBacklog = 0;
       Object.keys(epicStories).forEach(epicKey => {
@@ -552,6 +554,7 @@ let boardTeams = [];
         let required = epicRequiredAlloc[epicKey];
         let mc = epicForecastResults[epicKey];
         let probRows = [[50,mc[Math.floor(0.5*mc.length)]],[75,mc[Math.floor(0.75*mc.length)]],[95,mc[Math.floor(0.95*mc.length)]]];
+        const pointsFor = pct => Math.round(avgVelocity * targetSprints * pct / 100);
 
         let baseStories = (epicStoriesBaseline[epicKey]||[]);
         let baseKeys = new Set(baseStories.map(s=>s.key));
@@ -562,6 +565,7 @@ let boardTeams = [];
         let doneSince = ptsDone - baseDone;
         let estimateBaseline = baseStories.map(s=>s.points).reduce((a,b)=>a+b,0);
         let deltaEstimate = totalEstimate - estimateBaseline;
+        const ptsFor = pct => Math.round(avgVelocity * targetSprints * pct / 100);
         const currSprintObj = sprints.find(s => String(s.id) === String(selectedSprintId));
         const storyMapId = `storyMap_${epicKey.replace(/[^a-zA-Z0-9]/g, '')}`;
         const risk = ((required["75"] && required["75"]-alloc>15) || scopeIncreaseConsistent(epicKey));
@@ -590,8 +594,8 @@ let boardTeams = [];
               <div style="margin-bottom:8px;">
                 <b>Required allocation to finish in ${targetSprints} sprints:</b>
                 <ul style="margin:3px 0 0 0;padding-left:1.3em;">
-                  <li>75% confidence: ${required["75"] ? required["75"]+"%" : '<span class="warn">Over 100%</span>'}</li>
-                  <li>95% confidence: ${required["95"] ? required["95"]+"%" : '<span class="warn">Over 100%</span>'}</li>
+                  <li>75% confidence: ${required["75"] ? required["75"]+"% ("+pointsFor(required["75"])+" SP)" : '<span class="warn">Over 100%</span>'}</li>
+                  <li>95% confidence: ${required["95"] ? required["95"]+"% ("+pointsFor(required["95"]) + " SP)" : '<span class="warn">Over 100%</span>'}</li>
                 </ul>
               </div>
               <div style="font-size:0.99em;">
@@ -714,6 +718,8 @@ let boardTeams = [];
       pdf.setFont('helvetica','normal');
       pdf.setFontSize(11);
       pdf.text(velocityArr.join(", "), 45, y); y+=18;
+      const velList = velocityArr.filter(v=>v>0);
+      avgVelocity = velList.reduce((a,b)=>a+b,0)/velList.length;
       pdf.setLineWidth(0.3);
       pdf.line(45, y, 530, y); y+=8;
       pdf.text('Story map legend: Done this sprint | Done before | New story | Open/In Progress', 45, y); y+=15;
@@ -765,7 +771,7 @@ let boardTeams = [];
         pdf.setFontSize(11);
 
         pdf.text(`Done: ${ptsDone}    In Progress: ${ptsProg}    Open: ${ptsOpen+ptsOther}    Total: ${totalEstimate} SP    Backlog: ${backlog} SP`, 45, y); y+=15;
-        pdf.text(`Team allocation: ${alloc}%   |   Required for ${targetSprints} sprints: 75% conf: ${required["75"]?required["75"]+"%":"Over 100%"}  / 95% conf: ${required["95"]?required["95"]+"%":"Over 100%"}`, 45, y); y+=13;
+        pdf.text(`Team allocation: ${alloc}%   |   Required for ${targetSprints} sprints: 75% conf: ${required["75"]?required["75"]+"% ("+ptsFor(required["75"])+" SP)":"Over 100%"}  / 95% conf: ${required["95"]?required["95"]+"% ("+ptsFor(required["95"]) + " SP)":"Over 100%"}`, 45, y); y+=13;
         pdf.text(`Probability forecast (sprints needed):`, 45, y); y+=12;
         probRows.forEach(r=>{
           pdf.text(`${r[0]}%: ${r[1]} sprints`, 70, y); y+=11;


### PR DESCRIPTION
## Summary
- track average velocity
- compute required story points given the required allocation
- show the story points in the UI and PDF sections for required allocation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878fa7907588325979f13514e6ddab2