### PR TITLE
Show unestimated stories in report

### DIFF
--- a/index.html
+++ b/index.html
@@ -592,6 +592,7 @@ let teamFilters = {};
         let currKeys = new Set(currStories.map(s=>s.key));
         let newStories = currStories.filter(s=>!baseKeys.has(s.key));
         let removedStories = baseStories.filter(s=>!currKeys.has(s.key));
+        let unestimated = currStories.filter(s=>s.points===0).length;
         let baseDone = baseStories.filter(s=>statusGroup(s.status)==="Done").map(s=>s.points).reduce((a,b)=>a+b,0);
         let doneSince = ptsDone - baseDone;
         let estimateBaseline = baseStories.map(s=>s.points).reduce((a,b)=>a+b,0);
@@ -607,7 +608,7 @@ let teamFilters = {};
             <span class="status-pill pill-done">${ptsDone} Done</span>
             <span class="status-pill pill-prog">${ptsProg} In Progress</span>
             <span class="status-pill pill-open">${ptsOpen+ptsOther} Open</span>
-            &nbsp; <b>Total:</b> ${totalEstimate} SP &nbsp; | &nbsp; <b>Backlog:</b> ${backlog} SP
+            &nbsp; <b>Total:</b> ${totalEstimate} SP &nbsp; | &nbsp; <b>Backlog:</b> ${backlog} SP &nbsp; | &nbsp; <b>Unestimated:</b> ${unestimated}
           </div>
           <div class="info-grid">
             <div>
@@ -623,7 +624,7 @@ let teamFilters = {};
                 </table>
               </div>
               <div style="margin-bottom:8px;">
-                <b>Required allocation to finish in ${targetSprints} sprints:</b>
+                <b>Required allocation${unestimated>0?'+':''} to finish in ${targetSprints} sprints:</b>
                 <ul style="margin:3px 0 0 0;padding-left:1.3em;">
                   ${(() => {
                     const fmt = pct => {
@@ -817,6 +818,7 @@ let teamFilters = {};
         let currKeys = new Set(currStories.map(s=>s.key));
         let newStories = currStories.filter(s=>!baseKeys.has(s.key));
         let removedStories = baseStories.filter(s=>!currKeys.has(s.key));
+        let unestimated = currStories.filter(s=>s.points===0).length;
         let baseDone = baseStories.filter(s=>statusGroup(s.status)==="Done").map(s=>s.points).reduce((a,b)=>a+b,0);
         let doneSince = ptsDone - baseDone;
         let estimateBaseline = baseStories.map(s=>s.points).reduce((a,b)=>a+b,0);
@@ -830,14 +832,14 @@ let teamFilters = {};
         pdf.setFont('helvetica','normal');
         pdf.setFontSize(11);
 
-        pdf.text(`Done: ${ptsDone}    In Progress: ${ptsProg}    Open: ${ptsOpen+ptsOther}    Total: ${totalEstimate} SP    Backlog: ${backlog} SP`, 45, y); y+=15;
+        pdf.text(`Done: ${ptsDone}    In Progress: ${ptsProg}    Open: ${ptsOpen+ptsOther}    Total: ${totalEstimate} SP    Backlog: ${backlog} SP    Unestimated: ${unestimated}`, 45, y); y+=15;
 
         const fmtReq = pct => {
           const sp = epicRequiredSP[epicKey][pct];
           return sp != null ? `${sp} SP/sprint (${required[pct]}%)` : 'Over 100%';
         };
         pdf.text(
-          `Team allocation: ${alloc}%   |   Required for ${targetSprints} sprints: ` +
+          `Team allocation: ${alloc}%   |   Required for ${targetSprints} sprints${unestimated>0?'+':''}: ` +
           `75% conf: ${fmtReq("75")}  / 95% conf: ${fmtReq("95")}`, 45, y
         );
         y += 13;


### PR DESCRIPTION
## Summary
- display how many stories are unestimated per epic
- append `+` after required allocation if there are unestimated stories
- include the new info in the PDF export as well

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879f4fc1c6c832581bb13f0fc4b671b