### PR TITLE
Adjust status and story map colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,10 @@
     .info-grid { display:grid; grid-template-columns:1.7fr 1.3fr; gap:1.5em; }
     .change-block { font-size: 0.99em; }
     .status-pill { display:inline-block; min-width:64px; font-size:0.96em; border-radius:12px; padding:1.5px 13px; margin-right:6px; margin-bottom:3px;}
-    .pill-done { background:#c7f9cc; color:#086d46; }
-    .pill-prog { background:#ffe066; color:#947600;}
-    .pill-open { background:#cfe2ff; color:#184e98;}
-    .pill-other { background:#ddd; color:#444;}
+    .pill-done { background:#10b981; color:#fff; }
+    .pill-prog { background:#f59e0b; color:#fff; }
+    .pill-open { background:#3b82f6; color:#fff; }
+    .pill-other { background:#6b7280; color:#fff; }
     .warn { color:#e11d48; font-weight: 600;}
     .success { color:#059669; font-weight:600;}
     .allocation-row {margin-bottom: 12px;}
@@ -44,21 +44,21 @@
     .story-table { border-collapse: collapse; width: 100%; margin: 6px 0 18px 0; }
     .story-table th, .story-table td { border: 1px solid #e5e7eb; padding: 4px 7px; font-size: 0.98em; text-align:left; }
     .story-table th { background: #e0e7ef; }
-    .story-status-current { background: #b2ebf2; }
-    .story-status-previous { background: #c8e6c9; }
-    .story-status-new { background: #fff59d; }
-    .story-status-open { background: #e0e7ff; }
-    .story-status-other { background: #ECECEC; }
+    .story-status-current { background: #b3e5fc; }
+    .story-status-previous { background: #dcedc8; }
+    .story-status-new { background: #fff9c4; }
+    .story-status-open { background: #f8bbd0; }
+    .story-status-other { background: #e0e0e0; }
     .story-map { display:flex; gap:12px; overflow-x:auto; }
     .story-lane { flex:1; min-width:180px; background:#fafafa; border:1px solid #e5e7eb; border-radius:6px; padding:6px; }
     .removed-lane { background:#fbe8eb; }
     .story-lane-header { font-weight:600; margin-bottom:4px; font-size:0.96em; color:#374151; }
     .story-card { border:1px solid #e5e7eb; border-radius:4px; padding:4px 5px; margin-bottom:6px; background:white; font-size:0.92em; }
-    .story-card.story-status-current { background:#b2ebf2; }
-    .story-card.story-status-previous { background:#c8e6c9; }
-    .story-card.story-status-new { background:#fff59d; }
-    .story-card.story-status-open { background:#e0e7ff; }
-    .story-card.story-status-other { background:#ECECEC; }
+    .story-card.story-status-current { background:#b3e5fc; }
+    .story-card.story-status-previous { background:#dcedc8; }
+    .story-card.story-status-new { background:#fff9c4; }
+    .story-card.story-status-open { background:#f8bbd0; }
+    .story-card.story-status-other { background:#e0e0e0; }
     .story-card .tags { margin-top:2px; }
     .story-tag { font-size:0.75em; background:#d1d5db; color:#111; border-radius:3px; padding:1px 4px; margin-right:3px; }
     .story-card .small { font-size:0.8em; color:#555; }


### PR DESCRIPTION
## Summary
- update status pill colors to saturated tones
- tweak story map colors to lighter palette

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688099ed68fc8325943531512b1946a8