### PR TITLE
Add remove all option for team filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,6 +403,11 @@ let teamChoices = null;
     }
 
 
+    function clearTeamFilter() {
+      Object.keys(teamFilters).forEach(t => { teamFilters[t] = false; });
+      renderEpicSummary(true);
+    }
+
 
     function renderFilterOptions() {
       if (statusChoices) { statusChoices.destroy(); statusChoices = null; }
@@ -429,7 +434,7 @@ let teamChoices = null;
       document.getElementById('filterOptions').innerHTML =
         '<span class="section-title" style="display:block;margin-top:0;">Story Map Filters:</span>'+
         statusSelectHtml+
-        (Object.keys(teamFilters).length ? '<br><span class="section-title" style="display:block;margin-top:0.8em;">Team Filter:</span>'+teamSelectHtml : '');
+        (Object.keys(teamFilters).length ? '<br><span class="section-title" style="display:block;margin-top:0.8em;">Team Filter:</span>'+teamSelectHtml+' <button class="btn" onclick="clearTeamFilter()">Remove All</button>' : '');
 
       const statusEl = document.getElementById('statusSelect');
       const teamEl = document.getElementById('teamSelect');


### PR DESCRIPTION
## Summary
- enable clearing team selections by setting all filters to `false`
- keep *Remove All* button in filter section

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6880c16723048325bc4f3a85d385cfaa