### PR TITLE
Improve story map statuses

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
     .status-pill { display:inline-block; min-width:64px; font-size:0.96em; border-radius:12px; padding:1.5px 13px; margin-right:6px; margin-bottom:3px;}
     .pill-done { background:#10b981; color:#fff; }
     .pill-prog { background:#f59e0b; color:#fff; }
+    .pill-blocked { background:#ef4444; color:#fff; }
     .pill-open { background:#3b82f6; color:#fff; }
     .pill-other { background:#6b7280; color:#fff; }
     .warn { color:#e11d48; font-weight: 600;}
@@ -49,6 +50,8 @@
     .story-status-previous { background: #dcedc8; }
     .story-status-new { background: #fff9c4; }
     .story-status-open { background: #f8bbd0; }
+    .story-status-inprogress { background: #ffe0b2; }
+    .story-status-blocked { background: #fecaca; }
     .story-status-other { background: #e0e0e0; }
     .story-map { display:flex; gap:12px; overflow-x:auto; }
     .story-lane { flex:1; min-width:180px; background:#fafafa; border:1px solid #e5e7eb; border-radius:6px; padding:6px; }
@@ -59,6 +62,8 @@
     .story-card.story-status-previous { background:#dcedc8; }
     .story-card.story-status-new { background:#fff9c4; }
     .story-card.story-status-open { background:#f8bbd0; }
+    .story-card.story-status-inprogress { background:#ffe0b2; }
+    .story-card.story-status-blocked { background:#fecaca; }
     .story-card.story-status-other { background:#e0e0e0; }
     .story-card .tags { margin-top:2px; }
     .story-tag { font-size:0.75em; background:#d1d5db; color:#111; border-radius:3px; padding:1px 4px; margin-right:3px; }
@@ -288,7 +293,10 @@ let teamChoices = null;
         return "story-status-previous";
       }
       if (!resolved || !story.status || !(story.status.toLowerCase().includes("done") || story.status.toLowerCase().includes("closed"))) {
-        return "story-status-open";
+        const st = (story.status||'').toLowerCase();
+        if (st.includes('block')) return 'story-status-blocked';
+        if (st.includes('progress') || st.includes('development')) return 'story-status-inprogress';
+        return 'story-status-open';
       }
       return "story-status-other";
     }
@@ -454,6 +462,8 @@ let teamChoices = null;
         document.querySelectorAll('.story-status-previous').forEach(el=>el.style.display = storyFilters.previous? '':'none');
         document.querySelectorAll('.story-status-new').forEach(el=>el.style.display = storyFilters.new? '':'none');
         document.querySelectorAll('.story-status-open').forEach(el=>el.style.display = storyFilters.open? '':'none');
+        document.querySelectorAll('.story-status-inprogress').forEach(el=>el.style.display = storyFilters.open? '':'none');
+        document.querySelectorAll('.story-status-blocked').forEach(el=>el.style.display = storyFilters.open? '':'none');
         document.querySelectorAll('.story-status-other').forEach(el=>el.style.display = storyFilters.open? '':'none');
         document.querySelectorAll('.removed-lane').forEach(el=>el.style.display = storyFilters.removed? '':'none');
         document.querySelectorAll('.story-card').forEach(el=>{
@@ -467,14 +477,14 @@ let teamChoices = null;
       function updateEpicStatusCounts() {
         const currSprintObj = sprints.find(s => String(s.id) === String(selectedSprintId));
         Object.keys(epicStories).forEach(epicKey => {
-          let done=0, prog=0, open=0, other=0;
+          let done=0, prog=0, open=0, blocked=0, other=0;
           (epicStories[epicKey]||[]).forEach(story => {
             let show=true;
             let cls = getStoryRowClass(story, currSprintObj);
             if (cls==='story-status-current' && !storyFilters.current) show=false;
             else if (cls==='story-status-previous' && !storyFilters.previous) show=false;
             else if (cls==='story-status-new' && !storyFilters.new) show=false;
-            else if ((cls==='story-status-open' || cls==='story-status-other') && !storyFilters.open) show=false;
+            else if ((cls==='story-status-open' || cls==='story-status-inprogress' || cls==='story-status-blocked' || cls==='story-status-other') && !storyFilters.open) show=false;
             if (show) {
               let teams=(story.team||'').split(',').map(t=>t.trim()).filter(Boolean);
               if (teams.length && !teams.some(t=>teamFilters[t])) show=false;
@@ -483,7 +493,8 @@ let teamChoices = null;
             let grp=statusGroup(story.status);
             if (grp==='Done') done++;
             else if (grp==='In Progress') prog++;
-            else if (grp==='Ready/Open') open++;
+            else if (grp==='Open') open++;
+            else if (grp==='Blocked') blocked++;
             else other++;
           });
           const block=document.getElementById(`storyMap_${epicKey.replace(/[^a-zA-Z0-9]/g,'')}`);
@@ -492,9 +503,11 @@ let teamChoices = null;
           if (!container) return;
           const doneSpan=container.querySelector('.pill-done');
           const progSpan=container.querySelector('.pill-prog');
+          const blockedSpan=container.querySelector('.pill-blocked');
           const openSpan=container.querySelector('.pill-open');
           if (doneSpan) doneSpan.textContent=`${done} Done`;
           if (progSpan) progSpan.textContent=`${prog} In Progress`;
+          if (blockedSpan) blockedSpan.textContent=`${blocked} Blocked`;
           if (openSpan) openSpan.textContent=`${open+other} Open`;
         });
       }
@@ -640,8 +653,8 @@ let teamChoices = null;
       Object.keys(epicStories).forEach((epicKey, idx) => {
         let stories = epicStories[epicKey];
         if (!stories || !stories.length) return;
-        let statusCounts = {done:0,prog:0,open:0,other:0};
-        let ptsDone=0, ptsProg=0, ptsOpen=0, ptsOther=0;
+        let statusCounts = {done:0,prog:0,open:0,blocked:0,other:0};
+        let ptsDone=0, ptsProg=0, ptsOpen=0, ptsBlocked=0, ptsOther=0;
         let unestimated = 0;
         stories.forEach(story => {
           let teams = (story.team||'').split(',').map(t=>t.trim()).filter(Boolean);
@@ -649,12 +662,13 @@ let teamChoices = null;
           let sgrp = statusGroup(story.status);
           if (sgrp==='Done') { statusCounts.done++; ptsDone+=story.points; }
           else if (sgrp==='In Progress') { statusCounts.prog++; ptsProg+=story.points; }
-          else if (sgrp==='Ready/Open') { statusCounts.open++; ptsOpen+=story.points; }
+          else if (sgrp==='Open') { statusCounts.open++; ptsOpen+=story.points; }
+          else if (sgrp==='Blocked') { statusCounts.blocked++; ptsBlocked+=story.points; }
           else { statusCounts.other++; ptsOther+=story.points; }
           if (!story.points && sgrp!=='Done') unestimated++;
         });
-        let totalEstimate = ptsDone+ptsProg+ptsOpen+ptsOther;
-        let backlog = ptsProg+ptsOpen+ptsOther;
+        let totalEstimate = ptsDone+ptsProg+ptsOpen+ptsBlocked+ptsOther;
+        let backlog = ptsProg+ptsOpen+ptsBlocked+ptsOther;
         let alloc = epicAllocations[epicKey];
         let required = epicRequiredAlloc[epicKey];
         let mc = epicForecastResults[epicKey];
@@ -687,6 +701,7 @@ let teamChoices = null;
           <div style="margin-top:4px;margin-bottom:10px;">
             <span class="status-pill pill-done">${ptsDone} Done</span>
             <span class="status-pill pill-prog">${ptsProg} In Progress</span>
+            <span class="status-pill pill-blocked">${ptsBlocked} Blocked</span>
             <span class="status-pill pill-open">${ptsOpen+ptsOther} Open</span>
             &nbsp; <b>Total:</b> ${totalEstimate} SP &nbsp; | &nbsp; <b>Backlog:</b> ${backlog} SP &nbsp; | &nbsp; <b>Unestimated:</b> ${unestimated}
           </div>
@@ -762,7 +777,8 @@ let teamChoices = null;
                 const lanes = [
                   ['Done', stories.filter(s=>statusGroup(s.status)==='Done')],
                   ['In Progress', stories.filter(s=>statusGroup(s.status)==='In Progress')],
-                  ['Open', stories.filter(s=>statusGroup(s.status)==='Ready/Open')]
+                  ['Open', stories.filter(s=>statusGroup(s.status)==='Open')],
+                  ['Blocked', stories.filter(s=>statusGroup(s.status)==='Blocked')]
                 ];
                 return lanes.map(l => `
                   <div class="story-lane">
@@ -794,7 +810,9 @@ let teamChoices = null;
               <span class="story-status-current">Done this sprint</span>
               <span class="story-status-previous">Done before</span>
               <span class="story-status-new">New story</span>
-              <span class="story-status-open">Open/In Progress</span>
+              <span class="story-status-inprogress">In Progress</span>
+              <span class="story-status-open">Open</span>
+              <span class="story-status-blocked">Blocked</span>
               <span class="removed-lane">Removed since last sprint</span>
               <span class="story-status-other">Other</span>
             </div>
@@ -824,8 +842,9 @@ let teamChoices = null;
     function statusGroup(s) {
       s = (s||"").toLowerCase();
       if (s.includes("done") || s.includes("closed")) return "Done";
+      if (s.includes("block")) return "Blocked";
       if (s.includes("progress") || s.includes("development")) return "In Progress";
-      if (s === "ready" || s === "open") return "Ready/Open";
+      if (s === "ready" || s === "open" || s === "todo") return "Open";
       return "Other";
     }
 


### PR DESCRIPTION
## Summary
- split `Open` and `In Progress` categories
- highlight stories marked **Blocked**
- update legend and epic status pills accordingly

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6880cb246ce08325943952ffdb313d3b