### PR TITLE
Add line break in epic summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -705,8 +705,8 @@ let teamChoices = null;
             <span class="status-pill pill-done">${statusCounts.done} Done (${ptsDone} SP)</span>
             <span class="status-pill pill-prog">${statusCounts.prog} In Progress (${ptsProg} SP)</span>
             <span class="status-pill pill-blocked">${statusCounts.blocked} Blocked (${ptsBlocked} SP)</span>
-            <span class="status-pill pill-open">${statusCounts.open} Open (${ptsOpen} SP)</span>
-            &nbsp; <b>Total:</b> ${totalEstimate} SP &nbsp; | &nbsp; <b>Backlog:</b> ${backlog} SP &nbsp; | &nbsp; <b>Unestimated:</b> ${unestimated}
+            <span class="status-pill pill-open">${statusCounts.open} Open (${ptsOpen} SP)</span><br>
+            <b>Total:</b> ${totalEstimate} SP &nbsp; | &nbsp; <b>Backlog:</b> ${backlog} SP &nbsp; | &nbsp; <b>Unestimated:</b> ${unestimated}
           </div>
           <div class="info-grid">
             <div>


### PR DESCRIPTION
## Summary
- ensure epic summaries always break line between status pills and totals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880da51f60c8325b6ea383602aeb745