### PR TITLE
Update simulation counts

### DIFF
--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -91,7 +91,7 @@ percentage of team capacity), a single simulation run proceeds as:
    - Reduce the backlog `b = b - v_eff` and increment `s`.
 3. Record the number of sprints `s` for this run.
 
-Eight thousand runs are executed for each epic. After sorting the list of
+Ten thousand runs are executed for each epic. After sorting the list of
 `s` values, the 50th, 75th and 95th percentiles provide the simulated
 sprint counts at different confidence levels. Formally, if `S` is the
 sorted vector of results and `N` its length, the estimate for probability
@@ -99,7 +99,7 @@ sorted vector of results and `N` its length, the estimate for probability
 
 The tool also determines how much capacity an epic needs to finish within
 a target sprint count. For each allocation percentage between 1% and
-100%, 600 simulations are run as above using that allocation. The
+100%, 5000 simulations are run as above using that allocation. The
 smallest percentage where the 75% or 95% percentile does not exceed the
 target is reported as the required allocation (and converted into story
 points using the average velocity).

--- a/index.html
+++ b/index.html
@@ -563,7 +563,7 @@ let teamChoices = null;
         let alloc = epicAllocations[epicKey];
         let allocVels = velocity.map(v=>v*alloc/100);
         let mcRuns = [];
-        for (let i=0; i<8000; i++) {
+        for (let i=0; i<10000; i++) {
           let b = backlogPts, s=0;
           while (b>0 && s<100) {
             let v = allocVels[Math.floor(Math.random()*allocVels.length)];
@@ -578,7 +578,7 @@ let teamChoices = null;
         for (let pct=1;pct<=100;pct++) {
           let testVels = velocity.map(v=>v*pct/100);
           let runs = [];
-          for (let i=0;i<600;i++) {
+          for (let i=0;i<5000;i++) {
             let b = backlogPts, s=0;
             while (b>0 && s<100) {
               let v = testVels[Math.floor(Math.random()*testVels.length)];
@@ -611,7 +611,7 @@ let teamChoices = null;
         for (let pct=1;pct<=100;pct++) {
           let testVels = velocity.map(v=>v*pct/100);
           let runs = [];
-          for (let i=0;i<600;i++) {
+          for (let i=0;i<5000;i++) {
             let b = backlogPts, s=0;
             while (b>0 && s<100) {
               let v = testVels[Math.floor(Math.random()*testVels.length)];


### PR DESCRIPTION
## Summary
- run 10k Monte Carlo simulations when forecasting backlog
- run 5k simulations for required allocation calculations
- document the updated numbers in arc42

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6880e0611d80832596f0a43d27ac6c19