### PR TITLE
Improve allocation summary wording and docs

### DIFF
--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -104,3 +104,16 @@ smallest percentage where the 75% or 95% percentile does not exceed the
 target is reported as the required allocation (and converted into story
 points using the average velocity).
 
+To calculate this requirement the algorithm iterates over candidate
+allocations from 1&nbsp;% to 100&nbsp;%. For each candidate **p** the
+historic velocity array is scaled by `p/100` to create a set of possible
+sprint velocities. Five thousand runs are executed using that scaled
+array and the resulting sprint counts are sorted. If both the 75th and
+95th percentile of those counts are less than or equal to the target
+sprints, **p** is accepted as the minimum capacity needed. The resulting
+percentage is then multiplied by the average of the historic velocities
+to express the requirement in story points per sprint. When no
+percentage meets the target within 100&nbsp;%, the report shows the value
+as over 100&nbsp;% to signal that finishing in the chosen timeframe is
+unlikely with current velocity.
+

--- a/index.html
+++ b/index.html
@@ -648,8 +648,9 @@ let teamChoices = null;
         ? `<span class="warn">Required allocations exceed team capacity. Not all epics likely to finish.</span>`
         : `<span class="success">Required allocations within team capacity.</span>`;
       document.getElementById('requiredSummary').innerHTML =
-        `<div><b>Sum of required allocation for ${targetSprints} sprints:</b> `+
-        `75% = ${totalReq75}% &nbsp; | &nbsp; 95% = ${totalReq95}%<br>${reqWarn}</div>`;
+        `<div><b>Sum of required allocation to finish in ${targetSprints} sprints:</b> `+
+        `${totalReq75}% at 75% confidence &nbsp; | &nbsp; ${totalReq95}% at 95% confidence`+
+        `<br>${reqWarn}</div>`;
       // The total allocation info is still calculated for simulations but no longer displayed in the UI
       let html = '';
 


### PR DESCRIPTION
## Summary
- clarify wording for team allocation summary in the report
- describe allocation search logic in depth in arc42 docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880e3ca5d3083259dd8d76310adff98