### PR TITLE
Fix deltaEstimate to use backlog

### DIFF
--- a/index.html
+++ b/index.html
@@ -716,7 +716,7 @@ let teamChoices = null;
         let doneSince = ptsDone - baseDone;
         let estimateBaseline = baseStories.map(s=>s.points).reduce((a,b)=>a+b,0);
 
-        let deltaEstimate = totalEstimate - estimateBaseline;
+        let deltaEstimate = backlog - estimateBaseline;
         const storyMapId = `storyMap_${epicKey.replace(/[^a-zA-Z0-9]/g, '')}`;
         const risk = ((required["75"] && required["75"]-alloc>15) || scopeIncreaseConsistent(epicKey));
         html += `


### PR DESCRIPTION
## Summary
- correct `deltaEstimate` calculation to compare backlog against the baseline

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6881f0736e8c8325bbb42574aef44387