### PR TITLE
Remove tooltips from required allocation bullets

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,8 +816,8 @@ function addTooltipListeners() {
                       return sp != null ? `${sp} SP` : 'n/a';
                     };
                     return [
-                      `<li>75% confidence: ${fmt("75")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("75")})</span><span class="info-icon" data-tip="Estimated capacity per sprint for a 75% chance of finishing on time. Calculated using Monte Carlo simulations.">&#9432;<span class="tooltip"></span></span></li>`,
-                      `<li>95% confidence: ${fmt("95")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("95")})</span><span class="info-icon" data-tip="Capacity needed for a 95% likelihood of completion within the target sprints. Based on Monte Carlo results.">&#9432;<span class="tooltip"></span></span></li>`
+                      `<li>75% confidence: ${fmt("75")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("75")})</span></li>`,
+                      `<li>95% confidence: ${fmt("95")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("95")})</span></li>`
                     ].join('');
                   })()}
                 </ul>


### PR DESCRIPTION
## Summary
- clean up Required allocation bullets by removing info icons

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68832642fac88325895a207f4288775f