### PR TITLE
Add throughput-based version

### DIFF
--- a/index_throughput.html
+++ b/index_throughput.html
@@ -1,0 +1,963 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Stakeholder PI Status Report – MCW with Allocation</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
+  <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+  <style>
+    body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin: 0; padding: 0; }
+    .main { max-width: 950px; margin: 30px auto 40px auto; background: #fff; border-radius: 18px; box-shadow: 0 2px 12px #d1d5db70; padding: 36px 32px; }
+    h1 { font-size: 2.3em; margin:0 0 0.7em 0; font-weight: 600; }
+    h2 { font-size: 1.3em; margin-top:2em; }
+    .btn { background: #6366f1; color: #fff; border: none; border-radius: 6px; padding: 7px 18px; cursor: pointer; font-size:1em; margin: 0 10px 8px 0;}
+    .btn:disabled { background: #aaa; }
+    .sprint-row label { margin-right: 1.2em; }
+    .section-title { font-size: 1.1em; font-weight: 600; margin: 1.7em 0 0.5em 0; }
+    .epic-summary-block { margin:2em 0 2.5em 0; border-radius:14px; background: #f3f4f6; box-shadow: 0 1px 6px #e0e7ef70; padding: 24px 24px 18px 24px; position:relative; }
+    .epic-risk { border:2px solid #e11d48; box-shadow:0 0 6px #e11d48; }
+    .epic-select-label { position:absolute; bottom:8px; right:8px; font-size:0.9em; }
+    .epic-select-checkbox { margin-right:4px; }
+    .epic-header { font-size: 1.15em; font-weight: 600; color: #374151; }
+    .allocation-bar { height: 18px; border-radius: 8px; background: #6366f1; display:inline-block; vertical-align:middle;}
+    .prob-table { border-collapse:collapse; margin:12px 0 18px 0;}
+    .prob-table th, .prob-table td { border:1px solid #e5e7eb; font-size:0.98em; padding:4px 11px;}
+    .prob-table th { background:#e0e7ef;}
+    .info-grid { display:grid; grid-template-columns:1.7fr 1.3fr; gap:1.5em; }
+    .change-block { font-size: 0.99em; }
+    .status-pill { display:inline-block; min-width:64px; font-size:0.96em; border-radius:12px; padding:1.5px 13px; margin-right:6px; margin-bottom:3px;}
+    .pill-done { background:#10b981; color:#fff; }
+    .pill-prog { background:#f59e0b; color:#fff; }
+    .pill-blocked { background:#ef4444; color:#fff; }
+    .pill-open { background:#3b82f6; color:#fff; }
+    .warn { color:#e11d48; font-weight: 600;}
+    .success { color:#059669; font-weight:600;}
+    .allocation-row {margin-bottom: 12px;}
+    .alloc-label {display:inline-block; min-width: 80px;}
+    .editarr { width: 50px;}
+    .pdf-cover { font-size:2.1em; text-align:center; margin-top:80px; color:#6366f1;}
+    .pdf-sub { font-size:1.1em; color:#374151; text-align:center; margin-top:20px;}
+    .pdf-section-title { font-size:1.15em; font-weight:600; margin-top:25px;}
+    .details-toggle { margin: 10px 0 6px 0; }
+    .story-table { border-collapse: collapse; width: 100%; margin: 6px 0 18px 0; }
+    .story-table th, .story-table td { border: 1px solid #e5e7eb; padding: 4px 7px; font-size: 0.98em; text-align:left; }
+    .story-table th { background: #e0e7ef; }
+    .story-status-current { background: #b3e5fc; }
+    .story-status-previous { background: none; }
+    .story-status-new { background: #fff9c4; }
+    .story-status-open { background: none; }
+    .story-status-inprogress { background: none; }
+    .story-status-blocked { background: none; }
+    .story-status-other { background: #e0e0e0; }
+    .story-map { display:flex; gap:12px; overflow-x:auto; }
+    .story-lane { flex:1; min-width:180px; background:#fafafa; border:1px solid #e5e7eb; border-radius:6px; padding:6px; }
+    .removed-lane { background:#ffe4e6; }
+    .removed-lane .story-card.story-status-other { background:#ffd6dc; }
+    .story-lane-header { font-weight:600; margin-bottom:4px; font-size:0.96em; color:#374151; }
+    .story-card { border:1px solid #e5e7eb; border-radius:4px; padding:4px 5px; margin-bottom:6px; background:white; font-size:0.92em; }
+    .story-card.story-status-current { background:#b3e5fc; }
+    .story-card.story-status-previous { background:none; }
+    .story-card.story-status-new { background:#fff9c4; }
+    .story-card.story-status-open { background:none; }
+    .story-card.story-status-inprogress { background:none; }
+    .story-card.story-status-blocked { background:none; }
+    .story-card.story-status-other { background:#e0e0e0; }
+    .story-card .tags { margin-top:2px; }
+    .story-tag { font-size:0.75em; background:#d1d5db; color:#111; border-radius:3px; padding:1px 4px; margin-right:3px; }
+    .story-card .small { font-size:0.8em; color:#555; }
+    .story-map-legend span {
+      display:inline-block;
+      padding:2px 8px;
+      border-radius:4px;
+      margin-right:6px;
+      border:1px solid #9ca3af;
+      font-weight:600;
+    }
+    .info-icon {
+      cursor:pointer;
+      font-size:0.9em;
+      color:#555;
+      margin-left:4px;
+      position:relative;
+      user-select:none;
+    }
+    .info-icon .tooltip {
+      display:none;
+      position:absolute;
+      top:1.2em;
+      left:0;
+      background:#333;
+      color:#fff;
+      padding:3px 6px;
+      border-radius:4px;
+      font-size:0.82em;
+      max-width:220px;
+      white-space:normal;
+      z-index:20;
+    }
+    .info-icon.active .tooltip { display:block; }
+    /* Choices.js dropdown width */
+    .choices__list--dropdown { min-width: 240px; }
+    @media (max-width: 800px) {
+      .main {padding:14px;}
+      .info-grid {grid-template-columns:1fr;}
+    }
+  </style>
+</head>
+<body>
+  <div class="main">
+    <h1>Stakeholder PI Status Report (Monte Carlo, Resource Allocation)</h1>
+    <div>
+      <label>Jira Domain: <input id="jiraDomain" value="aldi-sued.atlassian.net" size="28"></label>
+      <label>Board Number:
+        <input id="boardNum" size="5">
+      </label>
+      <button class="btn" onclick="fetchAllSprints()">Fetch Sprints</button>
+    </div>
+    <div class="sprint-row" id="sprintRow" style="display:none; margin:1.1em 0;">
+      <label>Sprint:
+        <select id="sprintSelect"></select>
+      </label>
+      <button class="btn" onclick="fetchAll()">Load Data</button>
+    </div>
+    <div id="loadingMessage" style="display:none; font-weight:bold; margin:10px 0;"></div>
+
+    <div id="configSection" style="display:none;">
+      <div class="section-title">Throughput History (issues per sprint, last 6 closed sprints):</div>
+      <div id="throughputWrap"></div>
+      <div style="margin:0.9em 0 1.6em 0;">
+        <label>Target Sprints for Delivery:
+          <input id="targetSprintsInput" type="number" min="1" max="20" value="4" style="width:60px">
+        </label>
+        <button class="btn" onclick="renderEpicSummary()">Update Report</button>
+        <button class="btn" onclick="exportPDF()">Download PDF Report</button>
+      </div>
+      <div id="filterOptions" style="margin-bottom:15px;"></div>
+      <div id="requiredSummary" style="margin-bottom:15px;"></div>
+      <div id="epicSummary"></div>
+    </div>
+  </div>
+  <script>
+let jiraDomain = '', boardNum = '', sprints = [], closedSprintsSorted = [];
+let allEpics = {}, epicStories = {}, epicStoriesBaseline = {};
+let throughputArr = [];
+let avgThroughput = 0;
+let selectedSprintId = '', selectedSprintName = '', targetSprints = 4;
+let baselineSprintId = '';
+let epicAllocations = {}, epicBacklogs = {}, epicRequiredAlloc = {}, epicRequiredIssues = {},
+    epicRequiredIssuesPrev = {};
+let epicForecastResults = {};
+let historicData = [];
+let storyFilters = { current:true, previous:true, new:true, open:true, removed:true };
+let boardTeams = [];
+let teamFilters = {};
+let statusChoices = null;
+let teamChoices = null;
+
+function showLoading(msg) {
+  const el = document.getElementById('loadingMessage');
+  if (el) {
+    el.textContent = msg || 'Loading...';
+    el.style.display = '';
+  }
+}
+
+function hideLoading() {
+  const el = document.getElementById('loadingMessage');
+  if (el) el.style.display = 'none';
+}
+
+function addTooltipListeners() {
+  document.querySelectorAll('.info-icon').forEach(icon => {
+    icon.addEventListener('click', e => {
+      e.stopPropagation();
+      const tip = icon.querySelector('.tooltip');
+      if (tip) tip.textContent = icon.dataset.tip || '';
+      icon.classList.toggle('active');
+    });
+  });
+  document.addEventListener('click', () => {
+    document.querySelectorAll('.info-icon.active').forEach(i => i.classList.remove('active'));
+  });
+}
+
+
+    function loadHistoricData() {
+      try { historicData = JSON.parse(localStorage.getItem('mc_hist')) || []; }
+      catch (e) { historicData = []; }
+    }
+
+    function saveHistoricData() {
+      localStorage.setItem('mc_hist', JSON.stringify(historicData));
+    }
+
+    loadHistoricData();
+    renderFilterOptions();
+    addTooltipListeners();
+
+    // --- NEW: FETCH JIRA THROUGHPUT DATA (completed issues per sprint) ---
+    async function fetchThroughputFromReport(jiraDomain, boardNum) {
+      const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
+      const resp = await fetch(url, { credentials: "include" });
+      if (!resp.ok) {
+        alert("Failed to fetch throughput report. Are you logged in to Jira?");
+        return [];
+      }
+      const data = await resp.json();
+      let closed = (data.sprints || []).filter(s => s.state === "CLOSED");
+      closed.sort((a, b) => {
+        const ad = a.endDate || a.completeDate || a.startDate || '';
+        const bd = b.endDate || b.completeDate || b.startDate || '';
+        return ad && bd ? new Date(bd) - new Date(ad) : 0;
+      });
+      closed = closed.slice(0, 6);
+      const throughputs = await Promise.all(closed.map(async s => {
+        const surl = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId=${boardNum}&sprintId=${s.id}`;
+        try {
+          const r = await fetch(surl, { credentials: "include" });
+          if (!r.ok) return 0;
+          const d = await r.json();
+          return (d.contents?.completedIssues || []).length || 0;
+        } catch (e) { return 0; }
+      }));
+      console.log('Most recent 6 sprint throughputs:', throughputs, closed.map(s=>s.name));
+      return throughputs;
+    }
+
+    async function fetchBoardTeam() {
+      boardTeams = [];
+      try {
+        const cfgUrl = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/configuration`;
+        const cfgResp = await fetch(cfgUrl, { credentials: "include" });
+        if (!cfgResp.ok) return;
+        const cfg = await cfgResp.json();
+        const filterId = cfg.filter && cfg.filter.id;
+        if (!filterId) return;
+        const fResp = await fetch(`https://${jiraDomain}/rest/api/3/filter/${filterId}`, { credentials: "include" });
+        if (!fResp.ok) return;
+        const fd = await fResp.json();
+        const jql = fd.jql || '';
+        const regex = /(?:"Team"|customfield_12600|cf\[12600\])\s*(?:=|in)\s*(\([^\)]*\)|"[^"\n]+")/gi;
+        let m;
+        while ((m = regex.exec(jql)) !== null) {
+          let str = m[1].replace(/[()]/g, '');
+          str.split(',').forEach(t => {
+            t = t.replace(/"/g, '').trim();
+            if (t && !boardTeams.includes(t)) boardTeams.push(t);
+          });
+        }
+      } catch (e) {
+        console.error('Failed to fetch board team', e);
+      }
+      console.log('Board teams:', boardTeams.join(', '));
+    }
+
+
+
+    // --- SPRINT FETCH & SELECTION (paginated, NO sorting after fetch) ---
+    async function fetchAllSprints() {
+      jiraDomain = document.getElementById('jiraDomain').value.trim();
+      boardNum = document.getElementById('boardNum').value.trim();
+      if (!jiraDomain || !boardNum) return alert("Enter Jira domain and board number.");
+
+      showLoading('Fetching sprints...');
+      await fetchBoardTeam();
+
+      let allSprintsArr = [];
+      let startAt = 0;
+      const maxResults = 50; // Jira API typically caps sprint pages at 50
+      let total = null;
+
+      while (true) {
+        const url = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/sprint?maxResults=${maxResults}&startAt=${startAt}`;
+        console.log("Fetching sprints:", url);
+        try {
+          const resp = await fetch(url, { credentials: "include" });
+          if (!resp.ok) {
+            const text = await resp.text();
+            console.error("API Error Response:", resp.status, text);
+            alert("API returned an error. See console for details.");
+            hideLoading();
+            return;
+          }
+          const data = await resp.json();
+          if (data.values && data.values.length) {
+            allSprintsArr = allSprintsArr.concat(data.values);
+            total = data.total;
+            startAt += data.values.length; // advance by number returned
+            if (data.isLast || allSprintsArr.length >= total) break;
+          } else {
+            break;
+          }
+        } catch (e) {
+          console.error(e);
+          alert("Failed to fetch sprints. CORS? Are you logged into Jira?");
+          hideLoading();
+          return;
+        }
+      }
+
+      // Log all fetched sprints
+      console.log("Fetched sprints:", allSprintsArr.length, allSprintsArr.map(s => s.name + ' (' + (s.startDate ? s.startDate.substr(0,10) : "undefined") + ')'));
+
+      sprints = allSprintsArr.slice(); // keep original order; dropdown reverses
+      closedSprintsSorted = sprints.filter(s => s.state === "closed" && s.endDate)
+                                   .sort((a, b) => new Date(b.endDate) - new Date(a.endDate));
+      populateSprintDropdown();
+      hideLoading();
+    }
+
+    // --- SPRINT DROPDOWN: show all sprints in reverse order ---
+    function populateSprintDropdown() {
+      const sel = document.getElementById('sprintSelect');
+      sel.innerHTML = '';
+      for (let i = sprints.length - 1; i >= 0; i--) {
+        const sprint = sprints[i];
+        const opt = document.createElement('option');
+        opt.value = sprint.id;
+        let name = sprint.name || "(no name)";
+        if (sprint.startDate) name += " (" + sprint.startDate.substr(0, 10) + ")";
+        opt.textContent = (sprint.state === "active" ? "🟢 " : "") + name;
+        sel.appendChild(opt);
+      }
+      document.getElementById('sprintRow').style.display = '';
+    }
+
+    function getStoryRowClass(story, currSprintObj) {
+      const created = new Date(story.created);
+      const resolved = story.resolved ? new Date(story.resolved) : null;
+      const sprintStart = currSprintObj && currSprintObj.startDate ? new Date(currSprintObj.startDate) : null;
+      const sprintEnd = currSprintObj && currSprintObj.endDate ? new Date(currSprintObj.endDate) : null;
+      if (sprintStart && sprintEnd && created >= sprintStart && created < sprintEnd) {
+        return "story-status-new";
+      }
+      if (sprintStart && sprintEnd && resolved && resolved >= sprintStart && resolved < sprintEnd) {
+        return "story-status-current";
+      }
+      if (resolved && sprintStart && resolved < sprintStart) {
+        return "story-status-previous";
+      }
+      if (!resolved || !story.status || !(story.status.toLowerCase().includes("done") || story.status.toLowerCase().includes("closed"))) {
+        const st = (story.status||'').toLowerCase();
+        if (st.includes('block')) return 'story-status-blocked';
+        if (st.includes('progress') || st.includes('development')) return 'story-status-inprogress';
+        return 'story-status-open';
+      }
+      return 'story-status-open';
+   }
+
+    // --- MAIN DATA FETCH (Epics/Stories/Throughput) ---
+    async function fetchAll() {
+      selectedSprintId = document.getElementById('sprintSelect').value;
+      selectedSprintName = document.getElementById('sprintSelect').selectedOptions[0].textContent;
+      if (!selectedSprintId) return alert("Select a sprint.");
+      showLoading('Loading sprint data...');
+      if (!boardTeams.length) await fetchBoardTeam();
+      let currSprintObj = sprints.find(s => String(s.id) === String(selectedSprintId));
+      let currIdx = closedSprintsSorted.findIndex(s => String(s.id) === String(selectedSprintId));
+      let baselineIdx = (currIdx >= 0 && currIdx + 1 < closedSprintsSorted.length)
+        ? currIdx + 1
+        : -1;
+      baselineSprintId = baselineIdx >= 0 && closedSprintsSorted[baselineIdx]
+        ? closedSprintsSorted[baselineIdx].id
+        : '';
+      let jql = encodeURIComponent(`sprint = ${selectedSprintId} ORDER BY key`);
+      let url = `https://${jiraDomain}/rest/api/3/search?jql=${jql}&fields=summary,parent,customfield_10002,customfield_10005,customfield_12600,status,issuetype&maxResults=500`;
+      let epicKeysSet = new Set();
+      try {
+        const resp = await fetch(url, { credentials: "include" });
+        const data = await resp.json();
+        if (data.issues && data.issues.length) {
+          for (let issue of data.issues) {
+            if (issue.fields.issuetype && issue.fields.issuetype.name === "Epic") continue;
+            let parent = issue.fields.parent;
+            if (parent && parent.fields && parent.fields.issuetype && parent.fields.issuetype.name === "Epic") {
+              epicKeysSet.add(parent.key);
+              allEpics[parent.key] = parent.fields.summary;
+            }
+          }
+        }
+      } catch (e) { alert("Error fetching stories for selected sprint"); hideLoading(); return; }
+      epicStories = {};
+      await Promise.all(Array.from(epicKeysSet).map(async epicKey => {
+        let eq = encodeURIComponent(`"Epic Link" = ${epicKey}`);
+        let urlEpic = `https://${jiraDomain}/rest/api/3/search?jql=${eq}&fields=summary,status,resolution,assignee,customfield_10002,customfield_12600,created,resolutiondate,issuetype,customfield_10005&maxResults=500`;
+        try {
+          const resp = await fetch(urlEpic, { credentials: "include" });
+          const data = await resp.json();
+          epicStories[epicKey] = (data.issues || []).map(story => ({
+            key: story.key,
+            summary: story.fields.summary,
+            status: story.fields.status && story.fields.status.name,
+            resolution: story.fields.resolution && story.fields.resolution.name,
+            assignee: story.fields.assignee && story.fields.assignee.displayName,
+            points: Number(story.fields.customfield_10002) || 0,
+            team: (story.fields.customfield_12600 || []).join(', '),
+            created: story.fields.created,
+            resolved: story.fields.resolutiondate,
+            sprint: (story.fields.customfield_10005||[]).map(s=>s.name).join(', '),
+            issuetype: story.fields.issuetype && story.fields.issuetype.name,
+          }));
+        } catch (e) { epicStories[epicKey] = []; }
+      }));
+      epicStoriesBaseline = {};
+      await Promise.all(Array.from(epicKeysSet).map(async epicKey => {
+        let eq = encodeURIComponent(`"Epic Link" = ${epicKey}`);
+        let urlEpic = `https://${jiraDomain}/rest/api/3/search?jql=${eq}&fields=summary,status,resolution,assignee,customfield_10002,customfield_12600,created,resolutiondate,issuetype,customfield_10005&maxResults=500`;
+        try {
+          const resp = await fetch(urlEpic, { credentials: "include" });
+          const data = await resp.json();
+          epicStoriesBaseline[epicKey] = (data.issues || [])
+            .filter(story => {
+              let created = new Date(story.fields.created);
+              let resolved = story.fields.resolutiondate ? new Date(story.fields.resolutiondate) : null;
+              let baseSprint = closedSprintsSorted.find(s=>s.id==baselineSprintId);
+              let end = baseSprint ? new Date(baseSprint.endDate) : null;
+              return created <= end && (!resolved || resolved > end);
+            }).map(story => ({
+            key: story.key,
+            summary: story.fields.summary,
+            status: story.fields.status && story.fields.status.name,
+            resolution: story.fields.resolution && story.fields.resolution.name,
+            assignee: story.fields.assignee && story.fields.assignee.displayName,
+            points: Number(story.fields.customfield_10002) || 0,
+            team: (story.fields.customfield_12600 || []).join(', '),
+            created: story.fields.created,
+            resolved: story.fields.resolutiondate,
+            sprint: (story.fields.customfield_10005||[]).map(s=>s.name).join(', '),
+            issuetype: story.fields.issuetype && story.fields.issuetype.name,
+          }));
+        } catch (e) { epicStoriesBaseline[epicKey] = []; }
+      }));
+      let allTeams = new Set();
+      Object.values(epicStories).forEach(arr => {
+        arr.forEach(st => {
+          st.team.split(',').forEach(t => { t = t.trim(); if (t) allTeams.add(t); });
+        });
+      });
+      teamFilters = {};
+      allTeams.forEach(t => { teamFilters[t] = false; });
+      // --- FETCH HISTORICAL THROUGHPUT FROM JIRA REPORT ---
+      throughputArr = await fetchThroughputFromReport(jiraDomain, boardNum);
+      document.getElementById('configSection').style.display = '';
+      renderThroughputInputs();
+      renderEpicSummary();
+      hideLoading();
+    }
+
+    // --- THROUGHPUT INPUTS ---
+    function renderThroughputInputs() {
+      let vhtml = throughputArr.map((v, i) =>
+        `<input class="editarr" type="number" min="0" value="${v}" onchange="editThroughput(this,${i})">`).join(', ');
+      document.getElementById('throughputWrap').innerHTML = vhtml;
+    }
+    function editThroughput(inp, idx) { throughputArr[idx] = Number(inp.value) || 0; }
+
+    function updateHistoricTotals() {
+      const entry = {
+        sprint: selectedSprintName || ('#'+selectedSprintId),
+        date: new Date().toISOString().substr(0,10),
+        epicBacklogs: Object.assign({}, epicBacklogs),
+        backlog: Object.values(epicBacklogs).reduce((a,b)=>a+b,0)
+      };
+      historicData.push(entry);
+      if (historicData.length>12) historicData.shift();
+      saveHistoricData();
+    }
+
+
+    function renderFilterOptions() {
+      if (statusChoices) { statusChoices.destroy(); statusChoices = null; }
+      if (teamChoices) { teamChoices.destroy(); teamChoices = null; }
+
+      const statusOpts = [
+        ['current','Done this sprint'],
+        ['previous','Done before'],
+        ['new','New story'],
+        ['open','Open/In Progress'],
+        ['removed','Removed']
+      ];
+
+      const statusSelectHtml =
+        '<select id="statusSelect" multiple>'+
+        statusOpts.map(o=>`<option value="${o[0]}" ${storyFilters[o[0]]?'selected':''}>${o[1]}</option>`).join('')+
+        '</select>';
+
+      const teamSelectHtml =
+        '<select id="teamSelect" multiple>'+
+        Object.keys(teamFilters).sort().map(t=>`<option value="${t}" ${teamFilters[t]?'selected':''}>${t}</option>`).join('')+
+        '</select>';
+
+      document.getElementById('filterOptions').innerHTML =
+        '<span class="section-title" style="display:block;margin-top:0;">Story Map Filters:<span class="info-icon" data-tip="Toggle visibility of stories by status in the story map.">&#9432;<span class="tooltip"></span></span></span>'+
+        statusSelectHtml+
+        (Object.keys(teamFilters).length ? '<br><span class="section-title" style="display:block;margin-top:0.8em;">Team Filter:<span class="info-icon" data-tip="Filter stories shown by their assigned teams.">&#9432;<span class="tooltip"></span></span></span>'+teamSelectHtml : '');
+
+      const statusEl = document.getElementById('statusSelect');
+      const teamEl = document.getElementById('teamSelect');
+
+      statusChoices = new Choices(statusEl, { removeItemButton:true, shouldSort:false });
+      if (teamEl) teamChoices = new Choices(teamEl, { removeItemButton:true, searchResultLimit:15, shouldSort:true });
+
+      statusEl.addEventListener('change', ()=>{
+        const sel = new Set(statusChoices.getValue(true));
+        statusOpts.forEach(o=>{ storyFilters[o[0]] = sel.has(o[0]); });
+        applyStoryFilters();
+      });
+
+      if (teamEl) teamEl.addEventListener('change', ()=>{
+        const sel = new Set(teamChoices.getValue(true));
+        Object.keys(teamFilters).forEach(t=>{ teamFilters[t] = sel.has(t); });
+        renderEpicSummary(true);
+      });
+    }
+
+      function applyStoryFilters() {
+        document.querySelectorAll('.story-status-current').forEach(el=>el.style.display = storyFilters.current? '':'none');
+        document.querySelectorAll('.story-status-previous').forEach(el=>el.style.display = storyFilters.previous? '':'none');
+        document.querySelectorAll('.story-status-new').forEach(el=>el.style.display = storyFilters.new? '':'none');
+        document.querySelectorAll('.story-status-open').forEach(el=>el.style.display = storyFilters.open? '':'none');
+        document.querySelectorAll('.story-status-inprogress').forEach(el=>el.style.display = storyFilters.open? '':'none');
+        document.querySelectorAll('.story-status-blocked').forEach(el=>el.style.display = storyFilters.open? '':'none');
+        document.querySelectorAll('.story-status-other').forEach(el=>el.style.display = storyFilters.open? '':'none');
+        document.querySelectorAll('.removed-lane').forEach(el=>el.style.display = storyFilters.removed? '':'none');
+        document.querySelectorAll('.story-card').forEach(el=>{
+          if (el.style.display==='none') return;
+          let teams = (el.dataset.teams||'').split(',').map(t=>t.trim()).filter(Boolean);
+          if (!teams.length || !teams.some(t=>teamFilters[t])) el.style.display='none';
+        });
+        updateEpicStatusCounts();
+      }
+
+      function updateEpicStatusCounts() {
+        const currSprintObj = sprints.find(s => String(s.id) === String(selectedSprintId));
+        Object.keys(epicStories).forEach(epicKey => {
+          let done=0, prog=0, open=0, blocked=0;
+          let ptsDone=0, ptsProg=0, ptsOpen=0, ptsBlocked=0;
+          (epicStories[epicKey]||[]).forEach(story => {
+            let show=true;
+            let cls = getStoryRowClass(story, currSprintObj);
+            if (cls==='story-status-current' && !storyFilters.current) show=false;
+            else if (cls==='story-status-previous' && !storyFilters.previous) show=false;
+            else if (cls==='story-status-new' && !storyFilters.new) show=false;
+            else if ((cls==='story-status-open' || cls==='story-status-inprogress' || cls==='story-status-blocked' || cls==='story-status-other') && !storyFilters.open) show=false;
+            if (show) {
+              let teams=(story.team||'').split(',').map(t=>t.trim()).filter(Boolean);
+              if (!teams.length || !teams.some(t=>teamFilters[t])) show=false;
+            }
+            if (!show) return;
+            let grp=statusGroup(story.status);
+            if (grp==='Done') { done++; ptsDone+=story.points; }
+            else if (grp==='In Progress') { prog++; ptsProg+=story.points; }
+            else if (grp==='Open') { open++; ptsOpen+=story.points; }
+            else if (grp==='Blocked') { blocked++; ptsBlocked+=story.points; }
+            
+          });
+          const block=document.getElementById(`storyMap_${epicKey.replace(/[^a-zA-Z0-9]/g,'')}`);
+          if (!block) return;
+          const container=block.closest('.epic-summary-block');
+          if (!container) return;
+          const doneSpan=container.querySelector('.pill-done');
+          const progSpan=container.querySelector('.pill-prog');
+          const blockedSpan=container.querySelector('.pill-blocked');
+          const openSpan=container.querySelector('.pill-open');
+          if (doneSpan) doneSpan.textContent=`${done} Done (${ptsDone} SP)`;
+          if (progSpan) progSpan.textContent=`${prog} In Progress (${ptsProg} SP)`;
+          if (blockedSpan) blockedSpan.textContent=`${blocked} Blocked (${ptsBlocked} SP)`;
+          if (openSpan) openSpan.textContent=`${open} Open (${ptsOpen} SP)`;
+        });
+      }
+
+    function scopeIncreaseConsistent(epicKey) {
+      if (historicData.length < 3) return false;
+      const recs = historicData.slice(-3);
+      const b1 = recs[0].epicBacklogs[epicKey] || 0;
+      const b2 = recs[1].epicBacklogs[epicKey] || 0;
+      const b3 = recs[2].epicBacklogs[epicKey] || 0;
+      return (b2 > b1 && b3 > b2);
+    }
+
+    // --- MAIN REPORT RENDER ---
+    function renderEpicSummary(skipHistory = false) {
+      targetSprints = Number(document.getElementById('targetSprintsInput').value) || 4;
+      let throughput = throughputArr.filter(v=>v>0);
+      if (throughput.length<3) {
+        document.getElementById('epicSummary').innerHTML = '<div class="warn">Please set at least 3 recent throughput values.</div>';
+        return;
+      }
+      avgThroughput = throughput.reduce((a,b)=>a+b,0)/throughput.length;
+      const baselineSprintObj = closedSprintsSorted.find(s=>s.id==baselineSprintId);
+      const baselineEnd = baselineSprintObj ? new Date(baselineSprintObj.endDate) : null;
+      epicBacklogs = {};
+      let totalBacklog = 0;
+      Object.keys(epicStories).forEach(epicKey => {
+        let stories = epicStories[epicKey]||[];
+        let backlog = stories.filter(st => {
+          if (isDone(st.status)) return false;
+          let teams = (st.team||'').split(',').map(t=>t.trim()).filter(Boolean);
+          if (!teams.length || !teams.some(t=>teamFilters[t])) return false;
+          return true;
+        }).length;
+        epicBacklogs[epicKey] = backlog;
+        totalBacklog += backlog;
+      });
+      epicAllocations = {};
+      Object.keys(epicStories).forEach(epicKey => {
+        epicAllocations[epicKey] = totalBacklog ? Math.ceil(100*epicBacklogs[epicKey]/totalBacklog) : 0;
+      });
+      if (!skipHistory) updateHistoricTotals();
+      renderFilterOptions();
+      applyStoryFilters();
+      epicForecastResults = {};
+      epicRequiredAlloc = {};
+      epicRequiredIssues = {};
+      epicRequiredIssuesPrev = {};
+      Object.keys(epicStories).forEach(epicKey => {
+        let stories = epicStories[epicKey]||[];
+        let backlogPts = epicBacklogs[epicKey];
+        if (backlogPts <= 0) {
+          epicForecastResults[epicKey] = [0];
+          epicRequiredAlloc[epicKey] = { "75": 0, "95": 0 };
+          epicRequiredIssues[epicKey] = { "75": 0, "95": 0 };
+          return;
+        }
+        let alloc = epicAllocations[epicKey];
+        let allocTPs = throughput.map(v=>v*alloc/100);
+        let mcRuns = [];
+        for (let i=0; i<10000; i++) {
+          let b = backlogPts, s=0;
+          while (b>0 && s<100) {
+            let v = allocTPs[Math.floor(Math.random()*allocTPs.length)];
+            if (v<1) v=1;
+            b -= v; s++;
+          }
+          mcRuns.push(s);
+        }
+        mcRuns.sort((a,b)=>a-b);
+        epicForecastResults[epicKey] = mcRuns;
+        let allocNeeded = { "75": null, "95": null };
+        for (let pct=1;pct<=100;pct++) {
+          let testTPs = throughput.map(v=>v*pct/100);
+          let runs = [];
+          for (let i=0;i<5000;i++) {
+            let b = backlogPts, s=0;
+            while (b>0 && s<100) {
+              let v = testTPs[Math.floor(Math.random()*testTPs.length)];
+              if (v<1) v=1;
+              b -= v; s++;
+            }
+            runs.push(s);
+          }
+          runs.sort((a,b)=>a-b);
+          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetSprints) allocNeeded["75"] = pct;
+          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetSprints) allocNeeded["95"] = pct;
+          if (allocNeeded["75"] && allocNeeded["95"]) break;
+        }
+        epicRequiredAlloc[epicKey] = allocNeeded;
+      epicRequiredIssues[epicKey] = {
+        "75": allocNeeded["75"] ? Math.ceil(avgThroughput * allocNeeded["75"] / 100) : null,
+        "95": allocNeeded["95"] ? Math.ceil(avgThroughput * allocNeeded["95"] / 100) : null
+      };
+    });
+
+      Object.keys(epicStoriesBaseline).forEach(epicKey => {
+        let stories = epicStoriesBaseline[epicKey] || [];
+        let backlogPts = stories.filter(st => {
+          let teams = (st.team||'').split(',').map(t=>t.trim()).filter(Boolean);
+          if (!teams.length || !teams.some(t=>teamFilters[t])) return false;
+          let res = st.resolved ? new Date(st.resolved) : null;
+          if (baselineEnd && res && res <= baselineEnd) return false;
+          return true;
+        }).length;
+        if (backlogPts <= 0) {
+          epicRequiredIssuesPrev[epicKey] = { "75": 0, "95": 0 };
+          return;
+        }
+        let allocNeeded = { "75": null, "95": null };
+        for (let pct=1;pct<=100;pct++) {
+          let testTPs = throughput.map(v=>v*pct/100);
+          let runs = [];
+          for (let i=0;i<5000;i++) {
+            let b = backlogPts, s=0;
+            while (b>0 && s<100) {
+              let v = testTPs[Math.floor(Math.random()*testTPs.length)];
+              if (v<1) v=1;
+              b -= v; s++;
+            }
+            runs.push(s);
+          }
+          runs.sort((a,b)=>a-b);
+          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetSprints) allocNeeded["75"] = pct;
+          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetSprints) allocNeeded["95"] = pct;
+          if (allocNeeded["75"] && allocNeeded["95"]) break;
+        }
+        epicRequiredIssuesPrev[epicKey] = {
+          "75": allocNeeded["75"] ? Math.ceil(avgThroughput * allocNeeded["75"] / 100) : null,
+          "95": allocNeeded["95"] ? Math.ceil(avgThroughput * allocNeeded["95"] / 100) : null
+        };
+      });
+
+      let totalAlloc = Object.values(epicAllocations).reduce((a,b)=>a+b,0);
+      let allocWarn = '';
+      if (totalAlloc < 99) allocWarn = `<span class="warn">Warning: Not all team capacity is assigned to listed epics (${totalAlloc}% total).</span>`;
+      else if (totalAlloc > 101) allocWarn = `<span class="warn">Warning: Allocations exceed 100% of capacity! (${totalAlloc}%)</span>`;
+      else allocWarn = `<span class="success">Team allocation: ${totalAlloc}%</span>`;
+
+      let totalReq75 = 0, totalReq95 = 0;
+      Object.values(epicRequiredAlloc).forEach(r => {
+        totalReq75 += r["75"] != null ? r["75"] : 101;
+        totalReq95 += r["95"] != null ? r["95"] : 101;
+      });
+      totalReq75 = Math.ceil(totalReq75);
+      totalReq95 = Math.ceil(totalReq95);
+      let reqWarn = (totalReq75 > 100 || totalReq95 > 100)
+        ? `<span class="warn">Required allocations exceed team capacity. Not all epics likely to finish.</span>`
+        : `<span class="success">Required allocations within team capacity.</span>`;
+      document.getElementById('requiredSummary').innerHTML =
+        `<div><b>Sum of required allocation to finish in ${targetSprints} sprints:</b><span class="info-icon" data-tip="Combined team capacity needed across all epics to meet the target sprint goal.">&#9432;<span class="tooltip"></span></span> `+
+        `${totalReq75}% at 75% confidence &nbsp; | &nbsp; ${totalReq95}% at 95% confidence`+
+        `<br>${reqWarn}</div>`;
+      // The total allocation info is still calculated for simulations but no longer displayed in the UI
+      let html = '';
+
+      Object.keys(epicStories).forEach((epicKey, idx) => {
+        let stories = epicStories[epicKey];
+        if (!stories || !stories.length) return;
+        let statusCounts = {done:0,prog:0,open:0,blocked:0};
+        let ptsDone=0, ptsProg=0, ptsOpen=0, ptsBlocked=0;
+        let unestimated = 0;
+        stories.forEach(story => {
+          let teams = (story.team||'').split(',').map(t=>t.trim()).filter(Boolean);
+          if (!teams.length || !teams.some(t=>teamFilters[t])) return;
+          let sgrp = statusGroup(story.status);
+          if (sgrp==='Done') { statusCounts.done++; ptsDone+=story.points; }
+          else if (sgrp==='In Progress') { statusCounts.prog++; ptsProg+=story.points; }
+          else if (sgrp==='Open') { statusCounts.open++; ptsOpen+=story.points; }
+          else if (sgrp==='Blocked') { statusCounts.blocked++; ptsBlocked+=story.points; }
+          
+          if (!story.points && sgrp!=='Done') unestimated++;
+        });
+        let totalEstimate = ptsDone+ptsProg+ptsOpen+ptsBlocked;
+        let backlog = ptsProg+ptsOpen+ptsBlocked;
+        let alloc = epicAllocations[epicKey];
+        let required = epicRequiredAlloc[epicKey];
+        let mc = epicForecastResults[epicKey];
+        let probRows = [[50,mc[Math.floor(0.5*mc.length)]],[75,mc[Math.floor(0.75*mc.length)]],[95,mc[Math.floor(0.95*mc.length)]]];
+
+        let baseStories = (epicStoriesBaseline[epicKey]||[]).filter(st => {
+          let teams = (st.team||'').split(',').map(t=>t.trim()).filter(Boolean);
+          return teams.length ? teams.some(t=>teamFilters[t]) : false;
+        });
+        let baseKeys = new Set(baseStories.map(s=>s.key));
+        let currStories = stories.filter(s => {
+          let teams = (s.team||'').split(',').map(t=>t.trim()).filter(Boolean);
+          return teams.length ? teams.some(t=>teamFilters[t]) : false;
+        });
+        let currKeys = new Set(currStories.map(s=>s.key));
+        const currSprintObj = sprints.find(s => String(s.id) === String(selectedSprintId));
+        const sprintStart = currSprintObj && currSprintObj.startDate ? new Date(currSprintObj.startDate) : null;
+        const sprintEnd = currSprintObj && currSprintObj.endDate ? new Date(currSprintObj.endDate) : null;
+        let newStories = currStories.filter(s => {
+          if (!s.created) return false;
+          const created = new Date(s.created);
+          return sprintStart && sprintEnd && created >= sprintStart && created < sprintEnd;
+        });
+        let removedStories = baseStories.filter(s=>!currKeys.has(s.key));
+
+        let baseDone = (epicStories[epicKey]||[]).filter(s=>{
+          let teams = (s.team||'').split(',').map(t=>t.trim()).filter(Boolean);
+          if (!teams.length || !teams.some(t=>teamFilters[t])) return false;
+          let res = s.resolved ? new Date(s.resolved) : null;
+          return baselineEnd && res && res <= baselineEnd;
+        }).map(s=>s.points).reduce((a,b)=>a+b,0);
+        let doneSince = ptsDone - baseDone;
+        let estimateBaseline = baseStories.map(s=>s.points).reduce((a,b)=>a+b,0);
+
+        let deltaEstimate = backlog - estimateBaseline;
+        const storyMapId = `storyMap_${epicKey.replace(/[^a-zA-Z0-9]/g, '')}`;
+        const risk = ((required["75"] && required["75"]-alloc>15) || scopeIncreaseConsistent(epicKey));
+        html += `
+        <div class="epic-summary-block ${risk?'epic-risk':''}">
+          <div class="epic-header">${epicKey}: ${allEpics[epicKey]||''}</div>
+          <div style="margin-top:4px;margin-bottom:10px;">
+            <span class="status-pill pill-done">${statusCounts.done} Done (${ptsDone} SP)</span>
+            <span class="status-pill pill-prog">${statusCounts.prog} In Progress (${ptsProg} SP)</span>
+            <span class="status-pill pill-blocked">${statusCounts.blocked} Blocked (${ptsBlocked} SP)</span>
+            <span class="status-pill pill-open">${statusCounts.open} Open (${ptsOpen} SP)</span><br>
+            <b>Total:</b> ${totalEstimate} SP &nbsp; | &nbsp; <b>Backlog:</b> ${backlog} SP &nbsp; | &nbsp; <b>Unestimated:</b> ${unestimated}
+          </div>
+          <div class="info-grid">
+            <div>
+              <div style="margin-bottom:4px;">
+                <b>Team allocation for this epic:</b><span class="info-icon" data-tip="Percentage of team capacity dedicated to this epic.">&#9432;<span class="tooltip"></span></span>
+                <span style="font-size:1.1em;font-weight:600;">${alloc}%</span>
+                <div class="allocation-bar" style="width:${2*alloc}px"></div>
+              </div>
+              <div>
+                <table class="prob-table">
+                  <tr><th>Confidence</th><th>Sprints Needed</th></tr>
+                  ${probRows.map(r=>`<tr><td>${r[0]}%</td><td>${r[1]}</td></tr>`).join('')}
+                </table>
+              </div>
+              <div style="margin-bottom:8px;">
+                <b>Required allocation${unestimated>0?'+':''} to finish in ${targetSprints} sprints:</b>
+                <ul style="margin:3px 0 0 0;padding-left:1.3em;">
+                  ${(() => {
+                    const fmt = pct => {
+                      const sp = epicRequiredIssues[epicKey][pct];
+                      if (sp != null) {
+                        const plus = unestimated>0?'+':'';
+                        return `${sp}${plus} issues/sprint (${required[pct]}${plus}%)`;
+                      }
+                      return '<span class="warn">Over 100%</span>';
+                    };
+                    const prev = pct => {
+                      const sp = (epicRequiredIssuesPrev[epicKey]||{})[pct];
+                      return sp != null ? `${sp} issues` : 'n/a';
+                    };
+                    return [
+                      `<li>75% confidence: ${fmt("75")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("75")})</span><span class="info-icon" data-tip="Estimated capacity per sprint for a 75% chance of finishing on time. Calculated using Monte Carlo simulations.">&#9432;<span class="tooltip"></span></span></li>`,
+                      `<li>95% confidence: ${fmt("95")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("95")})</span><span class="info-icon" data-tip="Capacity needed for a 95% likelihood of completion within the target sprints. Based on Monte Carlo results.">&#9432;<span class="tooltip"></span></span></li>`
+                    ].join('');
+                  })()}
+                </ul>
+              </div>
+              <div style="font-size:0.99em;">
+                ${probRows[1][1] > targetSprints ?
+                  `<span class="warn">At 75% confidence, this epic is <b>not likely</b> to finish in ${targetSprints} sprints.<br>
+                  More allocation or throughput needed.</span>`
+                  :
+                  `<span class="success">On track to finish in ${targetSprints} sprints at 75% confidence.</span>`
+                }
+              </div>
+            </div>
+            <div>
+                <div class="pdf-section-title" style="margin-top:0;">Changes since last sprint:<span class="info-icon" data-tip="Summary of completed, new and removed stories plus overall scope change since the previous sprint.">&#9432;<span class="tooltip"></span></span></div>
+              <div class="change-block">
+                <ul>
+                  <li>Story points completed: <b>${doneSince}</b></li>
+                  <li>New stories: <b>${newStories.length}</b> (${newStories.reduce((a,b)=>a+b.points,0)} SP)</li>
+                  <li>Removed stories: <b>${removedStories.length}</b> (${removedStories.reduce((a,b)=>a+b.points,0)} SP)</li>
+                  <li>
+                    Scope change: ${
+                      deltaEstimate===0 ? "No change"
+                      : (deltaEstimate>0?'<span class="warn">Increased (+'
+                        +deltaEstimate+')</span>':'<span class="success">Reduced ('+deltaEstimate+')</span>')
+                    }
+                    
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <label class="epic-select-label"><input type="checkbox" class="epic-select-checkbox" data-epic="${epicKey}" checked> Include in PDF</label>
+          <button class="btn details-toggle" onclick="toggleEpicDetails(this, '${storyMapId}')">Show Details</button>
+          <div id="${storyMapId}" style="display:none; margin-top:10px;">
+            <div class="story-map">
+              ${(() => {
+                const newSet = new Set(newStories.map(s=>s.key));
+                const lanes = [
+                  ['Done', currStories.filter(s=>statusGroup(s.status)==='Done')],
+                  ['In Progress', currStories.filter(s=>statusGroup(s.status)==='In Progress')],
+                  ['Open', currStories.filter(s=>statusGroup(s.status)==='Open')],
+                  ['Blocked', currStories.filter(s=>statusGroup(s.status)==='Blocked')]
+                ];
+                return lanes.map(l => `
+                  <div class="story-lane">
+                    <div class="story-lane-header">${l[0]}</div>
+                    ${l[1].map(st => {
+                      const c = getStoryRowClass(st, currSprintObj);
+                      const tags = [];
+                      if (newSet.has(st.key)) tags.push('New');
+                      if (c==='story-status-current') tags.push('Done now');
+                      if (st.issuetype) tags.push(st.issuetype);
+                      return `<div class="story-card ${c}" data-teams="${st.team}">
+                        <div><b>${st.key}</b> (${st.points} SP)</div>
+                        <div>${st.summary}</div>
+                        <div class="small">${st.status}${st.assignee? ' - '+st.assignee : (st.team?' - '+st.team:'')}</div>
+                        <div class="small">${st.created?st.created.substr(0,10):''}${st.resolved?' → '+st.resolved.substr(0,10):''}</div>
+                        ${tags.length?`<div class="tags">${tags.map(t=>`<span class="story-tag">${t}</span>`).join('')}</div>`:''}
+                      </div>`;
+                    }).join('')}
+                  </div>
+                `).join('');
+              })()}
+              ${removedStories.length?`
+                <div class="story-lane removed-lane">
+                  <div class="story-lane-header">Removed since last sprint</div>
+                  ${removedStories.map(st=>`<div class="story-card story-status-other" data-teams="${st.team}"><b>${st.key}</b> (${st.points} SP)${st.resolution?` - ${st.resolution}`:''}${st.issuetype?`<div class="tags"><span class="story-tag">${st.issuetype}</span></div>`:''}</div>`).join('')}
+                </div>
+              `:''}
+            </div>
+            <div class="story-map-legend" style="font-size:0.95em;margin-top:8px;">
+              <span class="story-status-current">Done this sprint</span>
+              <span class="story-status-new">New story</span>
+              <span class="removed-lane">Removed since last sprint</span>
+            </div>
+          </div>
+        </div>
+        `;
+      });
+      document.getElementById('epicSummary').innerHTML = html;
+      applyStoryFilters();
+      addTooltipListeners();
+    }
+
+    function toggleEpicDetails(btn, id) {
+      const block = document.getElementById(id);
+      if (block.style.display === "none") {
+        block.style.display = "";
+        btn.textContent = "Hide Details";
+      } else {
+        block.style.display = "none";
+        btn.textContent = "Show Details";
+      }
+    }
+
+    function isDone(status) {
+      status = (status||'').toLowerCase();
+      return status.includes("done") || status.includes("closed");
+    }
+    function statusGroup(s) {
+      s = (s||"").toLowerCase();
+      if (s.includes("done") || s.includes("closed")) return "Done";
+      if (s.includes("block")) return "Blocked";
+      if (s.includes("progress") || s.includes("development")) return "In Progress";
+      return "Open";
+    }
+
+    function hexToRgb(hex) {
+      const m = hex.match(/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i);
+      return m ? {
+        r: parseInt(m[1], 16),
+        g: parseInt(m[2], 16),
+        b: parseInt(m[3], 16)
+      } : {r:0,g:0,b:0};
+    }
+
+    // --- PDF EXPORT (CLEAN SUMMARY ONLY) ---
+    function exportPDF() {
+      const { jsPDF } = window.jspdf;
+      const pdf = new jsPDF({ unit:'pt', format:'a4' });
+      const blocks = Array.from(document.querySelectorAll('.epic-summary-block'))
+        .filter(b => b.querySelector('.epic-select-checkbox')?.checked);
+      if (!blocks.length) return alert('Select at least one epic for PDF');
+      const margin = 20;
+      (async () => {
+        for (let i=0; i<blocks.length; i++) {
+          const canvas = await html2canvas(blocks[i]);
+          const img = canvas.toDataURL('image/png');
+          const width = pdf.internal.pageSize.getWidth() - margin*2;
+          const height = canvas.height * width / canvas.width;
+          if (i>0) pdf.addPage();
+          pdf.addImage(img, 'PNG', margin, margin, width, height);
+        }
+        pdf.save('Stakeholder_StatusReport.pdf');
+      })();
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replicate `index.html` as `index_throughput.html`
- replace velocity logic with throughput per sprint
- compute Monte Carlo simulation using issue counts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68871c3dd3bc8325bc583c9d50b85e7a