### PR TITLE
Update delivery target terminology to weeks

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,8 +138,8 @@
       <div class="section-title">Velocity History (editable, last 6 closed sprints):</div>
       <div id="velocityWrap"></div>
       <div style="margin:0.9em 0 1.6em 0;">
-        <label>Target Sprints for Delivery:
-          <input id="targetSprintsInput" type="number" min="1" max="20" value="4" style="width:60px">
+        <label>Target Weeks for Delivery:
+          <input id="targetWeeksInput" type="number" min="1" max="20" value="4" style="width:60px">
         </label>
         <button class="btn" onclick="renderEpicSummary()">Update Report</button>
         <button class="btn" onclick="exportPDF()">Download PDF Report</button>
@@ -154,7 +154,7 @@ let jiraDomain = '', boardNum = '', sprints = [], closedSprintsSorted = [];
 let allEpics = {}, epicStories = {}, epicStoriesBaseline = {};
 let velocityArr = [];
 let avgVelocity = 0;
-let selectedSprintId = '', selectedSprintName = '', targetSprints = 4;
+let selectedSprintId = '', selectedSprintName = '', targetWeeks = 4;
 let baselineSprintId = '';
 document.getElementById('versionSelect').value = 'index.html';
 function switchVersion(page) {
@@ -605,7 +605,7 @@ function addTooltipListeners() {
 
     // --- MAIN REPORT RENDER ---
     function renderEpicSummary(skipHistory = false) {
-      targetSprints = Number(document.getElementById('targetSprintsInput').value) || 4;
+      targetWeeks = Number(document.getElementById('targetWeeksInput').value) || 4;
       let velocity = velocityArr.filter(v=>v>0);
       if (velocity.length<3) {
         document.getElementById('epicSummary').innerHTML = '<div class="warn">Please set at least 3 recent velocity values.</div>';
@@ -675,8 +675,8 @@ function addTooltipListeners() {
             runs.push(s);
           }
           runs.sort((a,b)=>a-b);
-          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetSprints) allocNeeded["75"] = pct;
-          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetSprints) allocNeeded["95"] = pct;
+          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetWeeks) allocNeeded["75"] = pct;
+          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetWeeks) allocNeeded["95"] = pct;
           if (allocNeeded["75"] && allocNeeded["95"]) break;
         }
         epicRequiredAlloc[epicKey] = allocNeeded;
@@ -713,8 +713,8 @@ function addTooltipListeners() {
             runs.push(s);
           }
           runs.sort((a,b)=>a-b);
-          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetSprints) allocNeeded["75"] = pct;
-          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetSprints) allocNeeded["95"] = pct;
+          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetWeeks) allocNeeded["75"] = pct;
+          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetWeeks) allocNeeded["95"] = pct;
           if (allocNeeded["75"] && allocNeeded["95"]) break;
         }
         epicRequiredSPPrev[epicKey] = {
@@ -740,7 +740,7 @@ function addTooltipListeners() {
         ? `<span class="warn">Required allocations exceed team capacity. Not all epics likely to finish.</span>`
         : `<span class="success">Required allocations within team capacity.</span>`;
       document.getElementById('requiredSummary').innerHTML =
-        `<div><b>Sum of required allocation to finish in ${targetSprints} sprints:</b><span class="info-icon" data-tip="Combined team capacity needed across all epics to meet the target sprint goal.">&#9432;<span class="tooltip"></span></span> `+
+        `<div><b>Sum of required allocation to finish in ${targetWeeks} weeks:</b><span class="info-icon" data-tip="Combined team capacity needed across all epics to meet the target week goal.">&#9432;<span class="tooltip"></span></span> `+
         `${totalReq75}% at 75% confidence &nbsp; | &nbsp; ${totalReq95}% at 95% confidence`+
         `<br>${reqWarn}</div>`;
       // The total allocation info is still calculated for simulations but no longer displayed in the UI
@@ -821,12 +821,12 @@ function addTooltipListeners() {
               </div>
               <div>
                 <table class="prob-table">
-                  <tr><th>Confidence</th><th>Sprints Needed</th></tr>
+                  <tr><th>Confidence</th><th>Weeks Needed</th></tr>
                   ${probRows.map(r=>`<tr><td>${r[0]}%</td><td>${r[1]}</td></tr>`).join('')}
                 </table>
               </div>
               <div style="margin-bottom:8px;">
-                <b>Required allocation${unestimated>0?'+':''} to finish in ${targetSprints} sprints:</b>
+                <b>Required allocation${unestimated>0?'+':''} to finish in ${targetWeeks} weeks:</b>
                 <ul style="margin:3px 0 0 0;padding-left:1.3em;">
                   ${(() => {
                     const fmt = pct => {
@@ -843,17 +843,17 @@ function addTooltipListeners() {
                     };
                     return [
                       `<li>75% confidence: ${fmt("75")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("75")})</span><span class="info-icon" data-tip="Estimated capacity per sprint for a 75% chance of finishing on time. Calculated using Monte Carlo simulations.">&#9432;<span class="tooltip"></span></span></li>`,
-                      `<li>95% confidence: ${fmt("95")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("95")})</span><span class="info-icon" data-tip="Capacity needed for a 95% likelihood of completion within the target sprints. Based on Monte Carlo results.">&#9432;<span class="tooltip"></span></span></li>`
+                      `<li>95% confidence: ${fmt("95")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("95")})</span><span class="info-icon" data-tip="Capacity needed for a 95% likelihood of completion within the target weeks. Based on Monte Carlo results.">&#9432;<span class="tooltip"></span></span></li>`
                     ].join('');
                   })()}
                 </ul>
               </div>
               <div style="font-size:0.99em;">
-                ${probRows[1][1] > targetSprints ?
-                  `<span class="warn">At 75% confidence, this epic is <b>not likely</b> to finish in ${targetSprints} sprints.<br>
+                ${probRows[1][1] > targetWeeks ?
+                  `<span class="warn">At 75% confidence, this epic is <b>not likely</b> to finish in ${targetWeeks} weeks.<br>
                   More allocation or velocity needed.</span>`
                   :
-                  `<span class="success">On track to finish in ${targetSprints} sprints at 75% confidence.</span>`
+                  `<span class="success">On track to finish in ${targetWeeks} weeks at 75% confidence.</span>`
                 }
               </div>
             </div>

--- a/index_cycle_time.html
+++ b/index_cycle_time.html
@@ -138,8 +138,8 @@
       <div class="section-title">Cycle Time History (days, last 6 closed sprints):</div>
       <div id="cycleTimeWrap"></div>
       <div style="margin:0.9em 0 1.6em 0;">
-        <label>Target Sprints for Delivery:
-          <input id="targetSprintsInput" type="number" min="1" max="20" value="4" style="width:60px">
+        <label>Target Weeks for Delivery:
+          <input id="targetWeeksInput" type="number" min="1" max="20" value="4" style="width:60px">
         </label>
         <button class="btn" onclick="renderEpicSummary()">Update Report</button>
         <button class="btn" onclick="exportPDF()">Download PDF Report</button>
@@ -154,7 +154,7 @@ let jiraDomain = '', boardNum = '', sprints = [], closedSprintsSorted = [];
 let allEpics = {}, epicStories = {}, epicStoriesBaseline = {};
 let cycleTimeArr = [];
 let avgCycleTime = 0;
-let selectedSprintId = '', selectedSprintName = '', targetSprints = 4;
+let selectedSprintId = '', selectedSprintName = '', targetWeeks = 4;
 let baselineSprintId = '';
 document.getElementById('versionSelect').value = 'index_cycle_time.html';
 function switchVersion(page) {
@@ -626,7 +626,7 @@ function addTooltipListeners() {
 
     // --- MAIN REPORT RENDER ---
     function renderEpicSummary(skipHistory = false) {
-      targetSprints = Number(document.getElementById('targetSprintsInput').value) || 4;
+      targetWeeks = Number(document.getElementById('targetWeeksInput').value) || 4;
       let cycleTime = cycleTimeArr.filter(v=>v>0);
       if (cycleTime.length<3) {
         document.getElementById('epicSummary').innerHTML = '<div class="warn">Please set at least 3 recent cycleTime values.</div>';
@@ -699,8 +699,8 @@ function addTooltipListeners() {
             runs.push(days/avgSprintDays);
           }
           runs.sort((a,b)=>a-b);
-          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetSprints) allocNeeded["75"] = pct;
-          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetSprints) allocNeeded["95"] = pct;
+          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetWeeks) allocNeeded["75"] = pct;
+          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetWeeks) allocNeeded["95"] = pct;
           if (allocNeeded["75"] && allocNeeded["95"]) break;
         }
         epicRequiredAlloc[epicKey] = allocNeeded;
@@ -737,8 +737,8 @@ function addTooltipListeners() {
             runs.push(days/avgSprintDays);
           }
           runs.sort((a,b)=>a-b);
-          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetSprints) allocNeeded["75"] = pct;
-          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetSprints) allocNeeded["95"] = pct;
+          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetWeeks) allocNeeded["75"] = pct;
+          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetWeeks) allocNeeded["95"] = pct;
           if (allocNeeded["75"] && allocNeeded["95"]) break;
         }
         epicRequiredIssuesPrev[epicKey] = {
@@ -764,7 +764,7 @@ function addTooltipListeners() {
         ? `<span class="warn">Required allocations exceed team capacity. Not all epics likely to finish.</span>`
         : `<span class="success">Required allocations within team capacity.</span>`;
       document.getElementById('requiredSummary').innerHTML =
-        `<div><b>Sum of required allocation to finish in ${targetSprints} sprints:</b><span class="info-icon" data-tip="Combined team capacity needed across all epics to meet the target sprint goal.">&#9432;<span class="tooltip"></span></span> `+
+        `<div><b>Sum of required allocation to finish in ${targetWeeks} weeks:</b><span class="info-icon" data-tip="Combined team capacity needed across all epics to meet the target week goal.">&#9432;<span class="tooltip"></span></span> `+
         `${totalReq75}% at 75% confidence &nbsp; | &nbsp; ${totalReq95}% at 95% confidence`+
         `<br>${reqWarn}</div>`;
       // The total allocation info is still calculated for simulations but no longer displayed in the UI
@@ -845,12 +845,12 @@ function addTooltipListeners() {
               </div>
               <div>
                 <table class="prob-table">
-                  <tr><th>Confidence</th><th>Sprints Needed</th></tr>
+                  <tr><th>Confidence</th><th>Weeks Needed</th></tr>
                   ${probRows.map(r=>`<tr><td>${r[0]}%</td><td>${r[1]}</td></tr>`).join('')}
                 </table>
               </div>
               <div style="margin-bottom:8px;">
-                <b>Required allocation${unestimated>0?'+':''} to finish in ${targetSprints} sprints:</b>
+                <b>Required allocation${unestimated>0?'+':''} to finish in ${targetWeeks} weeks:</b>
                 <ul style="margin:3px 0 0 0;padding-left:1.3em;">
                   ${(() => {
                     const fmt = pct => {
@@ -867,17 +867,17 @@ function addTooltipListeners() {
                     };
                     return [
                       `<li>75% confidence: ${fmt("75")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("75")})</span><span class="info-icon" data-tip="Estimated capacity per sprint for a 75% chance of finishing on time. Calculated using Monte Carlo simulations.">&#9432;<span class="tooltip"></span></span></li>`,
-                      `<li>95% confidence: ${fmt("95")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("95")})</span><span class="info-icon" data-tip="Capacity needed for a 95% likelihood of completion within the target sprints. Based on Monte Carlo results.">&#9432;<span class="tooltip"></span></span></li>`
+                      `<li>95% confidence: ${fmt("95")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("95")})</span><span class="info-icon" data-tip="Capacity needed for a 95% likelihood of completion within the target weeks. Based on Monte Carlo results.">&#9432;<span class="tooltip"></span></span></li>`
                     ].join('');
                   })()}
                 </ul>
               </div>
               <div style="font-size:0.99em;">
-                ${probRows[1][1] > targetSprints ?
-                  `<span class="warn">At 75% confidence, this epic is <b>not likely</b> to finish in ${targetSprints} sprints.<br>
+                ${probRows[1][1] > targetWeeks ?
+                  `<span class="warn">At 75% confidence, this epic is <b>not likely</b> to finish in ${targetWeeks} weeks.<br>
                   More allocation or cycleTime needed.</span>`
                   :
-                  `<span class="success">On track to finish in ${targetSprints} sprints at 75% confidence.</span>`
+                  `<span class="success">On track to finish in ${targetWeeks} weeks at 75% confidence.</span>`
                 }
               </div>
             </div>

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -135,11 +135,11 @@
     <div id="loadingMessage" style="display:none; font-weight:bold; margin:10px 0;"></div>
 
     <div id="configSection" style="display:none;">
-      <div class="section-title">Throughput History (issues per week, last 12 calendar weeks):</div>
+      <div class="section-title">Throughput History (issues per week, last 12 weeks):</div>
       <div id="throughputWrap"></div>
       <div style="margin:0.9em 0 1.6em 0;">
-        <label>Target Sprints for Delivery:
-          <input id="targetSprintsInput" type="number" min="1" max="20" value="4" style="width:60px">
+        <label>Target Weeks for Delivery:
+          <input id="targetWeeksInput" type="number" min="1" max="20" value="4" style="width:60px">
         </label>
         <button class="btn" onclick="renderEpicSummary()">Update Report</button>
         <button class="btn" onclick="exportPDF()">Download PDF Report</button>
@@ -154,7 +154,7 @@ let jiraDomain = '', boardNum = '', sprints = [], closedSprintsSorted = [];
 let allEpics = {}, epicStories = {}, epicStoriesBaseline = {};
 let throughputArr = [];
 let avgThroughput = 0;
-let selectedSprintId = '', selectedSprintName = '', targetSprints = 4;
+let selectedSprintId = '', selectedSprintName = '', targetWeeks = 4;
 let baselineSprintId = '';
 document.getElementById('versionSelect').value = 'index_throughput.html';
 function switchVersion(page) {
@@ -621,7 +621,7 @@ function addTooltipListeners() {
 
     // --- MAIN REPORT RENDER ---
     function renderEpicSummary(skipHistory = false) {
-      targetSprints = Number(document.getElementById('targetSprintsInput').value) || 4;
+      targetWeeks = Number(document.getElementById('targetWeeksInput').value) || 4;
       let throughput = throughputArr.filter(v=>v>0);
       if (throughput.length<3) {
         document.getElementById('epicSummary').innerHTML = '<div class="warn">Please set at least 3 weeks of throughput data.</div>';
@@ -691,8 +691,8 @@ function addTooltipListeners() {
             runs.push(s);
           }
           runs.sort((a,b)=>a-b);
-          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetSprints) allocNeeded["75"] = pct;
-          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetSprints) allocNeeded["95"] = pct;
+          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetWeeks) allocNeeded["75"] = pct;
+          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetWeeks) allocNeeded["95"] = pct;
           if (allocNeeded["75"] && allocNeeded["95"]) break;
         }
         epicRequiredAlloc[epicKey] = allocNeeded;
@@ -729,8 +729,8 @@ function addTooltipListeners() {
             runs.push(s);
           }
           runs.sort((a,b)=>a-b);
-          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetSprints) allocNeeded["75"] = pct;
-          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetSprints) allocNeeded["95"] = pct;
+          if (allocNeeded["75"] === null && runs[Math.floor(0.75*runs.length)]<=targetWeeks) allocNeeded["75"] = pct;
+          if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetWeeks) allocNeeded["95"] = pct;
           if (allocNeeded["75"] && allocNeeded["95"]) break;
         }
         epicRequiredIssuesPrev[epicKey] = {
@@ -756,7 +756,7 @@ function addTooltipListeners() {
         ? `<span class="warn">Required allocations exceed team capacity. Not all epics likely to finish.</span>`
         : `<span class="success">Required allocations within team capacity.</span>`;
       document.getElementById('requiredSummary').innerHTML =
-        `<div><b>Sum of required allocation to finish in ${targetSprints} sprints:</b><span class="info-icon" data-tip="Combined team capacity needed across all epics to meet the target sprint goal.">&#9432;<span class="tooltip"></span></span> `+
+        `<div><b>Sum of required allocation to finish in ${targetWeeks} weeks:</b><span class="info-icon" data-tip="Combined team capacity needed across all epics to meet the target week goal.">&#9432;<span class="tooltip"></span></span> `+
         `${totalReq75}% at 75% confidence &nbsp; | &nbsp; ${totalReq95}% at 95% confidence`+
         `<br>${reqWarn}</div>`;
       // The total allocation info is still calculated for simulations but no longer displayed in the UI
@@ -837,19 +837,19 @@ function addTooltipListeners() {
               </div>
               <div>
                 <table class="prob-table">
-                  <tr><th>Confidence</th><th>Sprints Needed</th></tr>
+                  <tr><th>Confidence</th><th>Weeks Needed</th></tr>
                   ${probRows.map(r=>`<tr><td>${r[0]}%</td><td>${r[1]}</td></tr>`).join('')}
                 </table>
               </div>
               <div style="margin-bottom:8px;">
-                <b>Required allocation${unestimated>0?'+':''} to finish in ${targetSprints} sprints:</b>
+                <b>Required allocation${unestimated>0?'+':''} to finish in ${targetWeeks} weeks:</b>
                 <ul style="margin:3px 0 0 0;padding-left:1.3em;">
                   ${(() => {
                     const fmt = pct => {
                       const sp = epicRequiredIssues[epicKey][pct];
                       if (sp != null) {
                         const plus = unestimated>0?'+':'';
-                        return `${sp}${plus} issues/sprint (${required[pct]}${plus}%)`;
+                        return `${sp}${plus} issues/week (${required[pct]}${plus}%)`;
                       }
                       return '<span class="warn">Over 100%</span>';
                     };
@@ -858,18 +858,18 @@ function addTooltipListeners() {
                       return sp != null ? `${sp} issues` : 'n/a';
                     };
                     return [
-                      `<li>75% confidence: ${fmt("75")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("75")})</span><span class="info-icon" data-tip="Estimated capacity per sprint for a 75% chance of finishing on time. Calculated using Monte Carlo simulations.">&#9432;<span class="tooltip"></span></span></li>`,
-                      `<li>95% confidence: ${fmt("95")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("95")})</span><span class="info-icon" data-tip="Capacity needed for a 95% likelihood of completion within the target sprints. Based on Monte Carlo results.">&#9432;<span class="tooltip"></span></span></li>`
+                      `<li>75% confidence: ${fmt("75")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("75")})</span><span class="info-icon" data-tip="Estimated capacity per week for a 75% chance of finishing on time. Calculated using Monte Carlo simulations.">&#9432;<span class="tooltip"></span></span></li>`,
+                      `<li>95% confidence: ${fmt("95")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("95")})</span><span class="info-icon" data-tip="Capacity needed for a 95% likelihood of completion within the target weeks. Based on Monte Carlo results.">&#9432;<span class="tooltip"></span></span></li>`
                     ].join('');
                   })()}
                 </ul>
               </div>
               <div style="font-size:0.99em;">
-                ${probRows[1][1] > targetSprints ?
-                  `<span class="warn">At 75% confidence, this epic is <b>not likely</b> to finish in ${targetSprints} sprints.<br>
+                ${probRows[1][1] > targetWeeks ?
+                  `<span class="warn">At 75% confidence, this epic is <b>not likely</b> to finish in ${targetWeeks} weeks.<br>
                   More allocation or throughput needed.</span>`
                   :
-                  `<span class="success">On track to finish in ${targetSprints} sprints at 75% confidence.</span>`
+                  `<span class="success">On track to finish in ${targetWeeks} weeks at 75% confidence.</span>`
                 }
               </div>
             </div>


### PR DESCRIPTION
## Summary
- rename **Target Sprints for Delivery** to **Target Weeks for Delivery**
- switch variable `targetSprints` to `targetWeeks`
- update tooltips and allocation messages to use "weeks"
- change throughput header to "issues per week, last 12 weeks"
- show "Weeks Needed" in probability tables
- adjust throughput page text to reference per-week metrics

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68874039ffa88325b2c6bbbaeae094ca