### PR TITLE
Add Jest testing setup and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# MCreport
+
+This repository contains HTML reports and related documentation.
+
+## Running Tests
+
+Tests are written with [Jest](https://jestjs.io/). To execute the tests:
+
+```bash
+npm install    # install dev dependencies (requires internet access)
+npm test
+```
+
+The `npm test` command will run all unit tests located in the `test/` directory.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mcreport",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/src/sim.js
+++ b/src/sim.js
@@ -1,0 +1,39 @@
+function weekStart(dt) {
+  const d = new Date(dt);
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  d.setDate(diff);
+  d.setHours(0,0,0,0);
+  return d;
+}
+
+function calculateWeeklyThroughput(issues, current=new Date()) {
+  const counts = new Array(12).fill(0);
+  const currentWeek = weekStart(current);
+  issues.forEach(it => {
+    const dateStr = it.resolutiondate;
+    if (!dateStr) return;
+    const w = weekStart(dateStr);
+    const diff = Math.floor((currentWeek - w) / (7*24*60*60*1000));
+    if (diff >= 0 && diff < 12) counts[11 - diff]++;
+  });
+  return counts;
+}
+
+function monteCarloSprints(backlogPts, throughput, allocation=100, runs=1000) {
+  const allocTPs = throughput.map(v => v * allocation / 100);
+  const res = [];
+  for (let i = 0; i < runs; i++) {
+    let b = backlogPts, s = 0;
+    while (b > 0 && s < 100) {
+      let v = allocTPs[Math.floor(Math.random() * allocTPs.length)];
+      if (v < 1) v = 1;
+      b -= v; s++;
+    }
+    res.push(s);
+  }
+  res.sort((a,b) => a - b);
+  return res;
+}
+
+module.exports = { weekStart, calculateWeeklyThroughput, monteCarloSprints };

--- a/test/sim.test.js
+++ b/test/sim.test.js
@@ -1,0 +1,29 @@
+const { calculateWeeklyThroughput, monteCarloSprints } = require('../src/sim');
+
+describe('calculateWeeklyThroughput', () => {
+  test('counts issues resolved in each week', () => {
+    const base = new Date('2024-01-22'); // Monday
+    const issues = [
+      { resolutiondate: '2024-01-20' }, // previous week
+      { resolutiondate: '2024-01-21' }, // previous week Sunday -> same as above
+      { resolutiondate: '2024-01-22' }, // current week Monday
+      { resolutiondate: '2024-01-28' }, // current week Sunday
+      { resolutiondate: null },
+    ];
+    const counts = calculateWeeklyThroughput(issues, new Date('2024-01-29'));
+    // last value is most recent week
+    expect(counts[11]).toBe(2);
+    expect(counts[10]).toBe(2);
+    expect(counts.reduce((a,b)=>a+b,0)).toBe(4);
+  });
+});
+
+describe('monteCarloSprints', () => {
+  test('returns sorted sprint counts', () => {
+    const runs = monteCarloSprints(10, [5], 100, 5);
+    expect(runs.length).toBe(5);
+    for (let i=1;i<runs.length;i++) {
+      expect(runs[i]).toBeGreaterThanOrEqual(runs[i-1]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest test runner in `package.json`
- ignore `node_modules`
- add Monte Carlo and throughput helper functions
- add unit tests for these helpers
- document how to run tests in the root README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874735edf883259b6fe54b3676a7ef