### PR TITLE
Fix cycle time JQL when board filter contains ORDER BY

### DIFF
--- a/index_cycle_time.html
+++ b/index_cycle_time.html
@@ -256,7 +256,7 @@ function addTooltipListeners() {
           const fResp = await fetch(`https://${jiraDomain}/rest/api/3/filter/${filterId}`, { credentials: "include" });
           if (fResp.ok) {
             const fd = await fResp.json();
-            boardJql = fd.jql || '';
+            boardJql = (fd.jql || '').replace(/ORDER BY[\s\S]*$/i, '').trim();
           }
         }
         const jql = `${boardJql ? '('+boardJql+') AND ' : ''}statusCategory = Done AND resolutiondate >= startOfWeek(-11)`;


### PR DESCRIPTION
## Summary
- fix cycle time query by stripping `ORDER BY` clause from board filter

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874e7a215c8325ac79ea374d1d800b