### PR TITLE
Fix cycle time rounding and revert other pages

### DIFF
--- a/index_cycle_time.html
+++ b/index_cycle_time.html
@@ -145,6 +145,7 @@
         <button class="btn" onclick="exportPDF()">Download PDF Report</button>
       </div>
       <div id="filterOptions" style="margin-bottom:15px;"></div>
+      <div id="requiredSummary" style="margin-bottom:15px;"></div>
       <div id="epicSummary"></div>
     </div>
   </div>
@@ -159,7 +160,8 @@ document.getElementById('versionSelect').value = 'index_cycle_time.html';
 function switchVersion(page) {
   if (page !== 'index_cycle_time.html') location.href = page;
 }
-let epicAllocations = {}, epicBacklogs = {};
+let epicAllocations = {}, epicBacklogs = {}, epicRequiredAlloc = {}, epicRequiredIssues = {},
+    epicRequiredIssuesPrev = {};
 let epicForecastResults = {};
 let historicData = [];
 let storyFilters = { current:true, previous:true, new:true, open:true, removed:true };
@@ -655,7 +657,7 @@ function addTooltipListeners() {
         document.getElementById('epicSummary').innerHTML = '<div class="warn">Please set at least 3 recent cycleTime values.</div>';
         return;
       }
-      avgCycleTime = cycleTime.reduce((a,b)=>a+b,0)/cycleTime.length;
+      avgCycleTime = Math.floor(cycleTime.reduce((a,b)=>a+b,0)/cycleTime.length);
       const avgIssuesPerWeek = 7 / avgCycleTime;
       const baselineSprintObj = closedSprintsSorted.find(s=>s.id==baselineSprintId);
       const baselineEnd = baselineSprintObj ? new Date(baselineSprintObj.endDate) : null;
@@ -680,6 +682,9 @@ function addTooltipListeners() {
       renderFilterOptions();
       applyStoryFilters();
       epicForecastResults = {};
+      epicRequiredAlloc = {};
+      epicRequiredIssues = {};
+      epicRequiredIssuesPrev = {};
       Object.keys(epicStories).forEach(epicKey => {
         let stories = epicStories[epicKey]||[];
         let backlogPts = epicBacklogs[epicKey];
@@ -721,11 +726,11 @@ function addTooltipListeners() {
           if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetWeeks) allocNeeded["95"] = pct;
           if (allocNeeded["75"] && allocNeeded["95"]) break;
         }
-        // epicRequiredAlloc[epicKey] = allocNeeded;
-        // epicRequiredIssues[epicKey] = {
-        //   "75": allocNeeded["75"] ? Math.ceil(avgIssuesPerWeek * allocNeeded["75"] / 100) : null,
-        //   "95": allocNeeded["95"] ? Math.ceil(avgIssuesPerWeek * allocNeeded["95"] / 100) : null
-        // };
+        epicRequiredAlloc[epicKey] = allocNeeded;
+        epicRequiredIssues[epicKey] = {
+          "75": allocNeeded["75"] ? Math.ceil(avgIssuesPerWeek * allocNeeded["75"] / 100) : null,
+          "95": allocNeeded["95"] ? Math.ceil(avgIssuesPerWeek * allocNeeded["95"] / 100) : null
+        };
     });
 
       Object.keys(epicStoriesBaseline).forEach(epicKey => {
@@ -738,7 +743,7 @@ function addTooltipListeners() {
           return true;
         }).length;
         if (backlogPts <= 0) {
-          // epicRequiredIssuesPrev[epicKey] = { "75": 0, "95": 0 };
+          epicRequiredIssuesPrev[epicKey] = { "75": 0, "95": 0 };
           return;
         }
         let allocNeeded = { "75": null, "95": null };
@@ -760,11 +765,10 @@ function addTooltipListeners() {
           if (allocNeeded["95"] === null && runs[Math.floor(0.95*runs.length)]<=targetWeeks) allocNeeded["95"] = pct;
           if (allocNeeded["75"] && allocNeeded["95"]) break;
         }
-        // epicRequiredIssuesPrev[epicKey] = {
-        //   "75": allocNeeded["75"] ? Math.ceil(avgIssuesPerWeek * allocNeeded["75"] / 100) : null,
-        //   "95": allocNeeded["95"] ? Math.ceil(avgIssuesPerWeek * allocNeeded["95"] / 100) : null
-        // };
-        // Required allocation per epic removed
+        epicRequiredIssuesPrev[epicKey] = {
+          "75": allocNeeded["75"] ? Math.ceil(avgIssuesPerWeek * allocNeeded["75"] / 100) : null,
+          "95": allocNeeded["95"] ? Math.ceil(avgIssuesPerWeek * allocNeeded["95"] / 100) : null
+        };
 
       });
 
@@ -776,7 +780,21 @@ function addTooltipListeners() {
       else if (totalAlloc > 101) allocWarn = `<span class="warn">Warning: Allocations exceed 100% of capacity! (${totalAlloc}%)</span>`;
       else allocWarn = `<span class="success">Team allocation: ${totalAlloc}%</span>`;
 
-      // Required allocation summary removed
+      let totalReq75 = 0, totalReq95 = 0;
+      Object.values(epicRequiredAlloc).forEach(r => {
+        totalReq75 += r["75"] != null ? r["75"] : 101;
+        totalReq95 += r["95"] != null ? r["95"] : 101;
+      });
+      totalReq75 = Math.ceil(totalReq75);
+      totalReq95 = Math.ceil(totalReq95);
+      let reqWarn = (totalReq75 > 100 || totalReq95 > 100)
+        ? `<span class="warn">Required allocations exceed team capacity. Not all epics likely to finish.</span>`
+        : `<span class="success">Required allocations within team capacity.</span>`;
+      document.getElementById('requiredSummary').innerHTML =
+        `<div><b>Sum of required allocation to finish in ${targetWeeks} weeks:</b><span class="info-icon" data-tip="Combined team capacity needed across all epics to meet the target goal.">&#9432;<span class="tooltip"></span></span> `+
+        `${totalReq75}% at 75% confidence &nbsp; | &nbsp; ${totalReq95}% at 95% confidence`+
+        `<br>${reqWarn}</div>`;
+      let html = '';
       let html = '';
 
       Object.keys(epicStories).forEach((epicKey, idx) => {
@@ -799,6 +817,7 @@ function addTooltipListeners() {
         let totalEstimate = ptsDone+ptsProg+ptsOpen+ptsBlocked;
         let backlog = ptsProg+ptsOpen+ptsBlocked;
         let alloc = epicAllocations[epicKey];
+        let required = epicRequiredAlloc[epicKey];
         let mc = epicForecastResults[epicKey];
         let probRows = [[50,mc[Math.floor(0.5*mc.length)]],[75,mc[Math.floor(0.75*mc.length)]],[95,mc[Math.floor(0.95*mc.length)]]];
 
@@ -846,18 +865,35 @@ function addTooltipListeners() {
           </div>
           <div class="info-grid">
             <div>
-              <div style="margin-bottom:4px;">
-                <b>Team allocation for this epic:</b><span class="info-icon" data-tip="Percentage of team capacity dedicated to this epic.">&#9432;<span class="tooltip"></span></span>
-                <span style="font-size:1.1em;font-weight:600;">${alloc}%</span>
-                <div class="allocation-bar" style="width:${2*alloc}px"></div>
-              </div>
               <div>
                 <table class="prob-table">
                   <tr><th>Confidence</th><th>Sprints Needed</th></tr>
                   ${probRows.map(r=>`<tr><td>${r[0]}%</td><td>${r[1]}</td></tr>`).join('')}
                 </table>
               </div>
-              <!-- Required allocation section removed -->
+              <div style="margin-bottom:8px;">
+                <b>Required allocation${unestimated>0?'+':''} to finish in ${targetWeeks} weeks:</b>
+                <ul style="margin:3px 0 0 0;padding-left:1.3em;">
+                  ${(() => {
+                    const fmt = pct => {
+                      const sp = epicRequiredIssues[epicKey][pct];
+                      if (sp != null) {
+                        const plus = unestimated>0?'+':'';
+                        return `${sp}${plus} Items per Sprint (${required[pct]}${plus}%)`;
+                      }
+                      return '<span class="warn">Over 100%</span>';
+                    };
+                    const prev = pct => {
+                      const sp = (epicRequiredIssuesPrev[epicKey]||{})[pct];
+                      return sp != null ? `${sp} Items` : 'n/a';
+                    };
+                    return [
+                      `<li>75% confidence: ${fmt("75")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("75")})</span><span class="info-icon" data-tip="Estimated capacity per sprint for a 75% chance of finishing on time. Calculated using Monte Carlo simulations.">&#9432;<span class="tooltip"></span></span></li>`,
+                      `<li>95% confidence: ${fmt("95")} <span style="font-size:0.9em;color:#555;">(last sprint: ${prev("95")})</span><span class="info-icon" data-tip="Capacity needed for a 95% likelihood of completion within the target weeks. Based on Monte Carlo results.">&#9432;<span class="tooltip"></span></span></li>`
+                    ].join('');
+                  })()}
+                </ul>
+              </div>
               <div style="font-size:0.99em;">
                 ${probRows[1][1] > targetWeeks ?
                   `<span class="warn">At 75% confidence, this epic is <b>not likely</b> to finish in ${targetWeeks} weeks.<br>


### PR DESCRIPTION
## Summary
- floor cycle time averages in cycle time report
- show required allocation as `Items per Sprint` and remove the per-epic team allocation section
- keep other pages unchanged

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68875a858ea08325985509dec791a30e