### PR TITLE
Fix cycle time label

### DIFF
--- a/index_cycle_time.html
+++ b/index_cycle_time.html
@@ -866,7 +866,7 @@ function addTooltipListeners() {
             <div>
               <div>
                 <table class="prob-table">
-                  <tr><th>Confidence</th><th>Sprints Needed</th></tr>
+                  <tr><th>Confidence</th><th>Weeks Needed</th></tr>
                   ${probRows.map(r=>`<tr><td>${r[0]}%</td><td>${r[1]}</td></tr>`).join('')}
                 </table>
               </div>


### PR DESCRIPTION
## Summary
- rename Monte Carlo result header to show weeks instead of sprints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876556a8e08325bd094efbbf57d332