### PR TITLE
Add resolution filtering only in cycle time view

### DIFF
--- a/index_cycle_time.html
+++ b/index_cycle_time.html
@@ -1022,8 +1022,9 @@ function addTooltipListeners() {
       return status.includes("done") || status.includes("closed");
     }
     function validResolution(res) {
-      res = (res||'').toLowerCase();
-      return !res || res === 'done' || res === 'implemented/done' || res === 'implemented done';
+      res = (res || '').toLowerCase().trim();
+      if (!res) return true;
+      return res === 'done' || res === 'implemented/done' || res === 'implemented done';
     }
     function statusGroup(s) {
       s = (s||"").toLowerCase();


### PR DESCRIPTION
## Summary
- revert resolution filtering for velocity/throughput pages
- tighten `validResolution` on cycle time page to ignore `Duplicate`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888a00f6f48325870859832c4c6d4f