### PR TITLE
Fix cycle time query

### DIFF
--- a/index_cycle_time.html
+++ b/index_cycle_time.html
@@ -277,8 +277,7 @@ function addTooltipListeners() {
             boardJql = (fd.jql || '').replace(/ORDER BY[\s\S]*$/i, '').trim();
           }
         }
-        const excludeRes = ['"Won\'t Do"', 'Duplicate', '"Cannot Reproduce"', 'Rejected', 'Cancelled', '"Won\'t Fix"', 'Other'];
-        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}issuetype in (Story,Bug,Task) AND statusCategory = Done AND resolutiondate >= startOfWeek(-11) AND resolution not in (${excludeRes.join(',')})`;
+        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}issuetype in (Story,Bug,Task) AND statusCategory = Done AND resolutiondate >= startOfWeek(-11)`;
         const enc = encodeURIComponent(jql);
         let startAt = 0;
         let issues = [];


### PR DESCRIPTION
## Summary
- drop resolution filtering from JQL in cycle time view

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888a8837e4083259eb49589af959b3c