### PR TITLE
Improve throughput report clarity and filtering

### DIFF
--- a/index_throughput.html
+++ b/index_throughput.html
@@ -135,7 +135,7 @@
     <div id="loadingMessage" style="display:none; font-weight:bold; margin:10px 0;"></div>
 
     <div id="configSection" style="display:none;">
-      <div class="section-title">Throughput History (issues per week, last 12 calendar weeks):</div>
+      <div class="section-title">Throughput History (issues per sprint, last 6 closed sprints):</div>
       <div id="throughputWrap"></div>
       <div style="margin:0.9em 0 1.6em 0;">
         <label>Target Sprints for Delivery:
@@ -153,8 +153,8 @@
 let jiraDomain = '', boardNum = '', sprints = [], closedSprintsSorted = [];
 let allEpics = {}, epicStories = {}, epicStoriesBaseline = {};
 let throughputArr = [];
-let throughputIssues = new Array(12).fill([]);
-let throughputWeekNums = new Array(12).fill(0);
+let throughputIssues = [];
+let throughputSprintNames = [];
 let avgThroughput = 0;
 let selectedSprintId = '', selectedSprintName = '', targetSprints = 4;
 let baselineSprintId = '';
@@ -185,14 +185,6 @@ function hideLoading() {
   if (el) el.style.display = 'none';
 }
 
-function isoWeekNumber(dt) {
-  const d = new Date(Date.UTC(dt.getFullYear(), dt.getMonth(), dt.getDate()));
-  const day = d.getUTCDay() || 7;
-  d.setUTCDate(d.getUTCDate() + 4 - day);
-  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
-}
-
 function addTooltipListeners() {
   document.querySelectorAll('.info-icon').forEach(icon => {
     icon.addEventListener('click', e => {
@@ -221,80 +213,37 @@ function addTooltipListeners() {
     renderFilterOptions();
     addTooltipListeners();
 
-    // --- NEW: FETCH JIRA THROUGHPUT DATA (completed issues per week) ---
+    // --- NEW: FETCH JIRA THROUGHPUT DATA (completed issues per sprint) ---
     async function fetchThroughputFromReport(jiraDomain, boardNum) {
-      function weekStart(dt) {
-        const d = new Date(dt);
-        const day = d.getDay();
-        const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-        d.setDate(diff);
-        d.setHours(0,0,0,0);
-        return d;
-      }
-      try {
-        const cfgUrl = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/configuration`;
-        const cfgResp = await fetch(cfgUrl, { credentials: "include" });
-        if (!cfgResp.ok) throw new Error('cfg');
-        const cfg = await cfgResp.json();
-        const filterId = cfg.filter && cfg.filter.id;
-        let boardJql = '';
-        if (filterId) {
-          const fResp = await fetch(`https://${jiraDomain}/rest/api/3/filter/${filterId}`, { credentials: "include" });
-          if (fResp.ok) {
-            const fd = await fResp.json();
-            boardJql = (fd.jql || '').replace(/ORDER BY[\s\S]*$/i, '').trim();
-          }
-        }
-        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}statusCategory = Done AND resolutiondate >= startOfWeek(-11)`;
-        let startAt = 0;
-        let issues = [];
-        while (true) {
-          const url = `https://${jiraDomain}/rest/api/3/search`;
-          const body = JSON.stringify({
-            jql,
-            fields: ["resolutiondate"],
-            startAt,
-            maxResults: 100,
-          });
-          const resp = await fetch(url, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            credentials: "include",
-            body,
-          });
-          if (!resp.ok) break;
-          const data = await resp.json();
-          issues = issues.concat(data.issues || []);
-          startAt += 100;
-          if (startAt >= (data.total || 0)) break;
-        }
-        const weeks = new Array(12).fill(0).map(()=>({count:0, keys:[]}));
-        const current = weekStart(new Date());
-        throughputWeekNums = [];
-        for (let i=0;i<12;i++) {
-          const d = new Date(current);
-          d.setDate(d.getDate() - (11 - i) * 7);
-          throughputWeekNums.push(isoWeekNumber(d));
-        }
-        issues.forEach(it => {
-          const dateStr = it.fields && it.fields.resolutiondate;
-          if (!dateStr) return;
-          const w = weekStart(dateStr);
-          const diff = Math.floor((current - w) / (7*24*60*60*1000));
-          if (diff >= 0 && diff < 12) {
-            weeks[11-diff].count++;
-            weeks[11-diff].keys.push(it.key);
-          }
-        });
-        throughputIssues = weeks.map(w=>w.keys);
-        const counts = weeks.map(w=>w.count);
-        console.log('Weekly throughput:', counts);
-        return counts;
-      } catch (e) {
-        console.error('Failed to fetch throughput', e);
-        alert('Failed to fetch throughput report. Are you logged in to Jira?');
+      const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
+      const resp = await fetch(url, { credentials: "include" });
+      if (!resp.ok) {
+        alert("Failed to fetch throughput report. Are you logged in to Jira?");
         return [];
       }
+      const data = await resp.json();
+      let closed = (data.sprints || []).filter(s => s.state === "CLOSED");
+      closed.sort((a, b) => {
+        const ad = a.endDate || a.completeDate || a.startDate || '';
+        const bd = b.endDate || b.completeDate || b.startDate || '';
+        return ad && bd ? new Date(bd) - new Date(ad) : 0;
+      });
+      closed = closed.slice(0, 6);
+      throughputSprintNames = closed.map(s => s.name);
+      throughputIssues = [];
+      const throughputs = await Promise.all(closed.map(async s => {
+        const surl = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId=${boardNum}&sprintId=${s.id}`;
+        try {
+          const r = await fetch(surl, { credentials: "include" });
+          if (!r.ok) { throughputIssues.push([]); return 0; }
+          const d = await r.json();
+          const issues = (d.contents?.completedIssues || []).map(it => it.key);
+          throughputIssues.push(issues);
+          return issues.length;
+        } catch (e) { throughputIssues.push([]); return 0; }
+      }));
+      console.log('Most recent 6 sprint throughputs:', throughputs, closed.map(s=>s.name));
+      return throughputs;
     }
 
     async function fetchBoardTeam() {
@@ -458,7 +407,9 @@ function addTooltipListeners() {
         try {
           const resp = await fetch(urlEpic, { credentials: "include" });
           const data = await resp.json();
-          epicStories[epicKey] = (data.issues || []).map(story => ({
+          epicStories[epicKey] = (data.issues || [])
+            .filter(story => validResolution(story.fields.resolution && story.fields.resolution.name))
+            .map(story => ({
             key: story.key,
             summary: story.fields.summary,
             status: story.fields.status && story.fields.status.name,
@@ -486,6 +437,7 @@ function addTooltipListeners() {
               let resolved = story.fields.resolutiondate ? new Date(story.fields.resolutiondate) : null;
               let baseSprint = closedSprintsSorted.find(s=>s.id==baselineSprintId);
               let end = baseSprint ? new Date(baseSprint.endDate) : null;
+              if (!validResolution(story.fields.resolution && story.fields.resolution.name)) return false;
               return created <= end && (!resolved || resolved > end);
             }).map(story => ({
             key: story.key,
@@ -522,8 +474,8 @@ function addTooltipListeners() {
     function renderThroughputInputs() {
       let vhtml = throughputArr.map((v, i) => {
         const issues = (throughputIssues[i] || []).join(', ');
-        const wk = throughputWeekNums[i] || '';
-        return `<span style="white-space:nowrap;">KW ${wk}: <input class="editarr" type="number" min="0" value="${v}" onchange="editThroughput(this,${i})"><span class="info-icon" data-tip="${issues}" title="${issues}">&#9432;<span class="tooltip"></span></span></span>`;
+        const name = throughputSprintNames[i] || `Sprint ${i+1}`;
+        return `<span style="white-space:nowrap;">${name}: <input class="editarr" type="number" min="0" value="${v}" onchange="editThroughput(this,${i})"><span class="info-icon" data-tip="${issues}" title="${issues}">&#9432;<span class="tooltip"></span></span></span>`;
       }).join(', ');
       document.getElementById('throughputWrap').innerHTML = vhtml;
       addTooltipListeners();
@@ -659,7 +611,7 @@ function addTooltipListeners() {
       targetSprints = Number(document.getElementById('targetSprintsInput').value) || 4;
       let throughput = throughputArr.filter(v=>v>0);
       if (throughput.length<3) {
-        document.getElementById('epicSummary').innerHTML = '<div class="warn">Please set at least 3 weeks of throughput data.</div>';
+        document.getElementById('epicSummary').innerHTML = '<div class="warn">Please set at least 3 recent throughput values.</div>';
         return;
       }
       avgThroughput = throughput.reduce((a,b)=>a+b,0)/throughput.length;
@@ -671,6 +623,7 @@ function addTooltipListeners() {
         let stories = epicStories[epicKey]||[];
         let backlog = stories.filter(st => {
           if (isDone(st.status)) return false;
+          if (!validResolution(st.resolution)) return false;
           let teams = (st.team||'').split(',').map(t=>t.trim()).filter(Boolean);
           if (!teams.length || !teams.some(t=>teamFilters[t])) return false;
           return true;
@@ -742,6 +695,7 @@ function addTooltipListeners() {
         let backlogPts = stories.filter(st => {
           let teams = (st.team||'').split(',').map(t=>t.trim()).filter(Boolean);
           if (!teams.length || !teams.some(t=>teamFilters[t])) return false;
+          if (!validResolution(st.resolution)) return false;
           let res = st.resolved ? new Date(st.resolved) : null;
           if (baselineEnd && res && res <= baselineEnd) return false;
           return true;
@@ -994,6 +948,26 @@ function addTooltipListeners() {
     function isDone(status) {
       status = (status||'').toLowerCase();
       return status.includes("done") || status.includes("closed");
+    }
+    function validResolution(res) {
+      if (!res) return true;
+      res = res.toLowerCase().trim();
+      const invalid = [
+        'duplicate',
+        "won't do", 'wont do',
+        "won't fix", 'wont fix',
+        'reject', 'rejected',
+        'canceled', 'cancelled',
+        'cannot reproduce', "can't reproduce",
+        'other'
+      ];
+      if (invalid.some(v => res.includes(v))) return false;
+      const valid = [
+        'done',
+        'implemented/done', 'implemented done',
+        'fixed', 'resolved', 'complete', 'completed'
+      ];
+      return valid.some(v => res.includes(v));
     }
     function statusGroup(s) {
       s = (s||"").toLowerCase();


### PR DESCRIPTION
## Summary
- revert throughput HTML to sprint-based logic
- show sprint names and completed issue keys when editing throughput history
- ignore issues with invalid resolutions when building epic data

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6889c0d3f81c83259d6406c2f78a38ac