### PR TITLE
Add filterable overview page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ Usage:
 node src/overview.js sample-issues.json --team Alpha
 ```
 This reads issues from `sample-issues.json` and prints metrics for the selected team.
+
+## Overview Web Page
+
+An HTML page (`index_overview.html`) displays the same metrics in the browser.
+It loads issues from `sample-issues.json` and lets you filter by team, product
+and project. The page shows average cycle time, weekly throughput, velocity and
+lists the issues grouped by resolution week.

--- a/index.html
+++ b/index.html
@@ -116,6 +116,7 @@
           <option value="index.html">Velocity</option>
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
+          <option value="index_overview.html">Overview</option>
         </select>
       </label>
     </div>

--- a/index_overview.html
+++ b/index_overview.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Issue Overview</title>
+  <style>
+    body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
+    .main { max-width: 950px; margin: 30px auto 40px auto; background:#fff; border-radius:18px; box-shadow:0 2px 12px #d1d5db70; padding:36px 32px; }
+    h1 { font-size:2.3em; margin:0 0 0.7em 0; font-weight:600; }
+    .filters label { margin-right:1em; }
+    table { border-collapse: collapse; margin-top:1em; width:100%; }
+    th, td { border:1px solid #ccc; padding:4px 8px; text-align:left; }
+    th { background:#eee; }
+  </style>
+</head>
+<body>
+  <div class="main">
+    <h1>Issue Overview</h1>
+    <div style="margin-bottom:10px;">
+      <label>Version:
+        <select id="versionSelect" onchange="switchVersion(this.value)">
+          <option value="index.html">Velocity</option>
+          <option value="index_throughput.html">Throughput</option>
+          <option value="index_throughput_week.html">Weekly Throughput</option>
+          <option value="index_overview.html">Overview</option>
+        </select>
+      </label>
+    </div>
+    <div class="filters">
+      <label>Team:
+        <select id="teamFilter" onchange="applyFilters()">
+          <option value="">All</option>
+        </select>
+      </label>
+      <label>Product:
+        <select id="productFilter" onchange="applyFilters()">
+          <option value="">All</option>
+        </select>
+      </label>
+      <label>Project:
+        <select id="projectFilter" onchange="applyFilters()">
+          <option value="">All</option>
+        </select>
+      </label>
+    </div>
+    <div id="metrics" style="margin-top:1.5em;"></div>
+    <div id="issues"></div>
+  </div>
+<script>
+const versionEl = document.getElementById('versionSelect');
+versionEl.value = 'index_overview.html';
+function switchVersion(page){ if(page !== 'index_overview.html') location.href = page; }
+let allIssues = [];
+function isoWeekNumber(dt){
+  const d = new Date(dt); d.setHours(0,0,0,0);
+  d.setDate(d.getDate()+4-(d.getDay()||7));
+  const yearStart = new Date(d.getFullYear(),0,1);
+  const weekNo = Math.ceil(((d-yearStart)/86400000+1)/7);
+  return `${d.getFullYear()}-W${String(weekNo).padStart(2,'0')}`;
+}
+function calculateMetrics(issues){
+  if(!issues.length) return {avg:0, tp:{}, vel:{}};
+  let total=0; const tp={}, vel={};
+  for(const it of issues){
+    const c=new Date(it.created), r=new Date(it.resolved);
+    total += (r-c)/86400000;
+    const w=isoWeekNumber(it.resolved);
+    tp[w]=(tp[w]||0)+1;
+    vel[w]=(vel[w]||0)+(it.points||0);
+  }
+  return {avg: total/issues.length, tp, vel};
+}
+function renderMetrics(metrics){
+  const div=document.getElementById('metrics');
+  let html=`<b>Average Cycle Time:</b> ${metrics.avg.toFixed(2)} days`;
+  html += '<h3>Throughput Per Week</h3><table><tr><th>Week</th><th>Count</th></tr>';
+  for(const [w,c] of Object.entries(metrics.tp)) html+=`<tr><td>${w}</td><td>${c}</td></tr>`;
+  html += '</table><h3>Velocity Per Week</h3><table><tr><th>Week</th><th>Points</th></tr>';
+  for(const [w,p] of Object.entries(metrics.vel)) html+=`<tr><td>${w}</td><td>${p}</td></tr>`;
+  html += '</table>';
+  div.innerHTML=html;
+}
+function renderIssues(issues){
+  const byWeek={};
+  issues.forEach(it=>{ const w=isoWeekNumber(it.resolved); (byWeek[w]=byWeek[w]||[]).push(it); });
+  let html='<h3>Issues</h3>';
+  for(const week of Object.keys(byWeek).sort()){
+    html+=`<h4>${week}</h4><table><tr><th>ID</th><th>Created</th><th>Resolved</th><th>Points</th><th>Team</th><th>Product</th><th>Project</th></tr>`;
+    byWeek[week].forEach(it=>{ html+=`<tr><td>${it.id}</td><td>${it.created}</td><td>${it.resolved}</td><td>${it.points||''}</td><td>${it.team}</td><td>${it.product}</td><td>${it.project}</td></tr>`; });
+    html+='</table>';
+  }
+  document.getElementById('issues').innerHTML=html;
+}
+function populateFilters(){
+  const teams=new Set(), products=new Set(), projects=new Set();
+  allIssues.forEach(it=>{ teams.add(it.team); products.add(it.product); projects.add(it.project); });
+  const addOpts=(sel,vals)=>{ const el=document.getElementById(sel); vals.forEach(v=>{ const op=document.createElement('option'); op.value=v; op.textContent=v; el.appendChild(op); }); };
+  addOpts('teamFilter',Array.from(teams).sort());
+  addOpts('productFilter',Array.from(products).sort());
+  addOpts('projectFilter',Array.from(projects).sort());
+}
+function applyFilters(){
+  const t=document.getElementById('teamFilter').value;
+  const p=document.getElementById('productFilter').value;
+  const pr=document.getElementById('projectFilter').value;
+  const filtered=allIssues.filter(it=>{
+    if(t && it.team!==t) return false;
+    if(p && it.product!==p) return false;
+    if(pr && it.project!==pr) return false;
+    return true;
+  });
+  const metrics=calculateMetrics(filtered);
+  renderMetrics(metrics);
+  renderIssues(filtered);
+}
+fetch('sample-issues.json').then(r=>r.json()).then(data=>{
+  allIssues=data; populateFilters(); applyFilters();
+});
+</script>
+</body>
+</html>

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -116,6 +116,7 @@
           <option value="index.html">Velocity</option>
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
+          <option value="index_overview.html">Overview</option>
         </select>
       </label>
     </div>

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -115,6 +115,8 @@
         <select id="versionSelect" onchange="switchVersion(this.value)">
           <option value="index.html">Velocity</option>
           <option value="index_throughput.html">Throughput</option>
+          <option value="index_throughput_week.html">Weekly Throughput</option>
+          <option value="index_overview.html">Overview</option>
         </select>
       </label>
     </div>


### PR DESCRIPTION
## Summary
- add an `index_overview.html` page that loads sample issues and shows cycle time, throughput and velocity
- extend existing HTML reports with a link to the new overview page
- document the overview page in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cd0b4b52c832595dbda930e30e015