### PR TITLE
Add Jira fetch to overview

### DIFF
--- a/index_overview.html
+++ b/index_overview.html
@@ -8,6 +8,7 @@
     .main { max-width: 950px; margin: 30px auto 40px auto; background:#fff; border-radius:18px; box-shadow:0 2px 12px #d1d5db70; padding:36px 32px; }
     h1 { font-size:2.3em; margin:0 0 0.7em 0; font-weight:600; }
     .filters label { margin-right:1em; }
+    .btn { background:#6366f1; color:#fff; border:none; border-radius:6px; padding:7px 18px; cursor:pointer; font-size:1em; margin:0 10px 8px 0; }
     table { border-collapse: collapse; margin-top:1em; width:100%; }
     th, td { border:1px solid #ccc; padding:4px 8px; text-align:left; }
     th { background:#eee; }
@@ -25,6 +26,16 @@
           <option value="index_overview.html">Overview</option>
         </select>
       </label>
+    </div>
+    <div class="jira-inputs" style="margin-bottom:10px;">
+      <label>Jira Domain:
+        <input id="jiraDomain" value="aldi-sued.atlassian.net" size="28">
+      </label>
+      <label>JQL:
+        <input id="jqlInput" size="40" value="project = MC AND statusCategory = Done">
+      </label>
+      <button class="btn" onclick="loadIssues()">Load Issues</button>
+      <button class="btn" onclick="loadSample()">Load Sample</button>
     </div>
     <div class="filters">
       <label>Team:
@@ -51,6 +62,43 @@ const versionEl = document.getElementById('versionSelect');
 versionEl.value = 'index_overview.html';
 function switchVersion(page){ if(page !== 'index_overview.html') location.href = page; }
 let allIssues = [];
+let jiraDomain = '';
+
+function loadSample(){
+  fetch('sample-issues.json').then(r=>r.json()).then(data=>{
+    allIssues=data; populateFilters(); applyFilters();
+  });
+}
+
+async function loadIssues(){
+  jiraDomain = document.getElementById('jiraDomain').value.trim();
+  const jql = encodeURIComponent(document.getElementById('jqlInput').value.trim());
+  if(!jiraDomain || !jql){ alert('Enter Jira domain and JQL'); return; }
+  const fields='created,resolutiondate,customfield_10002,customfield_12600,project';
+  let startAt=0, issues=[];
+  while(true){
+    const url=`https://${jiraDomain}/rest/api/3/search?jql=${jql}&fields=${fields}&startAt=${startAt}&maxResults=100`;
+    try {
+      const resp=await fetch(url,{credentials:'include'});
+      if(!resp.ok){ alert('Failed to fetch issues'); return; }
+      const data=await resp.json();
+      issues=issues.concat(data.issues||[]);
+      startAt+=data.issues?data.issues.length:0;
+      if(!data.issues || startAt>=(data.total||0)) break;
+    } catch(e){ alert('Error fetching issues'); return; }
+  }
+  allIssues=issues.map(it=>({
+    id: it.key,
+    team: (it.fields.customfield_12600||[]).join(', '),
+    product: (it.fields.project && it.fields.project.name) || '',
+    project: (it.fields.project && it.fields.project.key) || '',
+    created: it.fields.created,
+    resolved: it.fields.resolutiondate,
+    points: Number(it.fields.customfield_10002)||0
+  }));
+  populateFilters();
+  applyFilters();
+}
 function isoWeekNumber(dt){
   const d = new Date(dt); d.setHours(0,0,0,0);
   d.setDate(d.getDate()+4-(d.getDay()||7));
@@ -113,9 +161,8 @@ function applyFilters(){
   renderMetrics(metrics);
   renderIssues(filtered);
 }
-fetch('sample-issues.json').then(r=>r.json()).then(data=>{
-  allIssues=data; populateFilters(); applyFilters();
-});
+
+loadSample();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Jira domain and JQL inputs to Overview page
- allow loading sample issues or querying Jira
- style the new buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cd3f38fec83259a4276ca5c027770