### PR TITLE
Add disruption KPI page and browser support

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
           <option value="index_overview.html">Overview</option>
+          <option value="index_disruption.html">Disruption</option>
         </select>
       </label>
     </div>

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Stakeholder Report – Disruption KPIs</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
+  <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+  <style>
+    body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin: 0; padding: 0; }
+    .main { max-width: 950px; margin: 30px auto 40px auto; background: #fff; border-radius: 18px; box-shadow: 0 2px 12px #d1d5db70; padding: 36px 32px; }
+    h1 { font-size: 2.3em; margin:0 0 0.7em 0; font-weight: 600; }
+    .btn { background: #6366f1; color: #fff; border: none; border-radius: 6px; padding: 7px 18px; cursor: pointer; font-size:1em; margin: 0 10px 8px 0;}
+    .btn:disabled { background: #aaa; }
+    table { border-collapse: collapse; width: 100%; margin-top:20px; }
+    th, td { border: 1px solid #e5e7eb; padding:4px 7px; font-size:0.95em; text-align:left; }
+    th { background:#e0e7ef; }
+  </style>
+</head>
+<body>
+  <div class="main">
+    <h1>Stakeholder Report – Disruption KPIs</h1>
+    <div style="margin-bottom:10px;">
+      <label>Version:
+        <select id="versionSelect" onchange="switchVersion(this.value)">
+          <option value="index.html">Velocity</option>
+          <option value="index_throughput.html">Throughput</option>
+          <option value="index_throughput_week.html">Weekly Throughput</option>
+          <option value="index_overview.html">Overview</option>
+          <option value="index_disruption.html">Disruption</option>
+        </select>
+      </label>
+    </div>
+    <div style="margin-bottom:20px;">
+      <label for="boardSelect" class="section-title">Select Team Board:</label>
+      <select id="boardSelect"></select>
+      <button class="btn" onclick="loadReport()">Load Report</button>
+    </div>
+    <div id="stats"></div>
+    <table id="resultTable" style="display:none;">
+      <thead>
+        <tr>
+          <th>Sprint</th>
+          <th>Velocity</th>
+          <th>Pulled</th>
+          <th>Blocked</th>
+          <th>Moved</th>
+          <th>Type Changed</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <script src="src/disruption.js"></script>
+  <script>
+    const jiraDomain = location.host;
+
+    function switchVersion(page) {
+      if (location.pathname.endsWith(page)) return;
+      location.href = page;
+    }
+
+    document.getElementById('versionSelect').value = 'index_disruption.html';
+
+    async function loadBoards() {
+      const projects = ['ANP','BF','NPSCO'];
+      const boards = [];
+      for (const p of projects) {
+        try {
+          const resp = await fetch(`https://${jiraDomain}/rest/agile/1.0/board?projectKeyOrId=${p}`, { credentials:'include' });
+          if (!resp.ok) continue;
+          const data = await resp.json();
+          boards.push(...data.values);
+        } catch (e) {}
+      }
+      boards.sort((a,b)=>a.name.localeCompare(b.name));
+      const sel = document.getElementById('boardSelect');
+      boards.forEach(b => {
+        const opt = document.createElement('option');
+        opt.value = b.id;
+        opt.textContent = `${b.name} (${b.location.projectKey})`;
+        sel.appendChild(opt);
+      });
+      new Choices(sel);
+    }
+
+    async function fetchIssuesForSprint(boardId, sprintId) {
+      const jql = encodeURIComponent(`Sprint = ${sprintId}`);
+      const url = `https://${jiraDomain}/rest/api/2/search?jql=${jql}&expand=changelog&maxResults=1000`;
+      const resp = await fetch(url, { credentials:'include' });
+      if (!resp.ok) return [];
+      const data = await resp.json();
+      return data.issues || [];
+    }
+
+    async function loadReport() {
+      const boardId = document.getElementById('boardSelect').value;
+      if (!boardId) return alert('Select a board');
+      const sprintUrl = `https://${jiraDomain}/rest/agile/1.0/board/${boardId}/sprint?state=closed&maxResults=50`;
+      const resp = await fetch(sprintUrl, { credentials:'include' });
+      if (!resp.ok) return alert('Failed to fetch sprints');
+      const data = await resp.json();
+      let sprints = data.values || [];
+      sprints = sprints.filter(s=>s.startDate).sort((a,b)=>new Date(b.startDate)-new Date(a.startDate)).slice(0,12).reverse();
+      const results = [];
+      for (const s of sprints) {
+        const issues = await fetchIssuesForSprint(boardId, s.id);
+        const velocity = issues.reduce((sum,it)=>sum+(it.fields?.customfield_10016||0),0);
+        const disruptions = window.aggregateDisruptions(issues.map(i=>({ changelog: i.changelog.histories.map(h=>({ field:h.items[0]?.field, from:h.items[0]?.fromString, to:h.items[0]?.toString, created:h.created })) })), s.startDate);
+        results.push({ sprint:s.name, velocity, ...disruptions });
+      }
+      const velocities = results.map(r=>r.velocity);
+      const avg = velocities.reduce((a,b)=>a+b,0)/velocities.length || 0;
+      const sd = Math.sqrt(velocities.reduce((s,v)=>s+(v-avg)**2,0)/velocities.length || 0);
+      const stats = document.getElementById('stats');
+      stats.textContent = `Average Velocity: ${avg.toFixed(2)} | Standard Deviation: ${sd.toFixed(2)}`;
+      const tbody = document.querySelector('#resultTable tbody');
+      tbody.innerHTML = '';
+      results.forEach(r=>{
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${r.sprint}</td><td>${r.velocity}</td><td>${r.pulled}</td><td>${r.blocked}</td><td>${r.moved}</td><td>${r.typeChanged}</td>`;
+        tbody.appendChild(tr);
+      });
+      document.getElementById('resultTable').style.display = '';
+    }
+
+    loadBoards();
+  </script>
+</body>
+</html>

--- a/index_overview.html
+++ b/index_overview.html
@@ -24,6 +24,7 @@
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
           <option value="index_overview.html">Overview</option>
+          <option value="index_disruption.html">Disruption</option>
         </select>
       </label>
     </div>

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -117,6 +117,7 @@
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
           <option value="index_overview.html">Overview</option>
+          <option value="index_disruption.html">Disruption</option>
         </select>
       </label>
     </div>

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -117,6 +117,7 @@
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
           <option value="index_overview.html">Overview</option>
+          <option value="index_disruption.html">Disruption</option>
         </select>
       </label>
     </div>

--- a/src/disruption.js
+++ b/src/disruption.js
@@ -1,0 +1,44 @@
+function countDisruptions(issue, sprintStart) {
+  const start = new Date(sprintStart);
+  let pulled = 0, blocked = 0, moved = 0, typeChanged = 0;
+  const events = issue.changelog || [];
+  for (const ev of events) {
+    const when = new Date(ev.created);
+    if (when < start) continue;
+    const field = ev.field && ev.field.toLowerCase();
+    if (field === 'sprint') {
+      const from = ev.from || '';
+      const to = ev.to || '';
+      if (!from && to) pulled++;
+      else if (from && !to) moved++;
+      else if (from && to && from !== to) moved++;
+    } else if (field === 'status' && ev.to && ev.to.toLowerCase() === 'blocked') {
+      blocked++;
+    } else if (field === 'issuetype' && ev.from !== ev.to) {
+      typeChanged++;
+    }
+  }
+  return { pulled, blocked, moved, typeChanged };
+}
+
+function aggregateDisruptions(issues, sprintStart) {
+  const totals = { pulled: 0, blocked: 0, moved: 0, typeChanged: 0 };
+  for (const it of issues) {
+    const res = countDisruptions(it, sprintStart);
+    totals.pulled += res.pulled;
+    totals.blocked += res.blocked;
+    totals.moved += res.moved;
+    totals.typeChanged += res.typeChanged;
+  }
+  return totals;
+}
+
+// Expose functions for both Node (CommonJS) and browser environments
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { countDisruptions, aggregateDisruptions };
+} else {
+  // eslint-disable-next-line no-undef
+  window.countDisruptions = countDisruptions;
+  // eslint-disable-next-line no-undef
+  window.aggregateDisruptions = aggregateDisruptions;
+}

--- a/test/disruption.test.js
+++ b/test/disruption.test.js
@@ -1,0 +1,28 @@
+const { countDisruptions, aggregateDisruptions } = require('../src/disruption');
+
+describe('countDisruptions', () => {
+  test('counts events occurring after sprint start', () => {
+    const issue = {
+      changelog: [
+        { field: 'Sprint', from: null, to: '1', created: '2024-01-05' },
+        { field: 'status', from: 'Open', to: 'Blocked', created: '2024-01-10' },
+        { field: 'issuetype', from: 'Bug', to: 'Task', created: '2024-01-12' },
+        { field: 'Sprint', from: '1', to: null, created: '2024-01-13' },
+        { field: 'Sprint', from: null, to: '1', created: '2023-12-30' }
+      ]
+    };
+    const res = countDisruptions(issue, '2024-01-01');
+    expect(res).toEqual({ pulled:1, blocked:1, moved:1, typeChanged:1 });
+  });
+});
+
+describe('aggregateDisruptions', () => {
+  test('sums results for multiple issues', () => {
+    const issues = [
+      { changelog:[{ field:'Sprint', from:null, to:'1', created:'2024-01-05' }] },
+      { changelog:[{ field:'status', to:'Blocked', created:'2024-01-06' }] }
+    ];
+    const totals = aggregateDisruptions(issues, '2024-01-01');
+    expect(totals).toEqual({ pulled:1, blocked:1, moved:0, typeChanged:0 });
+  });
+});


### PR DESCRIPTION
## Summary
- expose disruption helpers for browser usage
- add standalone disruption KPI page that loads boards and sprint metrics
- allow switching to the new disruption view from existing report pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68930fb486088325aeb5dcc2e836cd5a