### PR TITLE
Handle missing board project key in disruption view

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -86,7 +86,8 @@
         boards.forEach(b => {
           const opt = document.createElement('option');
           opt.value = b.id;
-          opt.textContent = `${b.name} (${b.location.projectKey})`;
+          const projectKey = b.location && b.location.projectKey ? ` (${b.location.projectKey})` : '';
+          opt.textContent = `${b.name}${projectKey}`;
           sel.appendChild(opt);
         });
         if (sel.choicesInstance) {


### PR DESCRIPTION
## Summary
- avoid failure when board missing project key by including board name only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689331c9010083259c9b20bdec77746b