### PR TITLE
Add disruption detail reporting and chart

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -8,6 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
   <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin: 0; padding: 0; }
     .main { max-width: 950px; margin: 30px auto 40px auto; background: #fff; border-radius: 18px; box-shadow: 0 2px 12px #d1d5db70; padding: 36px 32px; }
@@ -61,6 +62,8 @@
       </thead>
       <tbody></tbody>
     </table>
+    <canvas id="chart" style="max-width:100%; margin-top:20px; display:none;"></canvas>
+    <div id="details" style="margin-top:20px;"></div>
   </div>
 
   <script src="src/disruption.js"></script>
@@ -182,7 +185,7 @@
       let startAt = 0;
       const maxResults = 100;
       while (true) {
-        const url = `https://${jiraDomain}/rest/api/3/search?jql=${jql}&fields=customfield_10016&expand=changelog&startAt=${startAt}&maxResults=${maxResults}`;
+        const url = `https://${jiraDomain}/rest/api/3/search?jql=${jql}&fields=customfield_10016,customfield_10002&expand=changelog&startAt=${startAt}&maxResults=${maxResults}`;
         try {
           const resp = await fetch(url, { credentials: 'include' });
           if (!resp.ok) {
@@ -219,8 +222,10 @@
         const sprintObj = sprints.find(s => String(s.id) === String(sprintId));
         const issues = await fetchIssuesForSprint(sprintId);
         if (issues === null) { hideLoading(); return; }
-        const velocity = issues.reduce((sum, it) => sum + (it.fields?.customfield_10016 || 0), 0);
+        const velocity = issues.reduce((sum, it) =>
+          sum + (it.fields?.customfield_10016 || it.fields?.customfield_10002 || 0), 0);
         const events = issues.map(i => ({
+          key: i.key,
           changelog: (i.changelog?.histories || []).map(h => ({
             field: h.items[0]?.field,
             from: h.items[0]?.fromString,
@@ -246,7 +251,40 @@
         tbody.appendChild(tr);
       });
       document.getElementById('resultTable').style.display = '';
+      renderChart(results);
+      renderDetails(results);
       hideLoading();
+    }
+
+    function renderDetails(results) {
+      const container = document.getElementById('details');
+      container.innerHTML = '';
+      results.forEach(r => {
+        const div = document.createElement('div');
+        div.innerHTML = `<h3>${r.sprint}</h3>` +
+          `<b>Pulled:</b> ${r.details.pulled.join(', ') || 'None'}<br>` +
+          `<b>Blocked:</b> ${r.details.blocked.join(', ') || 'None'}<br>` +
+          `<b>Moved:</b> ${r.details.moved.join(', ') || 'None'}<br>` +
+          `<b>Type Changed:</b> ${r.details.typeChanged.join(', ') || 'None'}<br>`;
+        container.appendChild(div);
+      });
+    }
+
+    function renderChart(results) {
+      const canvas = document.getElementById('chart');
+      canvas.style.display = '';
+      const ctx = canvas.getContext('2d');
+      const labels = results.map(r => r.sprint);
+      const data = {
+        labels,
+        datasets: [
+          { label: 'Pulled', data: results.map(r => r.pulled), backgroundColor: '#f87171' },
+          { label: 'Blocked', data: results.map(r => r.blocked), backgroundColor: '#fbbf24' },
+          { label: 'Moved', data: results.map(r => r.moved), backgroundColor: '#60a5fa' },
+          { label: 'Type Changed', data: results.map(r => r.typeChanged), backgroundColor: '#a78bfa' }
+        ]
+      };
+      new Chart(ctx, { type: 'bar', data, options: { responsive: true, scales: { y: { beginAtZero: true } } } });
     }
 
   </script>

--- a/src/disruption.js
+++ b/src/disruption.js
@@ -1,6 +1,7 @@
 function countDisruptions(issue, sprintStart) {
   const start = new Date(sprintStart);
   let pulled = 0, blocked = 0, moved = 0, typeChanged = 0;
+  const details = { pulled: new Set(), blocked: new Set(), moved: new Set(), typeChanged: new Set() };
   const events = issue.changelog || [];
   for (const ev of events) {
     const when = new Date(ev.created);
@@ -9,28 +10,76 @@ function countDisruptions(issue, sprintStart) {
     if (field === 'sprint') {
       const from = ev.from || '';
       const to = ev.to || '';
-      if (!from && to) pulled++;
-      else if (from && !to) moved++;
-      else if (from && to && from !== to) moved++;
+      if (!from && to) {
+        pulled++;
+        if (issue.key) details.pulled.add(issue.key);
+      } else if (from && !to) {
+        moved++;
+        if (issue.key) details.moved.add(issue.key);
+      } else if (from && to && from !== to) {
+        moved++;
+        if (issue.key) details.moved.add(issue.key);
+      }
     } else if (field === 'status' && ev.to && ev.to.toLowerCase() === 'blocked') {
       blocked++;
+      if (issue.key) details.blocked.add(issue.key);
     } else if (field === 'issuetype' && ev.from !== ev.to) {
       typeChanged++;
+      if (issue.key) details.typeChanged.add(issue.key);
     }
   }
-  return { pulled, blocked, moved, typeChanged };
+  return {
+    pulled,
+    blocked,
+    moved,
+    typeChanged,
+    details: {
+      pulled: Array.from(details.pulled),
+      blocked: Array.from(details.blocked),
+      moved: Array.from(details.moved),
+      typeChanged: Array.from(details.typeChanged)
+    }
+  };
 }
 
 function aggregateDisruptions(issues, sprintStart) {
-  const totals = { pulled: 0, blocked: 0, moved: 0, typeChanged: 0 };
+  const totals = {
+    pulled: 0,
+    blocked: 0,
+    moved: 0,
+    typeChanged: 0,
+    details: {
+      pulled: new Set(),
+      blocked: new Set(),
+      moved: new Set(),
+      typeChanged: new Set()
+    }
+  };
   for (const it of issues) {
     const res = countDisruptions(it, sprintStart);
     totals.pulled += res.pulled;
     totals.blocked += res.blocked;
     totals.moved += res.moved;
     totals.typeChanged += res.typeChanged;
+    if (res.details) {
+      if (res.details.pulled) res.details.pulled.forEach(k => totals.details.pulled.add(k));
+      if (res.details.blocked) res.details.blocked.forEach(k => totals.details.blocked.add(k));
+      if (res.details.moved) res.details.moved.forEach(k => totals.details.moved.add(k));
+      if (res.details.typeChanged) res.details.typeChanged.forEach(k => totals.details.typeChanged.add(k));
+    }
   }
-  return totals;
+  return {
+    pulled: totals.pulled,
+    blocked: totals.blocked,
+    moved: totals.moved,
+    typeChanged: totals.typeChanged,
+    details: {
+      pulled: Array.from(totals.details.pulled),
+      blocked: Array.from(totals.details.blocked),
+      moved: Array.from(totals.details.moved),
+      typeChanged: Array.from(totals.details.typeChanged)
+    }
+  };
 }
 
 // Expose functions for both Node (CommonJS) and browser environments

--- a/test/disruption.test.js
+++ b/test/disruption.test.js
@@ -3,6 +3,7 @@ const { countDisruptions, aggregateDisruptions } = require('../src/disruption');
 describe('countDisruptions', () => {
   test('counts events occurring after sprint start', () => {
     const issue = {
+      key: 'ISSUE-1',
       changelog: [
         { field: 'Sprint', from: null, to: '1', created: '2024-01-05' },
         { field: 'status', from: 'Open', to: 'Blocked', created: '2024-01-10' },
@@ -12,17 +13,29 @@ describe('countDisruptions', () => {
       ]
     };
     const res = countDisruptions(issue, '2024-01-01');
-    expect(res).toEqual({ pulled:1, blocked:1, moved:1, typeChanged:1 });
+    expect(res.pulled).toBe(1);
+    expect(res.blocked).toBe(1);
+    expect(res.moved).toBe(1);
+    expect(res.typeChanged).toBe(1);
+    expect(res.details.pulled).toContain('ISSUE-1');
+    expect(res.details.blocked).toContain('ISSUE-1');
+    expect(res.details.moved).toContain('ISSUE-1');
+    expect(res.details.typeChanged).toContain('ISSUE-1');
   });
 });
 
 describe('aggregateDisruptions', () => {
   test('sums results for multiple issues', () => {
     const issues = [
-      { changelog:[{ field:'Sprint', from:null, to:'1', created:'2024-01-05' }] },
-      { changelog:[{ field:'status', to:'Blocked', created:'2024-01-06' }] }
+      { key:'A', changelog:[{ field:'Sprint', from:null, to:'1', created:'2024-01-05' }] },
+      { key:'B', changelog:[{ field:'status', to:'Blocked', created:'2024-01-06' }] }
     ];
     const totals = aggregateDisruptions(issues, '2024-01-01');
-    expect(totals).toEqual({ pulled:1, blocked:1, moved:0, typeChanged:0 });
+    expect(totals.pulled).toBe(1);
+    expect(totals.blocked).toBe(1);
+    expect(totals.moved).toBe(0);
+    expect(totals.typeChanged).toBe(0);
+    expect(totals.details.pulled).toEqual(['A']);
+    expect(totals.details.blocked).toEqual(['B']);
   });
 });


### PR DESCRIPTION
## Summary
- Track issue keys contributing to disruption categories
- Calculate velocity using multiple story point fields and list disruptions per sprint
- Visualize disruption counts per sprint with a bar chart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933fae37ec8325ab5e55b331a0c28f