### PR TITLE
Fix disruption counts and velocity calculation

### DIFF
--- a/index_overview.html
+++ b/index_overview.html
@@ -113,7 +113,7 @@ function calculateMetrics(issues){
     total += (r-c)/86400000;
     const w=isoWeekNumber(it.resolved);
     tp[w]=(tp[w]||0)+1;
-    vel[w]=(vel[w]||0)+(it.points||0);
+    vel[w]=(vel[w]||0)+(Number(it.points)||0);
   }
   return {avg: total/issues.length, tp, vel};
 }

--- a/src/disruption.js
+++ b/src/disruption.js
@@ -1,6 +1,5 @@
 function countDisruptions(issue, sprintStart) {
   const start = new Date(sprintStart);
-  let pulled = 0, blocked = 0, moved = 0, typeChanged = 0;
   const details = { pulled: new Set(), blocked: new Set(), moved: new Set(), typeChanged: new Set() };
   const events = issue.changelog || [];
   for (const ev of events) {
@@ -11,28 +10,21 @@ function countDisruptions(issue, sprintStart) {
       const from = ev.from || '';
       const to = ev.to || '';
       if (!from && to) {
-        pulled++;
         if (issue.key) details.pulled.add(issue.key);
-      } else if (from && !to) {
-        moved++;
-        if (issue.key) details.moved.add(issue.key);
-      } else if (from && to && from !== to) {
-        moved++;
+      } else if ((from && !to) || (from && to && from !== to)) {
         if (issue.key) details.moved.add(issue.key);
       }
     } else if (field === 'status' && ev.to && ev.to.toLowerCase() === 'blocked') {
-      blocked++;
       if (issue.key) details.blocked.add(issue.key);
     } else if (field === 'issuetype' && ev.from !== ev.to) {
-      typeChanged++;
       if (issue.key) details.typeChanged.add(issue.key);
     }
   }
   return {
-    pulled,
-    blocked,
-    moved,
-    typeChanged,
+    pulled: details.pulled.size,
+    blocked: details.blocked.size,
+    moved: details.moved.size,
+    typeChanged: details.typeChanged.size,
     details: {
       pulled: Array.from(details.pulled),
       blocked: Array.from(details.blocked),
@@ -44,40 +36,28 @@ function countDisruptions(issue, sprintStart) {
 
 function aggregateDisruptions(issues, sprintStart) {
   const totals = {
-    pulled: 0,
-    blocked: 0,
-    moved: 0,
-    typeChanged: 0,
-    details: {
-      pulled: new Set(),
-      blocked: new Set(),
-      moved: new Set(),
-      typeChanged: new Set()
-    }
+    pulled: new Set(),
+    blocked: new Set(),
+    moved: new Set(),
+    typeChanged: new Set()
   };
   for (const it of issues) {
     const res = countDisruptions(it, sprintStart);
-    totals.pulled += res.pulled;
-    totals.blocked += res.blocked;
-    totals.moved += res.moved;
-    totals.typeChanged += res.typeChanged;
-    if (res.details) {
-      if (res.details.pulled) res.details.pulled.forEach(k => totals.details.pulled.add(k));
-      if (res.details.blocked) res.details.blocked.forEach(k => totals.details.blocked.add(k));
-      if (res.details.moved) res.details.moved.forEach(k => totals.details.moved.add(k));
-      if (res.details.typeChanged) res.details.typeChanged.forEach(k => totals.details.typeChanged.add(k));
-    }
+    res.details.pulled.forEach(k => totals.pulled.add(k));
+    res.details.blocked.forEach(k => totals.blocked.add(k));
+    res.details.moved.forEach(k => totals.moved.add(k));
+    res.details.typeChanged.forEach(k => totals.typeChanged.add(k));
   }
   return {
-    pulled: totals.pulled,
-    blocked: totals.blocked,
-    moved: totals.moved,
-    typeChanged: totals.typeChanged,
+    pulled: totals.pulled.size,
+    blocked: totals.blocked.size,
+    moved: totals.moved.size,
+    typeChanged: totals.typeChanged.size,
     details: {
-      pulled: Array.from(totals.details.pulled),
-      blocked: Array.from(totals.details.blocked),
-      moved: Array.from(totals.details.moved),
-      typeChanged: Array.from(totals.details.typeChanged)
+      pulled: Array.from(totals.pulled),
+      blocked: Array.from(totals.blocked),
+      moved: Array.from(totals.moved),
+      typeChanged: Array.from(totals.typeChanged)
     }
   };
 }

--- a/src/overview.js
+++ b/src/overview.js
@@ -29,7 +29,7 @@ function calculateMetrics(issues) {
     totalCycle += diff;
     const week = isoWeekNumber(resolved);
     throughput[week] = (throughput[week] || 0) + 1;
-    velocity[week] = (velocity[week] || 0) + (it.points || 0);
+    velocity[week] = (velocity[week] || 0) + (Number(it.points) || 0);
   }
   return {
     averageCycleTime: totalCycle / issues.length,

--- a/test/disruption.test.js
+++ b/test/disruption.test.js
@@ -22,6 +22,20 @@ describe('countDisruptions', () => {
     expect(res.details.moved).toContain('ISSUE-1');
     expect(res.details.typeChanged).toContain('ISSUE-1');
   });
+
+  test('counts each disrupted story only once', () => {
+    const issue = {
+      key: 'ISSUE-2',
+      changelog: [
+        { field: 'status', from: 'In Progress', to: 'Blocked', created: '2024-02-01' },
+        { field: 'status', from: 'Blocked', to: 'In Progress', created: '2024-02-02' },
+        { field: 'status', from: 'In Progress', to: 'Blocked', created: '2024-02-03' }
+      ]
+    };
+    const res = countDisruptions(issue, '2024-01-30');
+    expect(res.blocked).toBe(1);
+    expect(res.details.blocked).toEqual(['ISSUE-2']);
+  });
 });
 
 describe('aggregateDisruptions', () => {

--- a/test/overview.test.js
+++ b/test/overview.test.js
@@ -24,4 +24,14 @@ describe('calculateMetrics', () => {
     expect(res.throughputPerWeek[week]).toBe(2);
     expect(res.velocityPerWeek[week]).toBe(8);
   });
+
+  test('handles story points as strings', () => {
+    const stringIssues = [
+      { created:'2025-02-01', resolved:'2025-02-05', points:'4' },
+      { created:'2025-02-02', resolved:'2025-02-05', points:'6' }
+    ];
+    const res = calculateMetrics(stringIssues);
+    const week = isoWeekNumber('2025-02-05');
+    expect(res.velocityPerWeek[week]).toBe(10);
+  });
 });


### PR DESCRIPTION
## Summary
- count disruptions by unique story instead of per event
- parse story points as numbers for accurate velocity
- mirror velocity fix in overview page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893432e611083258dde11ff97093e99