### PR TITLE
fetch disruption data from jira

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -12,6 +12,7 @@
     table { border-collapse: collapse; width: 100%; margin-top: 20px; }
     th, td { border: 1px solid #e5e7eb; padding: 6px 10px; text-align:left; font-size:0.95em; }
     th { background:#e0e7ef; }
+    .btn { background:#6366f1; color:#fff; border:none; border-radius:6px; padding:7px 18px; cursor:pointer; font-size:1em; }
   </style>
 </head>
 <body>
@@ -28,10 +29,9 @@
     </label>
   </div>
   <div style="margin-top:20px;">
-    <label for="boardSelect">Team/Board:</label>
-    <select id="boardSelect">
-      <option>Demo Board</option>
-    </select>
+    <label>Jira Domain: <input id="jiraDomain" value="aldi-sued.atlassian.net" size="28"></label>
+    <label style="margin-left:10px;">Board Number: <input id="boardNum" size="5"></label>
+    <button class="btn" onclick="loadDisruption()">Load Data</button>
   </div>
   <table>
     <thead>
@@ -51,29 +51,79 @@
 <script>
   function switchVersion(v){ window.location.href = v; }
 
-  const sampleData = [
-    {
-      name: 'Sprint 1',
-      issues: [
-        { points: 5, addedAfterStart: true },
-        { points: 3, blocked: true },
-        { points: 2, typeChanged: true }
-      ]
-    },
-    {
-      name: 'Sprint 2',
-      issues: [
-        { points: 8 },
-        { points: 1, movedOut: true },
-        { points: 3, blocked: true, addedAfterStart: true }
-      ]
+  async function fetchDisruptionData(jiraDomain, boardNum) {
+    const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
+    try {
+      const resp = await fetch(url, { credentials: 'include' });
+      if (!resp.ok) {
+        alert('Failed to fetch velocity report. Are you logged in to Jira?');
+        return [];
+      }
+      const data = await resp.json();
+      let closed = (data.sprints || []).filter(s => s.state === 'CLOSED');
+      closed.sort((a,b) => {
+        const ad = a.endDate || a.completeDate || a.startDate || '';
+        const bd = b.endDate || b.completeDate || b.startDate || '';
+        return ad && bd ? new Date(bd) - new Date(ad) : 0;
+      });
+      closed = closed.slice(0,6);
+      const results = [];
+      for (const s of closed) {
+        const surl = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId=${boardNum}&sprintId=${s.id}`;
+        try {
+          const r = await fetch(surl, { credentials: 'include' });
+          if (!r.ok) continue;
+          const d = await r.json();
+          const addedMap = d.contents.issueKeysAddedDuringSprint || {};
+          const issues = [];
+          const collect = (arr, movedOut=false) => {
+            (arr || []).forEach(it => {
+              issues.push({
+                key: it.key,
+                points: it.estimateStatistic?.statFieldValue?.value || 0,
+                addedAfterStart: !!addedMap[it.key],
+                blocked: !!it.flagged,
+                movedOut
+              });
+            });
+          };
+          collect(d.contents.completedIssues, false);
+          collect(d.contents.issuesNotCompletedInCurrentSprint, false);
+          collect(d.contents.puntedIssues, true);
+          const sprintStart = s.startDate ? new Date(s.startDate) : null;
+          const sprintEnd = s.completeDate ? new Date(s.completeDate) : (s.endDate ? new Date(s.endDate) : null);
+          await Promise.all(issues.map(async it => {
+            try {
+              const u = `https://${jiraDomain}/rest/api/3/issue/${it.key}?expand=changelog&fields=issuetype`;
+              const ir = await fetch(u, { credentials: 'include' });
+              if (!ir.ok) return;
+              const id = await ir.json();
+              const histories = id.changelog?.histories || [];
+              for (const h of histories) {
+                const chDate = new Date(h.created);
+                if (sprintStart && sprintEnd && chDate >= sprintStart && chDate <= sprintEnd) {
+                  for (const item of h.items) {
+                    if (item.field === 'issuetype') { it.typeChanged = true; return; }
+                  }
+                }
+              }
+            } catch(e) {}
+          }));
+          results.push({ name: s.name, issues });
+        } catch (e) { console.error('sprint fetch failed', e); }
+      }
+      return results;
+    } catch (e) {
+      console.error('Failed to fetch disruption data', e);
+      alert('Failed to fetch disruption data.');
+      return [];
     }
-  ];
+  }
 
-  function renderTable() {
+  function renderTable(data) {
     const tbody = document.getElementById('metricsBody');
     let html = '';
-    sampleData.forEach(sprint => {
+    data.forEach(sprint => {
       const metrics = Disruption.calculateDisruptionMetrics(sprint.issues);
       const velocity = sprint.issues.reduce((sum, i) => sum + (i.points || 0), 0);
       html += `<tr>
@@ -81,14 +131,24 @@
         <td>${velocity}</td>
         <td>${metrics.pulledIn}</td>
         <td>${metrics.blocked}</td>
-        <td>${metrics.typeChanged}</td>
+        <td>${metrics.typeChanged || 0}</td>
         <td>${metrics.movedOut}</td>
       </tr>`;
     });
     tbody.innerHTML = html;
   }
 
-  renderTable();
+  async function loadDisruption() {
+    const jiraDomain = document.getElementById('jiraDomain').value.trim();
+    const boardNum = document.getElementById('boardNum').value.trim();
+    if (!jiraDomain || !boardNum) {
+      alert('Enter Jira domain and board number.');
+      return;
+    }
+    const data = await fetchDisruptionData(jiraDomain, boardNum);
+    renderTable(data);
+  }
+
   document.getElementById('versionSelect').value = 'index_disruption.html';
 </script>
 </body>


### PR DESCRIPTION
## Summary
- replace demo board in disruption report with inputs for Jira domain and board number
- add `fetchDisruptionData` to pull sprint metrics from Jira and compute disruption values
- render disruption table from live Jira data

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689458206c388325b2dace6bb0a24dc3