### PR TITLE
Exclude pulled-in issues from initial planned points

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -94,16 +94,9 @@
           collect(d.contents.puntedIssues, true);
 
           const entry = data.velocityStatEntries?.[s.id] || {};
-          let planned = entry.estimated?.value || 0;
           let completed = entry.completed?.value || 0;
-          let other = completed > planned ? completed - planned : 0;
-
           if (!completed) {
             completed = d.contents?.completedIssuesEstimateSum?.value || 0;
-            planned = completed +
-                      (d.contents?.incompletedIssuesEstimateSum?.value || 0) +
-                      (d.contents?.puntedIssuesEstimateSum?.value || 0);
-            other = completed > planned ? completed - planned : 0;
           }
           const sprintStart = s.startDate ? new Date(s.startDate) : null;
           const sprintEnd = s.completeDate ? new Date(s.completeDate) : (s.endDate ? new Date(s.endDate) : null);
@@ -124,6 +117,9 @@
               }
             } catch(e) {}
           }));
+          const planned = issues.filter(it => !it.addedAfterStart)
+                               .reduce((sum, it) => sum + it.points, 0);
+          const other = completed > planned ? completed - planned : 0;
           results.push({ name: s.name, issues, planned, completed, other });
         } catch (e) { console.error('sprint fetch failed', e); }
       }


### PR DESCRIPTION
## Summary
- compute planned story points only from issues present at sprint start
- derive "other" points from difference between completed and planned

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689469ee77288325b2177b233f21ba2a