### PR TITLE
Use initial planned story points for disruption report

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -37,7 +37,7 @@
     <thead>
       <tr>
         <th>Sprint</th>
-        <th>Planned</th>
+        <th>Initially Planned</th>
         <th>Completed</th>
         <th>Other</th>
         <th>Pulled In</th>
@@ -98,6 +98,7 @@
           if (!completed) {
             completed = d.contents?.completedIssuesEstimateSum?.value || 0;
           }
+          let initiallyPlanned = entry.estimated?.value || 0;
           const sprintStart = s.startDate ? new Date(s.startDate) : null;
           const sprintEnd = s.completeDate ? new Date(s.completeDate) : (s.endDate ? new Date(s.endDate) : null);
           await Promise.all(issues.map(async it => {
@@ -117,10 +118,12 @@
               }
             } catch(e) {}
           }));
-          const planned = issues.filter(it => !it.addedAfterStart)
-                               .reduce((sum, it) => sum + it.points, 0);
-          const other = completed > planned ? completed - planned : 0;
-          results.push({ name: s.name, issues, planned, completed, other });
+          if (!initiallyPlanned) {
+            initiallyPlanned = issues.filter(it => !it.addedAfterStart)
+                                     .reduce((sum, it) => sum + it.points, 0);
+          }
+          const other = completed > initiallyPlanned ? completed - initiallyPlanned : 0;
+          results.push({ name: s.name, issues, initiallyPlanned, completed, other });
         } catch (e) { console.error('sprint fetch failed', e); }
       }
       return results;
@@ -138,7 +141,7 @@
       const metrics = Disruption.calculateDisruptionMetrics(sprint.issues);
       html += `<tr>
         <td>${sprint.name}</td>
-        <td>${sprint.planned || 0}</td>
+        <td>${sprint.initiallyPlanned || 0}</td>
         <td>${sprint.completed || 0}</td>
         <td>${sprint.other || 0}</td>
         <td>${metrics.pulledIn}</td>


### PR DESCRIPTION
## Summary
- Show initially planned story points in disruption KPI report
- Compute other points from completed vs initial commitment

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68946bb1b0208325908c0f85f43a8d66