### PR TITLE
Show story details in disruption KPI report

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -13,6 +13,10 @@
     th, td { border: 1px solid #e5e7eb; padding: 6px 10px; text-align:left; font-size:0.95em; }
     th { background:#e0e7ef; }
     .btn { background:#6366f1; color:#fff; border:none; border-radius:6px; padding:7px 18px; cursor:pointer; font-size:1em; }
+    .details-toggle { margin:10px 0 6px 0; }
+    .story-table { border-collapse: collapse; width: 100%; margin: 6px 0 18px 0; }
+    .story-table th, .story-table td { border: 1px solid #e5e7eb; padding: 4px 7px; font-size: 0.95em; text-align:left; }
+    .story-table th { background:#e0e7ef; }
   </style>
 </head>
 <body>
@@ -44,6 +48,7 @@
         <th>Blocked</th>
         <th>Type Changed</th>
         <th>Moved Out</th>
+        <th>Details</th>
       </tr>
     </thead>
     <tbody id="metricsBody"></tbody>
@@ -141,8 +146,9 @@
   function renderTable(data) {
     const tbody = document.getElementById('metricsBody');
     let html = '';
-    data.forEach(sprint => {
+    data.forEach((sprint, idx) => {
       const metrics = Disruption.calculateDisruptionMetrics(sprint.issues);
+      const detailsId = `details-${idx}`;
       html += `<tr>
         <td>${sprint.name}</td>
         <td title="${sprint.initiallyPlannedSource}">${sprint.initiallyPlanned || 0}</td>
@@ -152,9 +158,30 @@
         <td title="${metrics.blockedIssues.join(', ')}">${metrics.blocked}</td>
         <td title="${metrics.typeChangedIssues.join(', ')}">${metrics.typeChanged || 0}</td>
         <td title="${metrics.movedOutIssues.join(', ')}">${metrics.movedOut}</td>
+        <td><button class="btn details-toggle" onclick="toggleDetails('${detailsId}', this)">Show Details</button></td>
       </tr>`;
+      html += `<tr id="${detailsId}" style="display:none"><td colspan="9">
+        <table class="story-table">
+          <thead><tr><th>Metric</th><th>Stories</th></tr></thead>
+          <tbody>
+            <tr><td>Pulled In</td><td>${metrics.pulledInIssues.join(', ') || '-'}</td></tr>
+            <tr><td>Blocked</td><td>${metrics.blockedIssues.join(', ') || '-'}</td></tr>
+            <tr><td>Type Changed</td><td>${metrics.typeChangedIssues.join(', ') || '-'}</td></tr>
+            <tr><td>Moved Out</td><td>${metrics.movedOutIssues.join(', ') || '-'}</td></tr>
+          </tbody>
+        </table>
+      </td></tr>`;
     });
     tbody.innerHTML = html;
+  }
+
+  function toggleDetails(id, btn) {
+    const row = document.getElementById(id);
+    if (row) {
+      const hidden = row.style.display === 'none';
+      row.style.display = hidden ? '' : 'none';
+      if (btn) btn.textContent = hidden ? 'Hide Details' : 'Show Details';
+    }
   }
 
   async function loadDisruption() {


### PR DESCRIPTION
## Summary
- add Details column and show/hide button to disruption report that lists pulled-in, blocked, type-changed, and moved-out stories
- revert story detail tables from velocity and throughput reports so only disruption version displays issue breakdowns

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68947593c7b88325b778bc48049b1f74