### PR TITLE
Show story points and counts for disruption metrics

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -154,10 +154,10 @@
         <td title="${sprint.initiallyPlannedSource}">${sprint.initiallyPlanned || 0}</td>
         <td title="${sprint.completedSource}">${sprint.completed || 0}</td>
         <td title="completed minus initially planned">${sprint.other || 0}</td>
-        <td title="${metrics.pulledInIssues.join(', ')}">${metrics.pulledIn}</td>
-        <td title="${metrics.blockedIssues.join(', ')}">${metrics.blocked}</td>
-        <td title="${metrics.typeChangedIssues.join(', ')}">${metrics.typeChanged || 0}</td>
-        <td title="${metrics.movedOutIssues.join(', ')}">${metrics.movedOut}</td>
+        <td title="${metrics.pulledInIssues.join(', ')}">${metrics.pulledIn} (${metrics.pulledInCount})</td>
+        <td title="${metrics.blockedIssues.join(', ')}">${metrics.blocked} (${metrics.blockedCount})</td>
+        <td title="${metrics.typeChangedIssues.join(', ')}">${metrics.typeChanged || 0} (${metrics.typeChangedCount})</td>
+        <td title="${metrics.movedOutIssues.join(', ')}">${metrics.movedOut} (${metrics.movedOutCount})</td>
         <td><button class="btn details-toggle" onclick="toggleDetails('${detailsId}', this)">Show Details</button></td>
       </tr>`;
       html += `<tr id="${detailsId}" style="display:none"><td colspan="9">

--- a/src/disruption.js
+++ b/src/disruption.js
@@ -7,30 +7,39 @@
 }(this, function () {
   function calculateDisruptionMetrics(events = []) {
     const metrics = {
-      pulledIn: 0,
+      pulledIn: 0, // total story points
+      pulledInCount: 0,
       blocked: 0,
+      blockedCount: 0,
       typeChanged: 0,
+      typeChangedCount: 0,
       movedOut: 0,
+      movedOutCount: 0,
       pulledInIssues: [],
       blockedIssues: [],
       typeChangedIssues: [],
       movedOutIssues: []
     };
     events.forEach(ev => {
+      const pts = ev.points || 0;
       if (ev.addedAfterStart) {
-        metrics.pulledIn += 1;
+        metrics.pulledIn += pts;
+        metrics.pulledInCount += 1;
         metrics.pulledInIssues.push(ev.key);
       }
       if (ev.blocked) {
-        metrics.blocked += 1;
+        metrics.blocked += pts;
+        metrics.blockedCount += 1;
         metrics.blockedIssues.push(ev.key);
       }
       if (ev.typeChanged) {
-        metrics.typeChanged += 1;
+        metrics.typeChanged += pts;
+        metrics.typeChangedCount += 1;
         metrics.typeChangedIssues.push(ev.key);
       }
       if (ev.movedOut) {
-        metrics.movedOut += 1;
+        metrics.movedOut += pts;
+        metrics.movedOutCount += 1;
         metrics.movedOutIssues.push(ev.key);
       }
     });


### PR DESCRIPTION
## Summary
- track story points and counts for disruption metrics
- show metrics as `points (items)` in the disruption report table

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68948e1569e0832584c7b6b1558e637d