### PR TITLE
Fix undefined counts in disruption metrics

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -154,10 +154,10 @@
         <td title="${sprint.initiallyPlannedSource}">${sprint.initiallyPlanned || 0}</td>
         <td title="${sprint.completedSource}">${sprint.completed || 0}</td>
         <td title="completed minus initially planned">${sprint.other || 0}</td>
-        <td title="${metrics.pulledInIssues.join(', ')}">${metrics.pulledIn} (${metrics.pulledInCount})</td>
-        <td title="${metrics.blockedIssues.join(', ')}">${metrics.blocked} (${metrics.blockedCount})</td>
-        <td title="${metrics.typeChangedIssues.join(', ')}">${metrics.typeChanged || 0} (${metrics.typeChangedCount})</td>
-        <td title="${metrics.movedOutIssues.join(', ')}">${metrics.movedOut} (${metrics.movedOutCount})</td>
+        <td title="${metrics.pulledInIssues.join(', ')}">${metrics.pulledIn || 0} (${metrics.pulledInCount || 0})</td>
+        <td title="${metrics.blockedIssues.join(', ')}">${metrics.blocked || 0} (${metrics.blockedCount || 0})</td>
+        <td title="${metrics.typeChangedIssues.join(', ')}">${metrics.typeChanged || 0} (${metrics.typeChangedCount || 0})</td>
+        <td title="${metrics.movedOutIssues.join(', ')}">${metrics.movedOut || 0} (${metrics.movedOutCount || 0})</td>
         <td><button class="btn details-toggle" onclick="toggleDetails('${detailsId}', this)">Show Details</button></td>
       </tr>`;
       html += `<tr id="${detailsId}" style="display:none"><td colspan="9">

--- a/src/disruption.js
+++ b/src/disruption.js
@@ -20,29 +20,37 @@
       typeChangedIssues: [],
       movedOutIssues: []
     };
+
     events.forEach(ev => {
       const pts = ev.points || 0;
+
       if (ev.addedAfterStart) {
         metrics.pulledIn += pts;
-        metrics.pulledInCount += 1;
         metrics.pulledInIssues.push(ev.key);
       }
+
       if (ev.blocked) {
         metrics.blocked += pts;
-        metrics.blockedCount += 1;
         metrics.blockedIssues.push(ev.key);
       }
+
       if (ev.typeChanged) {
         metrics.typeChanged += pts;
-        metrics.typeChangedCount += 1;
         metrics.typeChangedIssues.push(ev.key);
       }
+
       if (ev.movedOut) {
         metrics.movedOut += pts;
-        metrics.movedOutCount += 1;
         metrics.movedOutIssues.push(ev.key);
       }
     });
+
+    // Derive counts from the collected issue lists to avoid undefined values
+    metrics.pulledInCount = metrics.pulledInIssues.length;
+    metrics.blockedCount = metrics.blockedIssues.length;
+    metrics.typeChangedCount = metrics.typeChangedIssues.length;
+    metrics.movedOutCount = metrics.movedOutIssues.length;
+
     return metrics;
   }
   return { calculateDisruptionMetrics };


### PR DESCRIPTION
## Summary
- ensure disruption metric counts derive from collected issue lists
- guard disruption report against undefined counts

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894904847ec832595a6781a2cc48059