### PR TITLE
feat: add logging utilities for debugging

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -54,6 +54,10 @@
     <tbody id="metricsBody"></tbody>
   </table>
 </div>
+<script src="src/logger.js"></script>
+<script>
+  Logger.setLevel('debug');
+</script>
 <script src="src/disruption.js"></script>
 <script>
   function switchVersion(v){ window.location.href = v; }

--- a/src/disruption.js
+++ b/src/disruption.js
@@ -5,7 +5,18 @@
     root.Disruption = factory();
   }
 }(this, function () {
+  const getGlobal = () => {
+    if (typeof globalThis !== 'undefined') return globalThis;
+    if (typeof window !== 'undefined') return window;
+    if (typeof self !== 'undefined') return self;
+    return {};
+  };
+  const logger = (typeof require === 'function' && typeof module === 'object' && module.exports)
+    ? require('./logger')
+    : (getGlobal().Logger || { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} });
+
   function calculateDisruptionMetrics(events = []) {
+    logger.debug('calculateDisruptionMetrics called with events', events);
     const metrics = {
       pulledIn: 0, // total story points
       pulledInCount: 0,
@@ -23,6 +34,7 @@
 
     events.forEach(ev => {
       const pts = ev.points || 0;
+      logger.debug('Processing event', ev);
 
       if (ev.addedAfterStart) {
         metrics.pulledIn += pts;
@@ -51,6 +63,7 @@
     metrics.typeChangedCount = metrics.typeChangedIssues.length;
     metrics.movedOutCount = metrics.movedOutIssues.length;
 
+    logger.debug('Calculated metrics', metrics);
     return metrics;
   }
   return { calculateDisruptionMetrics };

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,35 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.Logger = factory();
+  }
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  const levels = ['error', 'warn', 'info', 'debug'];
+  let current = 'warn';
+
+  if (typeof process !== 'undefined' && process.env.LOG_LEVEL) {
+    current = process.env.LOG_LEVEL;
+  } else if (typeof window !== 'undefined' && window.LOG_LEVEL) {
+    current = window.LOG_LEVEL;
+  }
+
+  function shouldLog(level) {
+    return levels.indexOf(level) <= levels.indexOf(current);
+  }
+
+  const logger = {};
+  levels.forEach(l => {
+    logger[l] = (...args) => {
+      if (shouldLog(l) && typeof console !== 'undefined') {
+        const method = console[l] ? l : 'log';
+        console[method]('[MCReport]', ...args);
+      }
+    };
+  });
+
+  logger.setLevel = lvl => { if (levels.includes(lvl)) current = lvl; };
+  logger.getLevel = () => current;
+
+  return logger;
+}));

--- a/src/sim.js
+++ b/src/sim.js
@@ -1,13 +1,18 @@
+const logger = require('./logger');
+
 function weekStart(dt) {
+  logger.debug('weekStart input', dt);
   const d = new Date(dt);
   const day = d.getDay();
   const diff = d.getDate() - day + (day === 0 ? -6 : 1);
   d.setDate(diff);
   d.setHours(0,0,0,0);
+  logger.debug('weekStart output', d);
   return d;
 }
 
 function calculateWeeklyThroughput(issues, current=new Date()) {
+  logger.debug('calculateWeeklyThroughput start', { count: issues.length, current });
   const counts = new Array(12).fill(0);
   const currentWeek = weekStart(current);
   issues.forEach(it => {
@@ -17,10 +22,12 @@ function calculateWeeklyThroughput(issues, current=new Date()) {
     const diff = Math.floor((currentWeek - w) / (7*24*60*60*1000));
     if (diff >= 0 && diff < 12) counts[11 - diff]++;
   });
+  logger.debug('calculateWeeklyThroughput result', counts);
   return counts;
 }
 
 function monteCarloSprints(backlogPts, throughput, allocation=100, runs=1000) {
+  logger.debug('monteCarloSprints start', { backlogPts, throughput, allocation, runs });
   const allocTPs = throughput.map(v => v * allocation / 100);
   const res = [];
   for (let i = 0; i < runs; i++) {
@@ -33,6 +40,7 @@ function monteCarloSprints(backlogPts, throughput, allocation=100, runs=1000) {
     res.push(s);
   }
   res.sort((a,b) => a - b);
+  logger.debug('monteCarloSprints result', res);
   return res;
 }
 


### PR DESCRIPTION
## Summary
- add simple Logger utility with adjustable levels
- instrument disruption and simulation modules with debug logs
- include logger in disruption report and default to debug output

## Testing
- `LOG_LEVEL=debug node - <<'NODE'
const Disruption = require('./src/disruption.js');
Disruption.calculateDisruptionMetrics([
  {key:'A', points:3, addedAfterStart:true},
  {key:'B', points:5, blocked:true},
  {key:'C', points:2, typeChanged:true},
  {key:'D', points:4, movedOut:true}
]);
NODE`
- `LOG_LEVEL=debug node - <<'NODE'
const { weekStart, calculateWeeklyThroughput, monteCarloSprints } = require('./src/sim.js');
weekStart('2024-05-20');
calculateWeeklyThroughput([{resolutiondate:'2024-05-20'}, {resolutiondate:'2024-05-22'}], new Date('2024-05-27'));
monteCarloSprints(10, [5,6,7], 100, 5);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68949b0e112c8325b88b83d4191430d3