### PR TITLE
Fix sprint fetching for disruption report

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -124,14 +124,23 @@
           let closed = (data.sprints || []).filter(s => s.state === 'CLOSED' && s.startDate);
 
           if (!closed.length) {
-            const sUrl = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/sprint?state=closed`;
-            const sResp = await fetch(sUrl, { credentials: 'include' });
-            if (!sResp.ok) {
-              Logger.error('Failed to fetch sprint list', sResp.status);
-              return;
+            let allSprints = [];
+            let startAt = 0;
+            const maxResults = 50;
+            while (true) {
+              const sUrl = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/sprint?state=closed&maxResults=${maxResults}&startAt=${startAt}`;
+              const sResp = await fetch(sUrl, { credentials: 'include' });
+              if (!sResp.ok) {
+                Logger.error('Failed to fetch sprint list', sResp.status);
+                break;
+              }
+              const sData = await sResp.json();
+              const values = sData.values || [];
+              allSprints = allSprints.concat(values);
+              if (sData.isLast || !values.length) break;
+              startAt += values.length;
             }
-            const sData = await sResp.json();
-            closed = (sData.values || []).filter(s => (s.state || '').toUpperCase() === 'CLOSED' && s.startDate);
+            closed = allSprints.filter(s => (s.state || '').toUpperCase() === 'CLOSED' && s.startDate);
           }
 
           closed.sort((a, b) => new Date(b.startDate) - new Date(a.startDate));


### PR DESCRIPTION
## Summary
- ensure disruption report fetches latest sprints by paging through closed sprint results

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895b4634d40832594b7f0f9d00f75ca