### PR TITLE
Guard sprint pagination in disruption report to avoid freeze

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -127,6 +127,7 @@
             let allSprints = [];
             let startAt = 0;
             const maxResults = 50;
+            let loops = 0;
             while (true) {
               const sUrl = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/sprint?state=closed&maxResults=${maxResults}&startAt=${startAt}`;
               const sResp = await fetch(sUrl, { credentials: 'include' });
@@ -137,8 +138,9 @@
               const sData = await sResp.json();
               const values = sData.values || [];
               allSprints = allSprints.concat(values);
-              if (sData.isLast || !values.length) break;
               startAt += values.length;
+              loops++;
+              if (sData.isLast || values.length < maxResults || loops > 100) break;
             }
             closed = allSprints.filter(s => (s.state || '').toUpperCase() === 'CLOSED' && s.startDate);
           }


### PR DESCRIPTION
## Summary
- revert pagination guard additions in velocity and throughput reports
- add loop counter and extra break conditions to sprint list fallback in disruption report

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895b94ef10c8325b0ce39d9b239aee3