### PR TITLE
fix: ensure type change detection only counts actual changes

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -197,7 +197,13 @@
                     if (sprintStart && sprintEnd && chDate >= sprintStart && chDate <= sprintEnd) {
                       ev.events = ev.events.concat(h.items || []);
                       for (const item of h.items) {
-                        if (item.field === 'issuetype') ev.typeChanged = true;
+                        if (item.field === 'issuetype') {
+                          const fromType = item.fromString || item.from;
+                          const toType = item.toString || item.to;
+                          if (fromType && toType && fromType !== toType) {
+                            ev.typeChanged = true;
+                          }
+                        }
                       }
                     }
                   }


### PR DESCRIPTION
## Summary
- avoid treating issue creation as a type change by requiring real from/to difference in `issuetype` changelog items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "require('./src/disruption.js'); console.log('disruption loaded');"`
- `node - <<'NODE'
const items = [
  { field: 'issuetype', fromString: null, toString: 'Story' },
  { field: 'issuetype', fromString: 'Story', toString: 'Bug' },
  { field: 'issuetype', fromString: 'Bug', toString: 'Bug' }
];
items.forEach(item => {
  let ev = {};
  if (item.field === 'issuetype') {
    const fromType = item.fromString || item.from;
    const toType = item.toString || item.to;
    if (fromType && toType && fromType !== toType) {
      ev.typeChanged = true;
    }
  }
  console.log(`${JSON.stringify(item)} -> ${ev.typeChanged ? 'changed' : 'unchanged'}`);
});
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6895cb2833d08325b999cf39a4421f23