### PR TITLE
fix: refine type change tracking

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -189,17 +189,31 @@
 
               await Promise.all(events.map(async ev => {
                 try {
-                  let histories;
-                  if (issueCache.has(ev.key)) {
-                    histories = issueCache.get(ev.key);
+                  let cached = issueCache.get(ev.key);
+                  let histories, initialType, currentType;
+                  if (cached) {
+                    ({ histories, initialType, currentType } = cached);
                   } else {
                     const u = `https://${jiraDomain}/rest/api/3/issue/${ev.key}?expand=changelog`;
                     const ir = await fetch(u, { credentials: 'include' });
                     if (!ir.ok) return;
                     const id = await ir.json();
                     histories = id.changelog?.histories || [];
-                    issueCache.set(ev.key, histories);
+                    currentType = id.fields?.issuetype?.name || '';
+                    const sorted = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
+                    initialType = currentType;
+                    for (const h of sorted) {
+                      const item = (h.items || []).find(i => i.field === 'issuetype');
+                      if (item) {
+                        initialType = item.fromString || item.from || item.toString || item.to || initialType;
+                        break;
+                      }
+                    }
+                    issueCache.set(ev.key, { histories, initialType, currentType });
                   }
+
+                  const allowedTypes = new Set(['task', 'story', 'bug']);
+                  let changedDuringSprint = false;
                   for (const h of histories) {
                     const chDate = new Date(h.created);
                     if (sprintStart && sprintEnd && chDate >= sprintStart && chDate <= sprintEnd) {
@@ -208,12 +222,17 @@
                           const fromType = item.fromString || item.from;
                           const toType = item.toString || item.to;
                           if (fromType && toType && fromType !== toType) {
-                            ev.typeChanged = true;
+                            changedDuringSprint = true;
                             break;
                           }
                         }
                       }
                     }
+                    if (changedDuringSprint) break;
+                  }
+
+                  if (changedDuringSprint && allowedTypes.has((initialType || '').toLowerCase()) && currentType && currentType !== initialType) {
+                    ev.typeChanged = true;
                   }
                 } catch (e) {}
               }));


### PR DESCRIPTION
## Summary
- only flag type changes when original work type is task, story, or bug and type has changed

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_6895e22ae2448325a556807722d61c1b