### PR TITLE
Fix pulled-in issue point calculations

### DIFF
--- a/src/disruption.js
+++ b/src/disruption.js
@@ -42,7 +42,8 @@
     });
 
     uniq.forEach(ev => {
-      const pts = ev.completed ? (ev.points || 0) : 0;
+      const pts = ev.points || 0;
+      const completedPts = ev.completed ? pts : 0;
       logger.debug('Processing event', ev);
 
       if (ev.addedAfterStart) {
@@ -51,17 +52,17 @@
       }
 
       if (ev.blocked) {
-        metrics.blocked += pts;
+        metrics.blocked += completedPts;
         metrics.blockedIssues.add(ev.key);
       }
 
       if (ev.typeChanged) {
-        metrics.typeChanged += pts;
+        metrics.typeChanged += completedPts;
         metrics.typeChangedIssues.add(ev.key);
       }
 
       if (ev.movedOut) {
-        metrics.movedOut += pts;
+        metrics.movedOut += completedPts;
         metrics.movedOutIssues.add(ev.key);
       }
     });


### PR DESCRIPTION
## Summary
- ensure `calculateDisruptionMetrics` counts points for issues added after sprint start even if not completed

## Testing
- `node -e "const d=require('./src/disruption');console.log(d.calculateDisruptionMetrics([{key:'A',points:5,addedAfterStart:true,completed:false},{key:'B',points:3,addedAfterStart:true,completed:true},{key:'C',points:2,blocked:true,completed:true}]));"`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895f52df7f88325a862aa6da493ec36