### PR TITLE
Improve rating zone clarity on disruption chart

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -22,6 +22,9 @@
     .story-table th { background:#e0e7ef; }
     .chart-section { margin-top: 30px; }
     .chart-section canvas { max-width: 100%; margin-top: 20px; }
+    .rating-zone-description { margin-top: 10px; font-size: 0.9em; }
+    .rating-zone-description div { margin-top: 4px; }
+    .rating-zone-description span { display:inline-block; width:12px; height:12px; margin-right:6px; vertical-align:middle; }
   </style>
 </head>
 <body>
@@ -65,6 +68,14 @@
   <div id="velocityStats"></div>
   <div id="chartSection" class="chart-section">
     <canvas id="disruptionChart"></canvas>
+    <div class="rating-zone-description">
+      <div><span style="background:rgba(254,202,202,0.4);"></span>Alarming: 0…AV-2SD</div>
+      <div><span style="background:rgba(254,249,195,0.4);"></span>Concerning: AV-2SD…AV-1SD</div>
+      <div><span style="background:rgba(209,250,229,0.4);"></span>Healthy: AV-1SD…AV</div>
+      <div><span style="background:rgba(110,231,183,0.4);"></span>Spot-on: AV…AV+1SD</div>
+      <div><span style="background:rgba(209,250,229,0.4);"></span>Lively: AV+1SD…AV+2SD</div>
+      <div><span style="background:rgba(254,249,195,0.4);"></span>Bloated: AV+2SD…∞</div>
+    </div>
   </div>
 </div>
 <script src="src/logger.js"></script>
@@ -329,17 +340,17 @@ function renderCharts(sprints) {
     const max = Math.max(...prev, avg + 2 * sd);
     return [
       // Alarming 0…AV-2SD
-      { yMin: 0, yMax: Math.max(avg - 2 * sd, 0), color: 'rgba(254,202,202,0.3)' },
+      { yMin: 0, yMax: Math.max(avg - 2 * sd, 0), color: 'rgba(254,202,202,0.4)' },
       // Concerning AV-2SD…-1SD
-      { yMin: Math.max(avg - 2 * sd, 0), yMax: avg - sd, color: 'rgba(254,249,195,0.3)' },
+      { yMin: Math.max(avg - 2 * sd, 0), yMax: avg - sd, color: 'rgba(254,249,195,0.4)' },
       // Healthy AV-1SD…AV
-      { yMin: avg - sd, yMax: avg, color: 'rgba(209,250,229,0.3)' },
+      { yMin: avg - sd, yMax: avg, color: 'rgba(209,250,229,0.4)' },
       // Spot-on AV…AV+1SD
-      { yMin: avg, yMax: avg + sd, color: 'rgba(110,231,183,0.3)' },
+      { yMin: avg, yMax: avg + sd, color: 'rgba(110,231,183,0.4)' },
       // Lively AV+1SD…+2SD
-      { yMin: avg + sd, yMax: avg + 2 * sd, color: 'rgba(209,250,229,0.3)' },
+      { yMin: avg + sd, yMax: avg + 2 * sd, color: 'rgba(209,250,229,0.4)' },
       // Bloated AV+2SD…∞
-      { yMin: avg + 2 * sd, yMax: max, color: 'rgba(254,249,195,0.3)' }
+      { yMin: avg + 2 * sd, yMax: max, color: 'rgba(254,249,195,0.4)' }
     ];
   });
   const zoneMaxes = zonesBySprint.filter(zs => zs).map(zs => zs[zs.length - 1].yMax);


### PR DESCRIPTION
## Summary
- Increase rating zone fill opacity for better visibility
- Add textual legend describing each rating zone beneath the disruption chart

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895f81ef1588325abc0ec2f29f4c038