### PR TITLE
Track blocked days instead of issue counts

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -57,7 +57,7 @@
         <th>Completed</th>
         <th>Other</th>
         <th>Pulled In</th>
-        <th>Blocked</th>
+        <th>Blocked Days</th>
         <th>Type Changed</th>
         <th>Moved Out</th>
         <th>Details</th>
@@ -221,6 +221,33 @@
                     issueCache.set(ev.key, { histories, initialType, currentType });
                   }
 
+                  // calculate total days flagged within the sprint
+                  const sortedHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
+                  let blockStart = null;
+                  const blockedPeriods = [];
+                  for (const h of sortedHist) {
+                    const item = (h.items || []).find(i => i.field === 'Flagged');
+                    if (!item) continue;
+                    const date = new Date(h.created);
+                    const added = !item.from && item.to;
+                    const removed = item.from && !item.to;
+                    if (added && !blockStart) blockStart = date;
+                    if (removed && blockStart) {
+                      blockedPeriods.push([blockStart, date]);
+                      blockStart = null;
+                    }
+                  }
+                  if (blockStart) blockedPeriods.push([blockStart, sprintEnd || new Date()]);
+                  if (!blockedPeriods.length && ev.blocked) {
+                    blockedPeriods.push([sprintStart, sprintEnd || new Date()]);
+                  }
+                  const msPerDay = 24 * 60 * 60 * 1000;
+                  ev.blockedDays = blockedPeriods.reduce((sum, [start, end]) => {
+                    const sClamped = sprintStart && start < sprintStart ? sprintStart : start;
+                    const eClamped = sprintEnd && end > sprintEnd ? sprintEnd : end;
+                    return eClamped > sClamped ? sum + (eClamped - sClamped) / msPerDay : sum;
+                  }, 0);
+
                   const allowedTypes = new Set(['task', 'story', 'bug']);
                   let typeChangedDuringSprint = false;
                   for (const h of histories) {
@@ -297,7 +324,7 @@
         <td title="${sprint.completedSource}">${sprint.completed || 0}</td>
         <td title="completed minus initially planned">${sprint.other || 0}</td>
         <td title="${metrics.pulledInIssues.join(', ')}">${metrics.pulledIn || 0} (${metrics.pulledInCount || 0})</td>
-        <td title="${metrics.blockedIssues.join(', ')}">${metrics.blocked || 0} (${metrics.blockedCount || 0})</td>
+        <td title="${metrics.blockedIssues.join(', ')}">${Number(metrics.blockedDays || 0).toFixed(1)} (${metrics.blockedCount || 0})</td>
         <td title="${metrics.typeChangedIssues.join(', ')}">${metrics.typeChanged || 0} (${metrics.typeChangedCount || 0})</td>
         <td title="${metrics.movedOutIssues.join(', ')}">${metrics.movedOut || 0} (${metrics.movedOutCount || 0})</td>
         <td><button class="btn details-toggle" onclick="toggleDetails('${detailsId}', this)">Show Details</button></td>
@@ -337,7 +364,7 @@ function renderCharts(sprints) {
   const completedSP = sprints.map(s => s.completed || 0);
   const metricsArr = sprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
   const pulledInCount = metricsArr.map(m => m.pulledInCount || 0);
-  const blockedCount = metricsArr.map(m => m.blockedCount || 0);
+  const blockedDays = metricsArr.map(m => m.blockedDays || 0);
   const typeChangedCount = metricsArr.map(m => m.typeChangedCount || 0);
   const movedOutCount = metricsArr.map(m => m.movedOutCount || 0);
 
@@ -393,7 +420,7 @@ function renderCharts(sprints) {
       datasets: [
         { label: 'Completed SP', data: completedSP, borderColor: '#6366f1', backgroundColor: 'rgba(99,102,241,0.3)', fill: false, tension: 0.1, yAxisID: 'y' },
         { label: 'Pulled In Issues', data: pulledInCount, borderColor: '#3b82f6', backgroundColor: '#3b82f6', fill: false, yAxisID: 'y1' },
-        { label: 'Blocked Issues', data: blockedCount, borderColor: '#ef4444', backgroundColor: '#ef4444', fill: false, yAxisID: 'y1' },
+        { label: 'Blocked Days', data: blockedDays, borderColor: '#ef4444', backgroundColor: '#ef4444', fill: false, yAxisID: 'y1' },
         { label: 'Type Changed Issues', data: typeChangedCount, borderColor: '#f59e0b', backgroundColor: '#f59e0b', fill: false, yAxisID: 'y1' },
         { label: 'Moved Out Issues', data: movedOutCount, borderColor: '#10b981', backgroundColor: '#10b981', fill: false, yAxisID: 'y1' }
       ]
@@ -401,7 +428,7 @@ function renderCharts(sprints) {
     options: {
       scales: {
         y: { beginAtZero: true, suggestedMax: maxY, title: { display: true, text: 'Completed Story Points' } },
-        y1: { beginAtZero: true, position: 'right', title: { display: true, text: 'Issue Count' }, grid: { drawOnChartArea: false } }
+          y1: { beginAtZero: true, position: 'right', title: { display: true, text: 'Issue Count / Blocked Days' }, grid: { drawOnChartArea: false } }
       },
       plugins: { legend: { position: 'bottom' }, ratingZones: { zonesBySprint } }
     },

--- a/src/disruption.js
+++ b/src/disruption.js
@@ -20,7 +20,7 @@
 
     const metrics = {
       pulledIn: 0,
-      blocked: 0,
+      blockedDays: 0,
       typeChanged: 0,
       movedOut: 0,
       pulledInIssues: new Set(),
@@ -51,8 +51,8 @@
         metrics.pulledInIssues.add(ev.key);
       }
 
-      if (ev.blocked) {
-        metrics.blocked += completedPts;
+      if (ev.blockedDays && ev.blockedDays > 0) {
+        metrics.blockedDays += ev.blockedDays;
         metrics.blockedIssues.add(ev.key);
       }
 


### PR DESCRIPTION
## Summary
- Aggregate total days issues were flagged during a sprint
- Display blocked days in disruption table and chart
- Clarify chart axis to cover counts and blocked days

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896055c6de08325870b910b19252ccf