### PR TITLE
Define blockedCount to fix ReferenceError in disruption chart

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -366,6 +366,7 @@ function renderCharts(sprints) {
   const metricsArr = sprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
   const pulledInCount = metricsArr.map(m => m.pulledInCount || 0);
   const blockedDays = metricsArr.map(m => m.blockedDays || 0);
+  const blockedCount = metricsArr.map(m => m.blockedCount || 0);
   const typeChangedCount = metricsArr.map(m => m.typeChangedCount || 0);
   const movedOutCount = metricsArr.map(m => m.movedOutCount || 0);
 


### PR DESCRIPTION
## Summary
- define `blockedCount` in `renderCharts` to prevent ReferenceError when rendering disruption chart

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68960b3b14ec8325920bb5a553934229