### PR TITLE
Use workday durations for blocked time calculation

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -242,11 +242,12 @@
                   if (!blockedPeriods.length && ev.blocked) {
                     blockedPeriods.push([sprintStart, sprintEnd || new Date()]);
                   }
-                  const msPerDay = 24 * 60 * 60 * 1000;
                   ev.blockedDays = blockedPeriods.reduce((sum, [start, end]) => {
                     const sClamped = sprintStart && start < sprintStart ? sprintStart : start;
                     const eClamped = sprintEnd && end > sprintEnd ? sprintEnd : end;
-                    return eClamped > sClamped ? sum + (eClamped - sClamped) / msPerDay : sum;
+                    return eClamped > sClamped
+                      ? sum + Kpis.calculateWorkDays(sClamped, eClamped)
+                      : sum;
                   }, 0);
 
                   const allowedTypes = new Set(['task', 'story', 'bug']);

--- a/src/kpis.js
+++ b/src/kpis.js
@@ -20,5 +20,26 @@
     return Math.sqrt(variance);
   }
 
-  return { calculateVelocity, calculateStdDev };
+  function calculateWorkDays(start, end) {
+    if (!start || !end) return 0;
+    const s = new Date(start);
+    const e = new Date(end);
+    if (isNaN(s) || isNaN(e) || e <= s) return 0;
+    const msPerDay = 24 * 60 * 60 * 1000;
+    let total = 0;
+    let cur = s;
+    while (cur < e) {
+      const next = new Date(cur);
+      next.setHours(24, 0, 0, 0);
+      const dayEnd = next < e ? next : e;
+      const day = cur.getDay();
+      if (day !== 0 && day !== 6) {
+        total += (dayEnd - cur) / msPerDay;
+      }
+      cur = next;
+    }
+    return total;
+  }
+
+  return { calculateVelocity, calculateStdDev, calculateWorkDays };
 }));


### PR DESCRIPTION
## Summary
- add `calculateWorkDays` utility to compute number of workdays between two dates
- use new workday calculation in disruption report when summarizing blocked periods

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68961035c194832584cbee1c56316e66