### PR TITLE
fix: show weeks needed for weekly throughput

### DIFF
--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -866,7 +866,7 @@ function addTooltipListeners() {
               </div>
               <div>
                 <table class="prob-table">
-                  <tr><th>Confidence</th><th>Sprints Needed</th></tr>
+                  <tr><th>Confidence</th><th>Weeks Needed</th></tr>
                   ${probRows.map(r=>`<tr><td>${r[0]}%</td><td>${r[1]}</td></tr>`).join('')}
                 </table>
               </div>


### PR DESCRIPTION
## Summary
- label weekly throughput results as weeks instead of sprints

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899a0c12c108325801ad09ebf4e50cc