### PR TITLE
Add new Jira board IDs

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -22,7 +22,7 @@
     // querying every board in the instance which previously resulted in
     // numerous 404 errors. Additional board IDs can be added to this
     // list as needed.
-    const boardIds = [2796, 2526, 6346, 4133, 4132, 4131, 6347, 6390];
+    const boardIds = [2796, 2526, 6346, 4133, 4132, 4131, 6347, 6390, 4894];
     const results = [];
 
     // Accept boards whose project keys match any of these values.


### PR DESCRIPTION
## Summary
- include boards 4133, 4132, 4131, 6347 and 6390 in Jira board lookup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899b4fb70fc8325b0bf9027f3854354