### PR TITLE
fix: limit sprint removal to disruption report

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -48,6 +48,12 @@
     <button class="btn" onclick="loadDisruption()">Load Data</button>
     <button class="btn" onclick="exportPDF()">Download PDF</button>
   </div>
+  <div id="sprintRow" style="margin-top:10px; display:none;">
+    <label>Sprint:
+      <select id="sprintSelect"></select>
+    </label>
+    <button class="btn" onclick="removeSelectedSprint()">Remove Sprint</button>
+  </div>
   <div id="logPanel" style="display:none; white-space:pre-wrap; font-size:0.85em; background:#f3f4f6; border:1px solid #e5e7eb; padding:6px; margin:10px 0; max-height:150px; overflow:auto;"></div>
   <table>
     <thead>
@@ -105,6 +111,7 @@
   // an error about reusing a canvas that is already in use.
   let completedChartInstance;
   let disruptionChartInstance;
+  let sprints = [];
   let removedSprintIds = [];
 
   function filterRecentSprints(allSprints, excludeIds = [], desiredCount = 6) {
@@ -120,6 +127,31 @@
       if (result.length >= desiredCount) break;
     }
     return result;
+  }
+
+  function populateSprintDropdown() {
+    const sel = document.getElementById('sprintSelect');
+    if (!sel) return;
+    sel.innerHTML = '';
+    sprints.forEach(s => {
+      const opt = document.createElement('option');
+      opt.value = s.id;
+      opt.textContent = s.name;
+      sel.appendChild(opt);
+    });
+  }
+
+  function removeSelectedSprint() {
+    const sel = document.getElementById('sprintSelect');
+    const sid = sel ? sel.value : '';
+    if (!sid) {
+      alert('Select a sprint to remove.');
+      return;
+    }
+    if (!removedSprintIds.includes(String(sid))) {
+      removedSprintIds.push(String(sid));
+    }
+    loadDisruption();
   }
 
   async function populateBoards() {
@@ -542,8 +574,11 @@ function renderCharts(sprints) {
       return;
     }
     Logger.info('Loading disruption report for boards', boards.join(','));
-    const { sprints, teamVelocity } = await fetchDisruptionData(jiraDomain, boards);
+    const { sprints: fetchedSprints, teamVelocity } = await fetchDisruptionData(jiraDomain, boards);
+    sprints = fetchedSprints;
     renderTable(sprints);
+    populateSprintDropdown();
+    document.getElementById('sprintRow').style.display = sprints.length ? '' : 'none';
     const boardNames = {};
     selected.forEach(b => { boardNames[b.value] = b.label; });
     renderVelocityStats(boardNames, teamVelocity);


### PR DESCRIPTION
## Summary
- remove sprint exclusion controls from velocity and throughput reports
- add sprint dropdown and removal logic to disruption report

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899d8e91f24832586f48d1179ec28dd