### PR TITLE
Ignore sprints from other boards in disruption report

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -180,7 +180,9 @@
             Logger.warn('Velocity report unavailable, falling back to sprint list', resp.status);
           }
 
-          let closed = (data.sprints || []).filter(s => s.state === 'CLOSED' && s.startDate);
+          let closed = (data.sprints || []).filter(
+            s => s.state === 'CLOSED' && s.startDate && String(s.originBoardId) === String(boardNum)
+          );
 
           if (!closed.length) {
             let allSprints = [];
@@ -201,7 +203,9 @@
               loops++;
               if (sData.isLast || values.length < maxResults || loops > 100) break;
             }
-            closed = allSprints.filter(s => (s.state || '').toUpperCase() === 'CLOSED' && s.startDate);
+            closed = allSprints.filter(
+              s => (s.state || '').toUpperCase() === 'CLOSED' && s.startDate && String(s.originBoardId) === String(boardNum)
+            );
           }
 
           closed = filterRecentSprints(closed, removedSprintIds, 6);


### PR DESCRIPTION
## Summary
- Ignore closed sprints whose `originBoardId` differs from the selected board so cross-team sprints are not processed

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check src/disruption.js`


------
https://chatgpt.com/codex/tasks/task_e_6899ed98407c83258c5ecfb19c4c0a4b