### PR TITLE
Add weekly cycle time and throughput chart to disruption report

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -83,6 +83,7 @@
       <div><span style="background:rgba(254,249,195,0.5);"></span>Bloated: AV+2SD…∞</div>
     </div>
     <canvas id="disruptionChart"></canvas>
+    <canvas id="cycleChart"></canvas>
   </div>
 </div>
 <script src="src/logger.js"></script>
@@ -111,10 +112,20 @@
   // an error about reusing a canvas that is already in use.
   let completedChartInstance;
   let disruptionChartInstance;
+  let cycleChartInstance;
   let sprints = [];
   let removedSprintIds = [];
   let teamVelocityData = {};
   let boardNamesData = {};
+
+  function isoWeekNumber(dt) {
+    const d = new Date(Date.UTC(dt.getFullYear(), dt.getMonth(), dt.getDate()));
+    const day = d.getUTCDay() || 7;
+    d.setUTCDate(d.getUTCDate() + 4 - day);
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    const week = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+    return `${d.getUTCFullYear()}-W${String(week).padStart(2,'0')}`;
+  }
 
   function filterRecentSprints(allSprints, excludeIds = [], desiredCount = 6) {
     const excluded = new Set((excludeIds || []).map(String));
@@ -246,17 +257,19 @@
               await Promise.all(events.map(async ev => {
                 try {
                   let cached = issueCache.get(ev.key);
-                  let histories, initialType, currentType, currentStatus;
+                  let histories, initialType, currentType, currentStatus, created, resolutionDate;
                   if (cached) {
-                    ({ histories, initialType, currentType, currentStatus } = cached);
+                    ({ histories, initialType, currentType, currentStatus, created, resolutionDate } = cached);
                   } else {
-                    const u = `https://${jiraDomain}/rest/api/3/issue/${ev.key}?expand=changelog&fields=issuetype,flagged,status`;
+                    const u = `https://${jiraDomain}/rest/api/3/issue/${ev.key}?expand=changelog&fields=issuetype,flagged,status,created,resolutiondate`;
                     const ir = await fetch(u, { credentials: 'include' });
                     if (!ir.ok) return;
                     const id = await ir.json();
                     histories = id.changelog?.histories || [];
                     currentType = id.fields?.issuetype?.name || '';
                     currentStatus = id.fields?.status?.name || '';
+                    created = id.fields?.created;
+                    resolutionDate = id.fields?.resolutiondate;
                     ev.blocked = ev.blocked || !!(id.fields?.flagged && id.fields.flagged.length);
                     ev.blocked = ev.blocked || currentStatus.toLowerCase().includes('block');
                     const sorted = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
@@ -268,7 +281,7 @@
                         break;
                       }
                     }
-                    issueCache.set(ev.key, { histories, initialType, currentType, currentStatus });
+                    issueCache.set(ev.key, { histories, initialType, currentType, currentStatus, created, resolutionDate });
                   }
 
                   const isBlockedStatus = name => (name || '').toLowerCase().includes('block');
@@ -323,6 +336,10 @@
                       : sum;
                   }, 0);
                   ev.blocked = ev.blocked || blockedPeriods.length > 0;
+                  ev.completedDate = resolutionDate;
+                  if (created && resolutionDate) {
+                    ev.cycleTime = Kpis.calculateWorkDays(new Date(created), new Date(resolutionDate));
+                  }
 
                   const allowedTypes = new Set(['task', 'story', 'bug']);
                   let typeChangedDuringSprint = false;
@@ -448,12 +465,35 @@ function renderCharts(sprints) {
   const typeChangedCount = metricsArr.map(m => m.typeChangedCount || 0);
   const movedOutCount = metricsArr.map(m => m.movedOutCount || 0);
 
+  const weekMap = {};
+  sprints.forEach(s => {
+    (s.events || []).forEach(ev => {
+      if (!ev.completedDate) return;
+      const d = new Date(ev.completedDate);
+      if (isNaN(d)) return;
+      const wk = isoWeekNumber(d);
+      if (!weekMap[wk]) weekMap[wk] = { cycles: [], count: 0 };
+      if (typeof ev.cycleTime === 'number') weekMap[wk].cycles.push(ev.cycleTime);
+      weekMap[wk].count++;
+    });
+  });
+  const weekLabels = Object.keys(weekMap).sort();
+  const avgCycleTime = weekLabels.map(w => {
+    const arr = weekMap[w].cycles;
+    return arr.length ? arr.reduce((a,b)=>a+b,0)/arr.length : 0;
+  });
+  const throughputPerWeek = weekLabels.map(w => weekMap[w].count);
+
   const chartWidth = Math.max(sprintLabels.length * 120, 600);
   ['completedChart','disruptionChart'].forEach(id => {
     const canvas = document.getElementById(id);
     canvas.width = chartWidth;
     canvas.height = 300;
   });
+  const cycleCanvas = document.getElementById('cycleChart');
+  const weekChartWidth = Math.max(weekLabels.length * 100, 600);
+  cycleCanvas.width = weekChartWidth;
+  cycleCanvas.height = 300;
 
   const zonesBySprint = [];
   const avgBySprint = [];
@@ -503,6 +543,9 @@ function renderCharts(sprints) {
   if (disruptionChartInstance) {
     disruptionChartInstance.destroy();
   }
+  if (cycleChartInstance) {
+    cycleChartInstance.destroy();
+  }
 
   const vctx = document.getElementById('completedChart').getContext('2d');
   completedChartInstance = new Chart(vctx, {
@@ -546,6 +589,27 @@ function renderCharts(sprints) {
       maintainAspectRatio: false,
       scales: {
         y: { beginAtZero: true, title: { display: true, text: 'Issue Count / Blocked Days' } }
+      },
+      plugins: { legend: { position: 'bottom' } }
+    }
+  });
+
+  const cctx = document.getElementById('cycleChart').getContext('2d');
+  cycleChartInstance = new Chart(cctx, {
+    type: 'line',
+    data: {
+      labels: weekLabels,
+      datasets: [
+        { label: 'Mean Cycle Time (days)', data: avgCycleTime, borderColor: '#8b5cf6', backgroundColor: 'rgba(139,92,246,0.3)', yAxisID: 'y1', fill: false, tension: 0.1 },
+        { label: 'Throughput per Week', data: throughputPerWeek, borderColor: '#f97316', backgroundColor: 'rgba(249,115,22,0.3)', yAxisID: 'y2', fill: false, tension: 0.1 }
+      ]
+    },
+    options: {
+      responsive: false,
+      maintainAspectRatio: false,
+      scales: {
+        y1: { type: 'linear', position: 'left', beginAtZero: true, title: { display: true, text: 'Cycle Time (days)' } },
+        y2: { type: 'linear', position: 'right', beginAtZero: true, title: { display: true, text: 'Throughput' }, grid: { drawOnChartArea: false } }
       },
       plugins: { legend: { position: 'bottom' } }
     }


### PR DESCRIPTION
## Summary
- extend Disruption report with a new chart visualizing mean cycle time and throughput per week
- compute cycle time from issue creation to resolution and aggregate weekly throughput

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899edc9502c8325a591c60dbc70e793