### PR TITLE
chore: remove sprint removal feature

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -26,7 +26,6 @@
     .rating-zone-description div { margin-top: 4px; }
     .rating-zone-description span { display:inline-block; width:12px; height:12px; margin-right:6px; vertical-align:middle; }
     .sprint-item { background:#e5e7eb; border-radius:4px; padding:2px 6px; margin-right:6px; display:inline-block; }
-    .sprint-item .remove { cursor:pointer; color:#e11d48; margin-left:4px; }
   </style>
 </head>
 <body>
@@ -114,7 +113,6 @@
   let disruptionChartInstance;
   let cycleChartInstance;
   let sprints = [];
-  let removedSprintIds = [];
   let teamVelocityData = {};
   let boardNamesData = {};
 
@@ -127,37 +125,21 @@
     return `${d.getUTCFullYear()}-W${String(week).padStart(2,'0')}`;
   }
 
-  function filterRecentSprints(allSprints, excludeIds = [], desiredCount = 6) {
-    const excluded = new Set((excludeIds || []).map(String));
+  function filterRecentSprints(allSprints, desiredCount = 6) {
     const sorted = allSprints.slice().sort((a, b) => {
       const ad = a.endDate || a.completeDate || a.startDate || '';
       const bd = b.endDate || b.completeDate || b.startDate || '';
       return ad && bd ? new Date(bd) - new Date(ad) : 0;
     });
-    const result = [];
-    for (const s of sorted) {
-      if (!excluded.has(String(s.id))) result.push(s);
-      if (result.length >= desiredCount) break;
-    }
-    return result;
+    return sorted.slice(0, desiredCount);
   }
 
   function renderSprintList() {
     const wrap = document.getElementById('sprintList');
     if (!wrap) return;
     wrap.innerHTML = sprints.map(s =>
-      `<span class="sprint-item">${s.name}<span class="remove" onclick="removeSprint('${s.id}')">&times;</span></span>`
+      `<span class="sprint-item">${s.name}</span>`
     ).join('');
-  }
-
-  function removeSprint(id) {
-    const sid = String(id);
-    if (!removedSprintIds.includes(sid)) removedSprintIds.push(sid);
-    sprints = sprints.filter(s => String(s.id) !== sid);
-    renderTable(sprints);
-    renderSprintList();
-    renderCharts(sprints);
-    renderVelocityStats(boardNamesData, teamVelocityData);
   }
 
   async function populateBoards() {
@@ -219,7 +201,7 @@
             );
           }
 
-          closed = filterRecentSprints(closed, removedSprintIds, 6);
+          closed = filterRecentSprints(closed, 6);
           teamVelocity[boardNum] = new Array(closed.length).fill(0);
 
           await Promise.all(closed.map(async (s, idx) => {


### PR DESCRIPTION
## Summary
- drop UI and code for manually removing sprints from Disruption KPI report
- simplify sprint filtering to only sort and limit recent sprints

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899f0f245a48325bf462dcd49ff319c