### PR TITLE
Fix filterRecentSprints usage causing fetch disruption data error

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -195,7 +195,7 @@
             );
           }
 
-          closed = filterRecentSprints(closed, 6);
+          closed = filterRecentSprints(closed, [], 6);
           teamVelocity[boardNum] = new Array(closed.length).fill(0);
 
           await Promise.all(closed.map(async (s, idx) => {


### PR DESCRIPTION
## Summary
- pass an empty exclude list when calling `filterRecentSprints` so desired sprint count is a separate argument

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899f5b337308325a39c2bde2b5f1d6f