### PR TITLE
Account for all moved-out stories in disruption metrics

### DIFF
--- a/src/disruption.js
+++ b/src/disruption.js
@@ -74,7 +74,7 @@
       }
 
       if (ev.movedOut) {
-        metrics.movedOut += completedPts;
+        metrics.movedOut += pts;
         metrics.movedOutIssues.add(ev.key);
       }
     });

--- a/test/disruption.test.js
+++ b/test/disruption.test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const { calculateDisruptionMetrics } = require('../src/disruption');
+
+// Test movedOut issues are counted regardless of completion status
+(() => {
+  const events = [
+    { key: 'ST-1', points: 5, completed: false, movedOut: true },
+    { key: 'ST-2', points: 3, completed: true, movedOut: true }
+  ];
+  const metrics = calculateDisruptionMetrics(events);
+  assert.strictEqual(metrics.movedOut, 8);
+  assert.strictEqual(metrics.movedOutCount, 2);
+  assert.deepStrictEqual(metrics.movedOutIssues.sort(), ['ST-1', 'ST-2']);
+})();
+
+console.log('disruption tests passed');


### PR DESCRIPTION
## Summary
- count story points for moved-out issues regardless of completion
- add a unit test covering moved-out issue handling

## Testing
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ae4eaf06c832590de3f08a665372d