### PR TITLE
Clarify cycle chart label in disruption report

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -287,6 +287,7 @@
                   let blockStart = curBlocked ? sprintStart : null;
                   const blockedPeriods = [];
                   const sortedHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
+                  let devStart = null;
                   for (const h of sortedHist) {
                     const date = new Date(h.created);
                     if (sprintStart && date < sprintStart) continue;
@@ -294,6 +295,7 @@
                     const stItem = (h.items || []).find(i => i.field === 'status');
                     if (!stItem) continue;
                     const toStatus = stItem.toString || stItem.to || '';
+                    if (!devStart && toStatus.toLowerCase() === 'in development') devStart = date;
                     const toBlocked = isBlockedStatus(toStatus);
                     if (curBlocked && !toBlocked) {
                       blockedPeriods.push([blockStart, date]);
@@ -317,8 +319,8 @@
                   }, 0);
                   ev.blocked = ev.blocked || blockedPeriods.length > 0;
                   ev.completedDate = resolutionDate;
-                  if (created && resolutionDate) {
-                    ev.cycleTime = Kpis.calculateWorkDays(new Date(created), new Date(resolutionDate));
+                  if (devStart && resolutionDate) {
+                    ev.cycleTime = Kpis.calculateWorkDays(devStart, new Date(resolutionDate));
                   }
 
                   const allowedTypes = new Set(['task', 'story', 'bug']);
@@ -573,7 +575,7 @@ function renderCharts(sprints) {
       responsive: false,
       maintainAspectRatio: false,
       scales: {
-        y1: { type: 'linear', position: 'left', beginAtZero: true, title: { display: true, text: 'Cycle Time (days)' } },
+        y1: { type: 'linear', position: 'left', beginAtZero: true, title: { display: true, text: 'Mean Cycle Time (days)' } },
         y2: { type: 'linear', position: 'right', beginAtZero: true, title: { display: true, text: 'Throughput' }, grid: { drawOnChartArea: false } }
       },
       plugins: { legend: { position: 'bottom' } }


### PR DESCRIPTION
## Summary
- Rename cycle chart y-axis to "Mean Cycle Time (days)" for clearer terminology in disruption report.
- Compute cycle time from transition into "In Development" through completion rather than from issue creation.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ae424ae2c8325aa84a231867e8359