### PR TITLE
Adjust rating tone colors and zone coverage

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -77,9 +77,9 @@
     <div class="rating-zone-description">
       <div><span style="background:rgba(254,202,202,0.5);"></span>Alarming: 0…AV-2SD</div>
       <div><span style="background:rgba(254,249,195,0.5);"></span>Concerning: AV-2SD…AV-1SD</div>
-      <div><span style="background:rgba(209,250,229,0.8);"></span>Healthy: AV-1SD…AV</div>
-      <div><span style="background:rgba(110,231,183,0.5);"></span>Spot-on: AV…AV+1SD</div>
-      <div><span style="background:rgba(209,250,229,0.8);"></span>Lively: AV+1SD…AV+2SD</div>
+      <div><span style="background:rgba(34,197,94,0.5);"></span>Healthy: AV-1SD…AV</div>
+      <div><span style="background:rgba(21,128,61,0.5);"></span>Spot-on: AV…AV+1SD</div>
+      <div><span style="background:rgba(34,197,94,0.5);"></span>Lively: AV+1SD…AV+2SD</div>
       <div><span style="background:rgba(254,249,195,0.5);"></span>Bloated: AV+2SD…∞</div>
     </div>
     <canvas id="disruptionChart"></canvas>
@@ -472,14 +472,15 @@ function renderCharts(sprints) {
     zonesBySprint.push([
       { yMin: 0, yMax: Math.max(avg - 2 * sd, 0), color: 'rgba(254,202,202,0.5)' },
       { yMin: Math.max(avg - 2 * sd, 0), yMax: avg - sd, color: 'rgba(254,249,195,0.5)' },
-      { yMin: avg - sd, yMax: avg, color: 'rgba(209,250,229,0.8)' },
-      { yMin: avg, yMax: avg + sd, color: 'rgba(110,231,183,0.5)' },
-      { yMin: avg + sd, yMax: avg + 2 * sd, color: 'rgba(209,250,229,0.8)' },
+      { yMin: avg - sd, yMax: avg, color: 'rgba(34,197,94,0.5)' },
+      { yMin: avg, yMax: avg + sd, color: 'rgba(21,128,61,0.5)' },
+      { yMin: avg + sd, yMax: avg + 2 * sd, color: 'rgba(34,197,94,0.5)' },
       { yMin: avg + 2 * sd, yMax: max, color: 'rgba(254,249,195,0.5)' }
     ]);
   });
   const zoneMaxes = zonesBySprint.map(zs => zs[zs.length - 1].yMax);
   const maxY = Math.max(...completedSP, ...zoneMaxes, ...avgBySprint);
+  zonesBySprint.forEach(zs => { zs[zs.length - 1].yMax = maxY; });
 
   const ratingZonesPlugin = {
     id: 'ratingZones',


### PR DESCRIPTION
## Summary
- use green for Healthy and Lively rating zones and darker green for Spot-on
- ensure rating zone shading covers all sprints by normalizing zone upper bounds

## Testing
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689aee67198c8325afa8cce597456c9c