### PR TITLE
Fix rating zone chart boundaries

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -501,8 +501,10 @@ function renderCharts(displaySprints, allSprints) {
       ctx.save();
       opts.zonesBySprint.forEach((zs, i) => {
         if (!zs) return;
-        const xStart = Math.max(x.getPixelForValue(i - 0.5), left);
-        const xEnd = Math.min(x.getPixelForValue(i + 0.5), right);
+        const isFirst = i === 0;
+        const isLast = i === opts.zonesBySprint.length - 1;
+        const xStart = isFirst ? left : x.getPixelForValue(i - 0.5);
+        const xEnd = isLast ? right : x.getPixelForValue(i + 0.5);
         zs.forEach(z => {
           const yStart = y.getPixelForValue(z.yMax);
           const yEnd = y.getPixelForValue(z.yMin);


### PR DESCRIPTION
## Summary
- Prevent first and last sprints from being clipped in rating zone chart

## Testing
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689afb08c7c08325b864f377b653e8de