### PR TITLE
fix: equalize sprint widths in charts

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -543,9 +543,8 @@ function renderCharts(displaySprints, allSprints) {
       responsive: false,
       maintainAspectRatio: false,
       scales: {
-
+        x: { offset: true },
         y: { beginAtZero: true, suggestedMax: maxY, title: { display: true, text: 'Completed Story Points' } }
-
       },
       plugins: { legend: { position: 'bottom' }, ratingZones: { zonesBySprint } }
     },
@@ -568,6 +567,7 @@ function renderCharts(displaySprints, allSprints) {
       responsive: false,
       maintainAspectRatio: false,
       scales: {
+        x: { offset: true },
         y: { beginAtZero: true, title: { display: true, text: 'Issue Count / Blocked Days' } }
       },
       plugins: { legend: { position: 'bottom' } }
@@ -588,6 +588,7 @@ function renderCharts(displaySprints, allSprints) {
       responsive: false,
       maintainAspectRatio: false,
       scales: {
+        x: { offset: true },
         y1: { type: 'linear', position: 'left', beginAtZero: true, title: { display: true, text: 'Mean Cycle Time (days)' } },
         y2: { type: 'linear', position: 'right', beginAtZero: true, title: { display: true, text: 'Throughput' }, grid: { drawOnChartArea: false } }
       },


### PR DESCRIPTION
## Summary
- offset x-axes so first and last sprints render at full width
- apply the same offset to disruption and cycle charts for consistent spacing

## Testing
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689afdc0cf308325bdd11465b00929e1