### PR TITLE
Add toggle for rating zone description

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -75,13 +75,15 @@
   <div id="chartSection" class="chart-section">
     <canvas id="completedChart"></canvas>
     <div class="rating-zone-description">
-      <div><strong>Rating zones</strong></div>
-      <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Bloated: AV+2SD…∞.</strong> A significant share of this exceedingly high output probably comes from other effects than team performance alone. Analysis is advised because possibly there's something to be learned.</div>
-      <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Lively: AV+1SD…AV+2SD.</strong> The team's performance was outstanding, pushing the envelope on the brink of an unsustainable pace.</div>
-      <div><span style="background:rgba(21,128,61,0.5);"></span><strong>Spot-on: AV…AV+1SD.</strong> The team performed very well while also managing to increase the stability of their long-term output.</div>
-      <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Healthy: AV-1SD…AV.</strong> Things cannot always go up, so going down within the team's usual range of performance is perfectly normal.</div>
-      <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Concerning: AV-2SD…AV-1SD.</strong> Something went considerably wrong, but we're still seeing a robust core performance. Analysis is needed and also some learning that may result in adjustments.</div>
-      <div><span style="background:rgba(254,202,202,0.5);"></span><strong>Alarming: 0…AV-2SD.</strong> The major share of this plummeting output was probably caused by factors beyond the team‘s influence. Thorough analysis is needed which will lead to profound learning and change.</div>
+      <div id="ratingZoneToggle" style="cursor:pointer;"><strong>Rating zones (show)</strong></div>
+      <div id="ratingZoneDetails" style="display:none;">
+        <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Bloated: AV+2SD…∞.</strong> A significant share of this exceedingly high output probably comes from other effects than team performance alone. Analysis is advised because possibly there's something to be learned.</div>
+        <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Lively: AV+1SD…AV+2SD.</strong> The team's performance was outstanding, pushing the envelope on the brink of an unsustainable pace.</div>
+        <div><span style="background:rgba(21,128,61,0.5);"></span><strong>Spot-on: AV…AV+1SD.</strong> The team performed very well while also managing to increase the stability of their long-term output.</div>
+        <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Healthy: AV-1SD…AV.</strong> Things cannot always go up, so going down within the team's usual range of performance is perfectly normal.</div>
+        <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Concerning: AV-2SD…AV-1SD.</strong> Something went considerably wrong, but we're still seeing a robust core performance. Analysis is needed and also some learning that may result in adjustments.</div>
+        <div><span style="background:rgba(254,202,202,0.5);"></span><strong>Alarming: 0…AV-2SD.</strong> The major share of this plummeting output was probably caused by factors beyond the team‘s influence. Thorough analysis is needed which will lead to profound learning and change.</div>
+      </div>
     </div>
     <canvas id="disruptionChart"></canvas>
     <canvas id="cycleChart"></canvas>
@@ -105,6 +107,15 @@
 <script src="src/kpis.js"></script>
 <script>
   function switchVersion(v){ window.location.href = v; }
+  const ratingToggle = document.getElementById('ratingZoneToggle');
+  const ratingDetails = document.getElementById('ratingZoneDetails');
+  if (ratingToggle && ratingDetails) {
+    ratingToggle.addEventListener('click', () => {
+      const hidden = ratingDetails.style.display === 'none';
+      ratingDetails.style.display = hidden ? '' : 'none';
+      ratingToggle.innerHTML = `<strong>Rating zones (${hidden ? 'hide' : 'show'})</strong>`;
+    });
+  }
 
   const boardSelect = document.getElementById('boardNum');
   let boardChoices = new Choices(boardSelect, { removeItemButton: true });


### PR DESCRIPTION
## Summary
- collapse rating zone descriptions by default with a clickable header
- add client-side toggle to show or hide rating zone details on demand

## Testing
- `node test/disruption.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689b007e6cbc8325a9b493aef93b6c78