### PR TITLE
Fix pulled-in issue detection when type changes

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -360,12 +360,11 @@
                           const toType = item.toString || item.to;
                           if (fromType && toType && fromType !== toType) {
                             typeChangedDuringSprint = true;
-                            break;
                           }
                         }
                       }
                     }
-                    if (typeChangedDuringSprint) break;
+                    // Continue scanning in case sprint membership changes occur after a type change
                   }
 
                   if (typeChangedDuringSprint && allowedTypes.has((initialType || '').toLowerCase()) && currentType && currentType !== initialType) {


### PR DESCRIPTION
## Summary
- ensure sprint changes are still checked even when an issue's type changes

## Testing
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689b095411348325bdc55ee6edb5d866