### PR TITLE
Handle pulled-in issues created after sprint start

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -367,6 +367,14 @@
                     // Continue scanning in case sprint membership changes occur after a type change
                   }
 
+                  // Some issues may be created after the sprint starts and assigned
+                  // to the sprint during creation. These won't have an explicit
+                  // sprint change entry in the history, so detect this case using
+                  // the issue's creation date.
+                  if (!ev.addedAfterStart && sprintStart && created && new Date(created) > sprintStart) {
+                    ev.addedAfterStart = true;
+                  }
+
                   if (typeChangedDuringSprint && allowedTypes.has((initialType || '').toLowerCase()) && currentType && currentType !== initialType) {
                     ev.typeChanged = true;
                   }


### PR DESCRIPTION
## Summary
- flag issues created after a sprint starts as pulled-in even if no sprint change history exists

## Testing
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689b10a60f8c8325a514d8e12fdd419d