### PR TITLE
Limit Disruption PDF to table and charts

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -55,38 +55,40 @@
     <div id="sprintList" style="display:inline-block;"></div>
   </div>
   <div id="logPanel" style="display:none; white-space:pre-wrap; font-size:0.85em; background:#f3f4f6; border:1px solid #e5e7eb; padding:6px; margin:10px 0; max-height:150px; overflow:auto;"></div>
-  <table>
-    <thead>
-      <tr>
-        <th>Sprint</th>
-        <th>Initially Planned</th>
-        <th>Completed</th>
-        <th>Pulled In</th>
-        <th>Blocked Days</th>
-        <th>Type Changed</th>
-        <th>Moved Out</th>
-        <th>Details</th>
-      </tr>
-    </thead>
-    <tbody id="metricsBody"></tbody>
-  </table>
-  <div class="table-description"><strong>Legend:</strong> Initially Planned and Completed show story points. Pulled In, Type Changed, and Moved Out list story points with the number of affected issues in parentheses. Blocked Days lists days with the number of blocked issues in parentheses.</div>
-  <div id="velocityStats"></div>
-  <div id="chartSection" class="chart-section">
-    <canvas id="completedChart"></canvas>
-    <div class="rating-zone-description">
-      <div id="ratingZoneToggle" style="cursor:pointer;"><strong>Rating zones (show)</strong></div>
-      <div id="ratingZoneDetails" style="display:none;">
-        <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Bloated: AV+2SD…∞.</strong> A significant share of this exceedingly high output probably comes from other effects than team performance alone. Analysis is advised because possibly there's something to be learned.</div>
-        <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Lively: AV+1SD…AV+2SD.</strong> The team's performance was outstanding, pushing the envelope on the brink of an unsustainable pace.</div>
-        <div><span style="background:rgba(21,128,61,0.5);"></span><strong>Spot-on: AV…AV+1SD.</strong> The team performed very well while also managing to increase the stability of their long-term output.</div>
-        <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Healthy: AV-1SD…AV.</strong> Things cannot always go up, so going down within the team's usual range of performance is perfectly normal.</div>
-        <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Concerning: AV-2SD…AV-1SD.</strong> Something went considerably wrong, but we're still seeing a robust core performance. Analysis is needed and also some learning that may result in adjustments.</div>
-        <div><span style="background:rgba(254,202,202,0.5);"></span><strong>Alarming: 0…AV-2SD.</strong> The major share of this plummeting output was probably caused by factors beyond the team‘s influence. Thorough analysis is needed which will lead to profound learning and change.</div>
+  <div id="pdfContent">
+    <table>
+      <thead>
+        <tr>
+          <th>Sprint</th>
+          <th>Initially Planned</th>
+          <th>Completed</th>
+          <th>Pulled In</th>
+          <th>Blocked Days</th>
+          <th>Type Changed</th>
+          <th>Moved Out</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody id="metricsBody"></tbody>
+    </table>
+    <div class="table-description"><strong>Legend:</strong> Initially Planned and Completed show story points. Pulled In, Type Changed, and Moved Out list story points with the number of affected issues in parentheses. Blocked Days lists days with the number of blocked issues in parentheses.</div>
+    <div id="velocityStats"></div>
+    <div id="chartSection" class="chart-section">
+      <canvas id="completedChart"></canvas>
+      <div class="rating-zone-description">
+        <div id="ratingZoneToggle" style="cursor:pointer;"><strong>Rating zones (show)</strong></div>
+        <div id="ratingZoneDetails" style="display:none;">
+          <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Bloated: AV+2SD…∞.</strong> A significant share of this exceedingly high output probably comes from other effects than team performance alone. Analysis is advised because possibly there's something to be learned.</div>
+          <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Lively: AV+1SD…AV+2SD.</strong> The team's performance was outstanding, pushing the envelope on the brink of an unsustainable pace.</div>
+          <div><span style="background:rgba(21,128,61,0.5);"></span><strong>Spot-on: AV…AV+1SD.</strong> The team performed very well while also managing to increase the stability of their long-term output.</div>
+          <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Healthy: AV-1SD…AV.</strong> Things cannot always go up, so going down within the team's usual range of performance is perfectly normal.</div>
+          <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Concerning: AV-2SD…AV-1SD.</strong> Something went considerably wrong, but we're still seeing a robust core performance. Analysis is needed and also some learning that may result in adjustments.</div>
+          <div><span style="background:rgba(254,202,202,0.5);"></span><strong>Alarming: 0…AV-2SD.</strong> The major share of this plummeting output was probably caused by factors beyond the team‘s influence. Thorough analysis is needed which will lead to profound learning and change.</div>
+        </div>
       </div>
+      <canvas id="disruptionChart"></canvas>
+      <canvas id="cycleChart"></canvas>
     </div>
-    <canvas id="disruptionChart"></canvas>
-    <canvas id="cycleChart"></canvas>
   </div>
 </div>
 <script src="src/logger.js"></script>
@@ -651,12 +653,17 @@ function renderCharts(displaySprints, allSprints) {
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
-    const elem = document.querySelector('.main');
+    const elem = document.getElementById('pdfContent');
     html2canvas(elem).then(canvas => {
       const img = canvas.toDataURL('image/png');
-      const width = pdf.internal.pageSize.getWidth();
-      const height = canvas.height * width / canvas.width;
-      pdf.addImage(img, 'PNG', 0, 0, width, height);
+      const pageWidth = pdf.internal.pageSize.getWidth();
+      const pageHeight = pdf.internal.pageSize.getHeight();
+      const margin = 20;
+      const ratio = Math.min((pageWidth - margin * 2) / canvas.width, (pageHeight - margin * 2) / canvas.height);
+      const imgWidth = canvas.width * ratio;
+      const imgHeight = canvas.height * ratio;
+      const x = (pageWidth - imgWidth) / 2;
+      pdf.addImage(img, 'PNG', x, margin, imgWidth, imgHeight);
       pdf.save('Disruption_Report.pdf');
     });
   }


### PR DESCRIPTION
## Summary
- capture only the report table and charts for the disruption PDF
- scale PDF content to fit on a single A4 page

## Testing
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689b33e50e7883258916ae7c8509038d