### PR TITLE
Include pulled-in stories in disruption throughput

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -239,9 +239,45 @@
               collect(d.contents.issuesNotCompletedInCurrentSprint, false);
               collect(d.contents.puntedIssues, false);
 
+              let completed = 0;
+              let completedSource = '';
+              try {
+                const doneJql = encodeURIComponent(`sprint = ${s.id} AND statusCategory = Done`);
+                const searchUrl = `https://${jiraDomain}/rest/api/3/search?jql=${doneJql}&fields=key,customfield_10002&maxResults=1000`;
+                const sr = await fetch(searchUrl, { credentials: 'include' });
+                if (sr.ok) {
+                  const sd = await sr.json();
+                  const doneIssues = sd.issues || [];
+                  doneIssues.forEach(it => {
+                    const key = it.key;
+                    const pts = Number(it.fields?.customfield_10002) || 0;
+                    let existing = events.find(ev => ev.key === key);
+                    if (existing) {
+                      existing.points = existing.points || pts;
+                      existing.completed = true;
+                    } else {
+                      events.push({
+                        key,
+                        points: pts,
+                        addedAfterStart: false,
+                        blocked: false,
+                        movedOut: false,
+                        completed: true
+                      });
+                    }
+                  });
+                  completed = doneIssues.reduce((sum, it) => sum + (Number(it.fields?.customfield_10002) || 0), 0);
+                  completedSource = 'search API Done issues';
+                }
+              } catch (e) {
+                Logger.warn('Done issues search failed', e);
+              }
+
               const entry = data.velocityStatEntries?.[s.id] || {};
-              let completed = entry.completed?.value || 0;
-              let completedSource = 'velocityStatEntries.completed';
+              if (!completed) {
+                completed = entry.completed?.value || 0;
+                completedSource = 'velocityStatEntries.completed';
+              }
               if (!completed) {
                 completed = d.contents?.completedIssuesEstimateSum?.value || 0;
                 completedSource = 'completedIssuesEstimateSum';
@@ -259,7 +295,7 @@
                   if (cached) {
                     ({ histories, initialType, currentType, currentStatus, created, resolutionDate } = cached);
                   } else {
-                    const u = `https://${jiraDomain}/rest/api/3/issue/${ev.key}?expand=changelog&fields=issuetype,flagged,status,created,resolutiondate`;
+                    const u = `https://${jiraDomain}/rest/api/3/issue/${ev.key}?expand=changelog&fields=issuetype,flagged,status,created,resolutiondate,customfield_10002`;
                     const ir = await fetch(u, { credentials: 'include' });
                     if (!ir.ok) return;
                     const id = await ir.json();
@@ -270,6 +306,7 @@
                     resolutionDate = id.fields?.resolutiondate;
                     ev.blocked = ev.blocked || !!(id.fields?.flagged && id.fields.flagged.length);
                     ev.blocked = ev.blocked || currentStatus.toLowerCase().includes('block');
+                    ev.points = ev.points || Number(id.fields?.customfield_10002) || 0;
                     const sorted = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
                     initialType = currentType;
                     for (const h of sorted) {


### PR DESCRIPTION
## Summary
- query Jira for all Done issues in a sprint so disruption throughput counts pulled-in stories
- revert throughput page back to sprint report fetching

## Testing
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689c7597f0508325b7b5dcd652b9509c