### PR TITLE
Add PI vs non-PI chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ Available pages:
 - `index.html`: Velocity report.
 - `index_throughput.html`: Throughput report.
 - `index_throughput_week.html`: Weekly throughput report.
+- `index_disruption.html`: Disruption report including a PI vs non-PI chart.
 
 No automated tests are included.

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -9,6 +9,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
   <style>
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
@@ -74,6 +75,7 @@
     <div class="table-description"><strong>Legend:</strong> Initially Planned and Completed show story points. Pulled In, Type Changed, and Moved Out list story points with the number of affected issues in parentheses. Blocked Days lists days with the number of blocked issues in parentheses.</div>
     <div id="velocityStats"></div>
     <div id="chartSection" class="chart-section">
+      <canvas id="piPlanChart"></canvas>
       <div id="plannedInfo" style="font-size:0.9em; margin-bottom:10px;"></div>
       <canvas id="completedChart"></canvas>
       <div class="rating-zone-description">
@@ -692,6 +694,61 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   document.getElementById('versionSelect').value = 'index_disruption.html';
+</script>
+<script type="module">
+  import { renderPiPlanVsCompleteChart } from './src/piPlanVsCompleteChart.mjs';
+
+  const demoSprints = [
+    { id: 's1', name: 'Sprint 1/2', start: '2024-01-01', end: '2024-01-14' },
+    { id: 's2', name: 'Sprint 3/4', start: '2024-01-15', end: '2024-01-28' },
+    { id: 's3', name: 'Sprint 5/6', start: '2024-01-29', end: '2024-02-11' }
+  ];
+
+  const demoBuckets = [
+    { id: 'b1', labelTop: 'Sprint 1+2', labelBottom: 'PI 1', sprintIds: ['s1'] },
+    { id: 'b2', labelTop: 'Sprint 3+4', labelBottom: 'PI 1', sprintIds: ['s2'] },
+    { id: 'b3', labelTop: 'Sprint 5+6', labelBottom: 'PI 1', sprintIds: ['s3'] }
+  ];
+
+  const demoIssues = [
+    {
+      id: 'ISSUE-1',
+      team: 'PAY',
+      product: 'POS',
+      storyPoints: 3,
+      epicLabels: ['2024_PI1_committed'],
+      changelog: [
+        { field: 'Sprint', to: 's1', at: '2023-12-30T00:00:00Z' },
+        { field: 'Status', to: 'Done', at: '2024-01-10T00:00:00Z' }
+      ]
+    },
+    {
+      id: 'ISSUE-2',
+      team: 'PAY',
+      product: 'POS',
+      storyPoints: 5,
+      epicLabels: [],
+      changelog: [
+        { field: 'Sprint', to: 's1', at: '2023-12-29T00:00:00Z' },
+        { field: 'Sprint', from: 's1', to: 's2', at: '2024-01-16T00:00:00Z' },
+        { field: 'Status', to: 'Done', at: '2024-01-25T00:00:00Z' }
+      ]
+    }
+  ];
+
+  const canvas = document.getElementById('piPlanChart');
+  if (canvas) {
+    canvas.width = 600;
+    canvas.height = 300;
+  }
+  renderPiPlanVsCompleteChart({
+    canvasId: 'piPlanChart',
+    team: 'PAY',
+    product: 'POS',
+    sprints: demoSprints,
+    issues: demoIssues,
+    piBuckets: demoBuckets
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Chart.js DataLabels and add PI vs non-PI canvas to the disruption report
- render demo PI vs non-PI chart using sample sprint data
- document disruption report in README

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_689f202934308325913f1401c7365cbb