### PR TITLE
Add PI label relevance helper

### DIFF
--- a/src/piLabel.js
+++ b/src/piLabel.js
@@ -1,0 +1,7 @@
+function isPiRelevant(epicLabels = []) {
+  if (!Array.isArray(epicLabels) || epicLabels.length === 0) return false;
+  const regex = /^\d{4}_PI\d+_committed$/i;
+  return epicLabels.some(label => regex.test(label));
+}
+
+module.exports = { isPiRelevant };

--- a/test/piLabel.test.js
+++ b/test/piLabel.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { isPiRelevant } = require('../src/piLabel');
+
+(() => {
+  assert.strictEqual(isPiRelevant(['2025_PI3_committed']), true);
+  assert.strictEqual(isPiRelevant(['misc']), false);
+  assert.strictEqual(isPiRelevant(['2025_PI3_committed', 'other']), true);
+  assert.strictEqual(isPiRelevant([]), false);
+})();
+
+console.log('piLabel tests passed');


### PR DESCRIPTION
## Summary
- add helper to detect PI-committed epics by label pattern
- test PI label relevance logic

## Testing
- `node test/piLabel.test.js && node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f22554ba88325a930b571ae344f1f