### PR TITLE
Fetch data for disruption chart

### DIFF
--- a/disruption-data.json
+++ b/disruption-data.json
@@ -1,0 +1,40 @@
+{
+  "team": "PAY",
+  "product": "POS",
+  "sprints": [
+    { "id": "s1", "name": "Sprint 1/2", "start": "2024-01-01", "end": "2024-01-14" },
+    { "id": "s2", "name": "Sprint 3/4", "start": "2024-01-15", "end": "2024-01-28" },
+    { "id": "s3", "name": "Sprint 5/6", "start": "2024-01-29", "end": "2024-02-11" }
+  ],
+  "piBuckets": [
+    { "id": "b1", "labelTop": "Sprint 1+2", "labelBottom": "PI 1", "sprintIds": ["s1"] },
+    { "id": "b2", "labelTop": "Sprint 3+4", "labelBottom": "PI 1", "sprintIds": ["s2"] },
+    { "id": "b3", "labelTop": "Sprint 5+6", "labelBottom": "PI 1", "sprintIds": ["s3"] }
+  ],
+  "issues": [
+    {
+      "id": "ISSUE-1",
+      "team": "PAY",
+      "product": "POS",
+      "storyPoints": 3,
+      "epicLabels": ["2024_PI1_committed"],
+      "changelog": [
+        { "field": "Sprint", "to": "s1", "at": "2023-12-30T00:00:00Z" },
+        { "field": "Status", "to": "Done", "at": "2024-01-10T00:00:00Z" }
+      ]
+    },
+    {
+      "id": "ISSUE-2",
+      "team": "PAY",
+      "product": "POS",
+      "storyPoints": 5,
+      "epicLabels": [],
+      "changelog": [
+        { "field": "Sprint", "to": "s1", "at": "2023-12-29T00:00:00Z" },
+        { "field": "Sprint", "from": "s1", "to": "s2", "at": "2024-01-16T00:00:00Z" },
+        { "field": "Status", "to": "Done", "at": "2024-01-25T00:00:00Z" }
+      ]
+    }
+  ]
+}
+

--- a/disruption.html
+++ b/disruption.html
@@ -5,6 +5,7 @@
   <title>PI Plan vs Completed Demo</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
+  <script src="./src/piLabel.js"></script>
   <style>
     body { font-family: sans-serif; padding:20px; }
     canvas { max-width: 800px; }
@@ -16,52 +17,21 @@
   <script type="module">
     import { renderPiPlanVsCompleteChart } from './src/piPlanVsCompleteChart.mjs';
 
-    const sprints = [
-      { id: 's1', name: 'Sprint 1/2', start: '2024-01-01', end: '2024-01-14' },
-      { id: 's2', name: 'Sprint 3/4', start: '2024-01-15', end: '2024-01-28' },
-      { id: 's3', name: 'Sprint 5/6', start: '2024-01-29', end: '2024-02-11' }
-    ];
+    async function init() {
+      const resp = await fetch('./disruption-data.json');
+      const data = await resp.json();
+      renderPiPlanVsCompleteChart({
+        canvasId: 'pi-plan-vs-complete',
+        team: data.team,
+        product: data.product,
+        sprints: data.sprints,
+        issues: data.issues,
+        piBuckets: data.piBuckets,
+        piCheck: PiLabel.isPiRelevant
+      });
+    }
 
-    const piBuckets = [
-      { id: 'b1', labelTop: 'Sprint 1+2', labelBottom: 'PI 1', sprintIds: ['s1'] },
-      { id: 'b2', labelTop: 'Sprint 3+4', labelBottom: 'PI 1', sprintIds: ['s2'] },
-      { id: 'b3', labelTop: 'Sprint 5+6', labelBottom: 'PI 1', sprintIds: ['s3'] }
-    ];
-
-    const issues = [
-      {
-        id: 'ISSUE-1',
-        team: 'PAY',
-        product: 'POS',
-        storyPoints: 3,
-        epicLabels: ['2024_PI1_committed'],
-        changelog: [
-          { field: 'Sprint', to: 's1', at: '2023-12-30T00:00:00Z' },
-          { field: 'Status', to: 'Done', at: '2024-01-10T00:00:00Z' }
-        ]
-      },
-      {
-        id: 'ISSUE-2',
-        team: 'PAY',
-        product: 'POS',
-        storyPoints: 5,
-        epicLabels: [],
-        changelog: [
-          { field: 'Sprint', to: 's1', at: '2023-12-29T00:00:00Z' },
-          { field: 'Sprint', from: 's1', to: 's2', at: '2024-01-16T00:00:00Z' },
-          { field: 'Status', to: 'Done', at: '2024-01-25T00:00:00Z' }
-        ]
-      }
-    ];
-
-    renderPiPlanVsCompleteChart({
-      canvasId: 'pi-plan-vs-complete',
-      team: 'PAY',
-      product: 'POS',
-      sprints,
-      issues,
-      piBuckets
-    });
+    init();
   </script>
 </body>
 </html>

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -10,6 +10,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
+  <script src="./src/piLabel.js"></script>
   <style>
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
@@ -698,57 +699,28 @@ function renderCharts(displaySprints, allSprints) {
 <script type="module">
   import { renderPiPlanVsCompleteChart } from './src/piPlanVsCompleteChart.mjs';
 
-  const demoSprints = [
-    { id: 's1', name: 'Sprint 1/2', start: '2024-01-01', end: '2024-01-14' },
-    { id: 's2', name: 'Sprint 3/4', start: '2024-01-15', end: '2024-01-28' },
-    { id: 's3', name: 'Sprint 5/6', start: '2024-01-29', end: '2024-02-11' }
-  ];
+  async function init() {
+    const resp = await fetch('./disruption-data.json');
+    const data = await resp.json();
 
-  const demoBuckets = [
-    { id: 'b1', labelTop: 'Sprint 1+2', labelBottom: 'PI 1', sprintIds: ['s1'] },
-    { id: 'b2', labelTop: 'Sprint 3+4', labelBottom: 'PI 1', sprintIds: ['s2'] },
-    { id: 'b3', labelTop: 'Sprint 5+6', labelBottom: 'PI 1', sprintIds: ['s3'] }
-  ];
-
-  const demoIssues = [
-    {
-      id: 'ISSUE-1',
-      team: 'PAY',
-      product: 'POS',
-      storyPoints: 3,
-      epicLabels: ['2024_PI1_committed'],
-      changelog: [
-        { field: 'Sprint', to: 's1', at: '2023-12-30T00:00:00Z' },
-        { field: 'Status', to: 'Done', at: '2024-01-10T00:00:00Z' }
-      ]
-    },
-    {
-      id: 'ISSUE-2',
-      team: 'PAY',
-      product: 'POS',
-      storyPoints: 5,
-      epicLabels: [],
-      changelog: [
-        { field: 'Sprint', to: 's1', at: '2023-12-29T00:00:00Z' },
-        { field: 'Sprint', from: 's1', to: 's2', at: '2024-01-16T00:00:00Z' },
-        { field: 'Status', to: 'Done', at: '2024-01-25T00:00:00Z' }
-      ]
+    const canvas = document.getElementById('piPlanChart');
+    if (canvas) {
+      canvas.width = 600;
+      canvas.height = 300;
     }
-  ];
 
-  const canvas = document.getElementById('piPlanChart');
-  if (canvas) {
-    canvas.width = 600;
-    canvas.height = 300;
+    renderPiPlanVsCompleteChart({
+      canvasId: 'piPlanChart',
+      team: data.team,
+      product: data.product,
+      sprints: data.sprints,
+      issues: data.issues,
+      piBuckets: data.piBuckets,
+      piCheck: PiLabel.isPiRelevant
+    });
   }
-  renderPiPlanVsCompleteChart({
-    canvasId: 'piPlanChart',
-    team: 'PAY',
-    product: 'POS',
-    sprints: demoSprints,
-    issues: demoIssues,
-    piBuckets: demoBuckets
-  });
+
+  init();
 </script>
 </body>
 </html>

--- a/src/piLabel.js
+++ b/src/piLabel.js
@@ -1,7 +1,15 @@
-function isPiRelevant(epicLabels = []) {
-  if (!Array.isArray(epicLabels) || epicLabels.length === 0) return false;
-  const regex = /^\d{4}_PI\d+_committed$/i;
-  return epicLabels.some(label => regex.test(label));
-}
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.PiLabel = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function() {
+  function isPiRelevant(epicLabels = []) {
+    if (!Array.isArray(epicLabels) || epicLabels.length === 0) return false;
+    const regex = /^\d{4}_PI\d+_committed$/i;
+    return epicLabels.some(label => regex.test(label));
+  }
+  return { isPiRelevant };
+}));
 
-module.exports = { isPiRelevant };

--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -19,7 +19,7 @@ function getSprintAt(timeline = [], time) {
   return current;
 }
 
-export function computeBucketSeries({ team, product, sprints = [], issues = [], piBuckets = [], piLabelTemplate = 'YEAR_PIX_committed' } = {}) {
+export function computeBucketSeries({ team, product, sprints = [], issues = [], piBuckets = [], piLabelTemplate = 'YEAR_PIX_committed', piCheck } = {}) {
   const sprintMap = new Map();
   sprints.forEach(s => sprintMap.set(s.id, s));
   const metrics = new Map();
@@ -28,6 +28,8 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
   });
 
   const filtered = (issues || []).filter(i => i.team === team && i.product === product);
+
+  const checkFn = typeof piCheck === 'function' ? piCheck : isPiCommitted;
 
   const processed = filtered.map(issue => {
     const sprintChanges = [];
@@ -47,7 +49,7 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
     const doneEntry = statusChanges.find(c => /done/i.test(c.to));
     const completion = doneEntry ? new Date(doneEntry.at) : null;
     return {
-      isPi: isPiCommitted(issue.epicLabels || [], piLabelTemplate),
+      isPi: checkFn(issue.epicLabels || [], piLabelTemplate),
       storyPoints: issue.storyPoints || 0,
       sprintTimeline: sprintChanges,
       completionTime: completion
@@ -123,7 +125,7 @@ function createHatch(color, bg) {
   return ctx.createPattern(canvas, 'repeat');
 }
 
-export function renderPiPlanVsCompleteChart({ canvasId, team, product, sprints = [], issues = [], piBuckets = [], piLabelTemplate = 'YEAR_PIX_committed' }) {
+export function renderPiPlanVsCompleteChart({ canvasId, team, product, sprints = [], issues = [], piBuckets = [], piLabelTemplate = 'YEAR_PIX_committed', piCheck } = {}) {
   const canvas = document.getElementById(canvasId);
   if (!canvas) return null;
   canvas.setAttribute('role', 'img');
@@ -132,7 +134,7 @@ export function renderPiPlanVsCompleteChart({ canvasId, team, product, sprints =
     canvas._chart.destroy();
   }
 
-  const series = computeBucketSeries({ team, product, sprints, issues, piBuckets, piLabelTemplate });
+  const series = computeBucketSeries({ team, product, sprints, issues, piBuckets, piLabelTemplate, piCheck });
 
   const blue = '#0EA5E9';
   const blueBorder = '#0284C7';


### PR DESCRIPTION
## Summary
- Load PI plan vs completed chart data in main disruption report via fetch rather than embedded demo arrays
- Include `piLabel.js` and pass `PiLabel.isPiRelevant` when rendering the PI plan chart

## Testing
- `node test/piLabel.test.js && node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f25b91c84832585b5f4aa24d403bd