### PR TITLE
Include 'maindriver' epic label as PI relevant

### DIFF
--- a/src/piLabel.js
+++ b/src/piLabel.js
@@ -7,8 +7,9 @@
 }(typeof self !== 'undefined' ? self : this, function() {
   function isPiRelevant(epicLabels = []) {
     if (!Array.isArray(epicLabels) || epicLabels.length === 0) return false;
-    const regex = /^\d{4}_PI\d+_committed$/i;
-    return epicLabels.some(label => regex.test(label));
+    const piRegex = /^\d{4}_PI\d+_committed$/i;
+    const mainDriverRegex = /^maindriver$/i;
+    return epicLabels.some(label => piRegex.test(label) || mainDriverRegex.test(label));
   }
   return { isPiRelevant };
 }));

--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -4,7 +4,8 @@ export function isPiCommitted(epicLabels = [], template = 'YEAR_PIX_committed') 
   const regex = new RegExp('^' + escaped
     .replace('YEAR', '(\\\d{4})')
     .replace('PIX', 'PI(\\\d+)') + '$', 'i');
-  return epicLabels.some(l => regex.test(l));
+  const mainDriverRegex = /^maindriver$/i;
+  return epicLabels.some(l => regex.test(l) || mainDriverRegex.test(l));
 }
 
 // Extracts a numeric sprint id from various formats (e.g. "123", "Sprint 123",

--- a/test/piLabel.test.js
+++ b/test/piLabel.test.js
@@ -5,6 +5,7 @@ const { isPiRelevant } = require('../src/piLabel');
   assert.strictEqual(isPiRelevant(['2025_PI3_committed']), true);
   assert.strictEqual(isPiRelevant(['misc']), false);
   assert.strictEqual(isPiRelevant(['2025_PI3_committed', 'other']), true);
+  assert.strictEqual(isPiRelevant(['maindriver']), true);
   assert.strictEqual(isPiRelevant([]), false);
 })();
 

--- a/test/piPlanVsCompleteChart.test.js
+++ b/test/piPlanVsCompleteChart.test.js
@@ -23,7 +23,7 @@ const assert = require('assert');
       team: 'ALL',
       product: 'ALL',
       storyPoints: 8,
-      epicLabels: [],
+      epicLabels: ['maindriver'],
       changelog: [
         { field: 'Sprint', from: '', to: '1', at: '2022-12-20' },
         { field: 'Sprint', from: '1', to: '2', at: '2023-01-09' },
@@ -45,9 +45,9 @@ const assert = require('assert');
     piBuckets
   });
 
-  assert.deepStrictEqual(series.plannedPi, [5, 0]);
-  assert.deepStrictEqual(series.plannedNonPi, [8, 0]);
-  assert.deepStrictEqual(series.completedPi, [5, 0]);
-  assert.deepStrictEqual(series.completedNonPi, [0, 8]);
+  assert.deepStrictEqual(series.plannedPi, [13, 0]);
+  assert.deepStrictEqual(series.plannedNonPi, [0, 0]);
+  assert.deepStrictEqual(series.completedPi, [5, 8]);
+  assert.deepStrictEqual(series.completedNonPi, [0, 0]);
   console.log('piPlanVsCompleteChart tests passed');
 })();


### PR DESCRIPTION
## Summary
- treat 'maindriver' epic labels as PI relevant items
- adjust PI planning logic to count maindriver epics as PI committed
- update tests for new PI relevance behavior

## Testing
- `node test/piLabel.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f322fb0e88325b6a1a4e8b84ddce2