### PR TITLE
Log epic labels for each story

### DIFF
--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -37,6 +37,18 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
 
   const filtered = (issues || []).filter(i => i.team === team && i.product === product);
 
+  // Display the epic labels associated with each story in the console so
+  // consumers can verify which PI or main driver an issue belongs to. This
+  // mirrors the behaviour in the web UI where labels are fetched for every
+  // epic. If a story has no labels, an empty array is shown.
+  filtered.forEach(issue => {
+    // `issue.key` is optional in the input but if present it helps to identify
+    // the story in the output. Fallback to an empty string to avoid `undefined`
+    // appearing in the log.
+    const ident = issue.key ? ` ${issue.key}` : '';
+    console.log(`Epic labels for story${ident}:`, issue.epicLabels || []);
+  });
+
   const checkFn = typeof piCheck === 'function' ? piCheck : isPiCommitted;
 
   const processed = filtered.map(issue => {

--- a/test/epicLabelsConsole.test.js
+++ b/test/epicLabelsConsole.test.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+
+(async () => {
+  const { computeBucketSeries } = await import('../src/piPlanVsCompleteChart.mjs');
+
+  const sprints = [
+    { id: 1, start: '2023-01-01', end: '2023-01-07' }
+  ];
+
+  const issues = [
+    {
+      key: 'ST-1',
+      team: 'ALL',
+      product: 'ALL',
+      storyPoints: 3,
+      epicLabels: ['L1'],
+      changelog: [
+        { field: 'Sprint', from: '', to: '1', at: '2022-12-20' }
+      ]
+    },
+    {
+      key: 'ST-2',
+      team: 'ALL',
+      product: 'ALL',
+      storyPoints: 5,
+      epicLabels: ['L2'],
+      changelog: [
+        { field: 'Sprint', from: '', to: '1', at: '2022-12-21' }
+      ]
+    }
+  ];
+
+  const piBuckets = [
+    { labelTop: 'S1', labelBottom: '', sprintIds: [1] }
+  ];
+
+  const logs = [];
+  const orig = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+
+  computeBucketSeries({ team: 'ALL', product: 'ALL', sprints, issues, piBuckets });
+
+  console.log = orig;
+
+  const epicLogs = logs.filter(l => l.startsWith('Epic labels for story'));
+  assert.strictEqual(epicLogs.length, issues.length);
+  assert(epicLogs.some(l => l.includes('L1')));
+  assert(epicLogs.some(l => l.includes('L2')));
+
+  console.log('epicLabelsConsole tests passed');
+})();


### PR DESCRIPTION
## Summary
- log epic labels for each story in computeBucketSeries
- add console logging test for epic labels

## Testing
- `node test/disruption.test.js`
- `node test/piLabel.test.js`
- `node test/piPlanVsCompleteChart.test.js`
- `node test/epicLabelsConsole.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f3346aef88325bf59b9940371da09