### PR TITLE
Log epic label details

### DIFF
--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -37,16 +37,15 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
 
   const filtered = (issues || []).filter(i => i.team === team && i.product === product);
 
-  // Display the epic labels associated with each story in the console so
-  // consumers can verify which PI or main driver an issue belongs to. This
-  // mirrors the behaviour in the web UI where labels are fetched for every
-  // epic. If a story has no labels, an empty array is shown.
+  // Collect the issue, its epic and associated labels so they can be printed
+  // once at the end of the computation. This helps consumers verify which
+  // labels were retrieved for each epic.
+  const issueEpicSummary = [];
   filtered.forEach(issue => {
-    // `issue.key` is optional in the input but if present it helps to identify
-    // the story in the output. Fallback to an empty string to avoid `undefined`
-    // appearing in the log.
-    const ident = issue.key ? ` ${issue.key}` : '';
-    console.log(`Epic labels for story${ident}:`, issue.epicLabels || []);
+    const issueKey = issue.key || '';
+    const epicKey = issue.epicKey || '';
+    const labels = Array.isArray(issue.epicLabels) ? issue.epicLabels : [];
+    issueEpicSummary.push(`${issueKey} - ${epicKey} - [${labels.join(', ')}]`);
   });
 
   const checkFn = typeof piCheck === 'function' ? piCheck : isPiCommitted;
@@ -129,6 +128,10 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
     series.plannedTotals.push(pPi + pNonPi);
     series.completedTotals.push(cPi + cNonPi);
   });
+  // Print the collected issue/epic/label information as the last output in
+  // the console so users can easily inspect which labels were fetched for
+  // each epic.
+  issueEpicSummary.forEach(line => console.log(line));
 
   return series;
 }

--- a/test/epicLabelsConsole.test.js
+++ b/test/epicLabelsConsole.test.js
@@ -13,6 +13,7 @@ const assert = require('assert');
       team: 'ALL',
       product: 'ALL',
       storyPoints: 3,
+      epicKey: 'EP-1',
       epicLabels: ['L1'],
       changelog: [
         { field: 'Sprint', from: '', to: '1', at: '2022-12-20' }
@@ -23,6 +24,7 @@ const assert = require('assert');
       team: 'ALL',
       product: 'ALL',
       storyPoints: 5,
+      epicKey: 'EP-2',
       epicLabels: ['L2'],
       changelog: [
         { field: 'Sprint', from: '', to: '1', at: '2022-12-21' }
@@ -42,10 +44,9 @@ const assert = require('assert');
 
   console.log = orig;
 
-  const epicLogs = logs.filter(l => l.startsWith('Epic labels for story'));
-  assert.strictEqual(epicLogs.length, issues.length);
-  assert(epicLogs.some(l => l.includes('L1')));
-  assert(epicLogs.some(l => l.includes('L2')));
+  assert.strictEqual(logs.length, issues.length);
+  assert(logs.some(l => l.includes('ST-1') && l.includes('EP-1') && l.includes('L1')));
+  assert(logs.some(l => l.includes('ST-2') && l.includes('EP-2') && l.includes('L2')));
 
   console.log('epicLabelsConsole tests passed');
 })();


### PR DESCRIPTION
## Summary
- log issue, epic, and label details at the end of computeBucketSeries
- test that console outputs issue-epic-label summaries

## Testing
- `node test/epicLabelsConsole.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f361213c8832590bc183466b7ea9f