### PR TITLE
chore: use logger for epic label output

### DIFF
--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -131,7 +131,13 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
   // Print the collected issue/epic/label information as the last output in
   // the console so users can easily inspect which labels were fetched for
   // each epic.
-  issueEpicSummary.forEach(line => console.log(line));
+  issueEpicSummary.forEach(line => {
+    if (typeof Logger !== 'undefined' && typeof Logger.info === 'function') {
+      Logger.info(line);
+    } else if (typeof console !== 'undefined' && typeof console.log === 'function') {
+      console.log(line);
+    }
+  });
 
   return series;
 }


### PR DESCRIPTION
## Summary
- log epic label summaries with MCReport logger when available

## Testing
- `node test/piPlanVsCompleteChart.test.js`
- `node test/epicLabelsConsole.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f39135e088325af97375ec181a7ef