### PR TITLE
Log parent issue key with epic label console output

### DIFF
--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -37,15 +37,16 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
 
   const filtered = (issues || []).filter(i => i.team === team && i.product === product);
 
-  // For each issue print its key, its parent epic and all labels retrieved for
-  // that epic. This allows consumers to verify which labels were associated
-  // with each story's parent.
+  // For each issue print its key, its parent (typically an epic) and all
+  // labels retrieved for that parent. This mirrors the behaviour in other
+  // MCreport variants and helps verify which labels were associated with each
+  // story's parent.
   filtered.forEach(issue => {
     const issueKey = issue.key || '';
-    const epicKey = issue.epicKey || '';
+    const parentKey = issue.parentKey || issue.epicKey || (issue.parent && issue.parent.key) || '';
     const labels = Array.isArray(issue.epicLabels) ? issue.epicLabels : [];
     if (typeof console !== 'undefined' && typeof console.log === 'function') {
-      console.log(`${issueKey} - ${epicKey} - [${labels.join(', ')}]`);
+      console.log(`${issueKey} - ${parentKey} - [${labels.join(', ')}]`);
     }
   });
 

--- a/test/epicLabelsConsole.test.js
+++ b/test/epicLabelsConsole.test.js
@@ -13,7 +13,7 @@ const assert = require('assert');
       team: 'ALL',
       product: 'ALL',
       storyPoints: 3,
-      epicKey: 'EP-1',
+      parentKey: 'EP-1',
       epicLabels: ['L1'],
       changelog: [
         { field: 'Sprint', from: '', to: '1', at: '2022-12-20' }
@@ -24,7 +24,7 @@ const assert = require('assert');
       team: 'ALL',
       product: 'ALL',
       storyPoints: 5,
-      epicKey: 'EP-2',
+      parentKey: 'EP-2',
       epicLabels: ['L2'],
       changelog: [
         { field: 'Sprint', from: '', to: '1', at: '2022-12-21' }


### PR DESCRIPTION
## Summary
- include parent issue key (falling back to epic) when logging epic labels
- update console logging test to use parentKey

## Testing
- `node test/epicLabelsConsole.test.js && node test/piPlanVsCompleteChart.test.js && node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f3e345bf08325bd02823796e4e30d