### PR TITLE
Fix PI vs non-PI differentiation

### DIFF
--- a/test/piPlanVsCompleteChart.test.js
+++ b/test/piPlanVsCompleteChart.test.js
@@ -4,8 +4,8 @@ const assert = require('assert');
   const { computeBucketSeries } = await import('../src/piPlanVsCompleteChart.mjs');
 
   const sprints = [
-    { id: 1, start: '2023-01-01', end: '2023-01-07' },
-    { id: 2, start: '2023-01-08', end: '2023-01-14' }
+    { id: 1, name: '2024 PI1 S1', start: '2024-01-01', end: '2024-01-07' },
+    { id: 2, name: '2024 PI2 S1', start: '2024-01-08', end: '2024-01-14' }
   ];
 
   const issues = [
@@ -15,8 +15,8 @@ const assert = require('assert');
       storyPoints: 5,
       epicLabels: ['2024_PI1_committed'],
       changelog: [
-        { field: 'Sprint', from: '', to: '1', at: '2022-12-20' },
-        { field: 'Status', from: 'To Do', to: 'Done', at: '2023-01-05' }
+        { field: 'Sprint', from: '', to: '1', at: '2023-12-20' },
+        { field: 'Status', from: 'To Do', to: 'Done', at: '2024-01-05' }
       ]
     },
     {
@@ -25,9 +25,20 @@ const assert = require('assert');
       storyPoints: 8,
       epicLabels: ['maindriver'],
       changelog: [
-        { field: 'Sprint', from: '', to: '1', at: '2022-12-20' },
-        { field: 'Sprint', from: '1', to: '2', at: '2023-01-09' },
-        { field: 'Status', from: 'To Do', to: 'Done', at: '2023-01-12' }
+        { field: 'Sprint', from: '', to: '1', at: '2023-12-20' },
+        { field: 'Sprint', from: '1', to: '2', at: '2024-01-09' },
+        { field: 'Status', from: 'To Do', to: 'Done', at: '2024-01-12' }
+      ]
+    },
+    {
+      team: 'ALL',
+      product: 'ALL',
+      storyPoints: 3,
+      epicLabels: ['2024_PI1_committed'],
+      changelog: [
+        { field: 'Sprint', from: '', to: '1', at: '2023-12-22' },
+        { field: 'Sprint', from: '1', to: '2', at: '2024-01-09' },
+        { field: 'Status', from: 'To Do', to: 'Done', at: '2024-01-13' }
       ]
     }
   ];
@@ -45,9 +56,9 @@ const assert = require('assert');
     piBuckets
   });
 
-  assert.deepStrictEqual(series.plannedPi, [13, 0]);
+  assert.deepStrictEqual(series.plannedPi, [16, 0]);
   assert.deepStrictEqual(series.plannedNonPi, [0, 0]);
   assert.deepStrictEqual(series.completedPi, [5, 8]);
-  assert.deepStrictEqual(series.completedNonPi, [0, 0]);
+  assert.deepStrictEqual(series.completedNonPi, [0, 3]);
   console.log('piPlanVsCompleteChart tests passed');
 })();


### PR DESCRIPTION
## Summary
- parse PI identifiers from epic labels and sprint names
- classify story points as PI or non-PI per sprint based on PI match
- add regression test for PI mismatch across sprints

## Testing
- `node test/piPlanVsCompleteChart.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f48a169dc8325938f33c089f91e66