### PR TITLE
Fix issue key missing in PI vs non-PI chart

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -405,6 +405,7 @@
                     );
                     issueDetails.set(ev.key, {
                       id: ev.key,
+                      key: ev.key,
                       team: CHART_TEAM,
                       product: CHART_PRODUCT,
                       storyPoints: (ev.points || existingIssue?.storyPoints || 0),


### PR DESCRIPTION
## Summary
- ensure issue objects retain their key when collecting disruption data so PI vs non-PI chart can display issues

## Testing
- `node --test test/piPlanVsCompleteChart.test.js`
- `node --test test/epicLabelsConsole.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f4b1439fc8325a9f5ce0d41c303ed