### PR TITLE
Add parent label mapping for PI relevance chart

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -410,6 +410,7 @@
                       product: CHART_PRODUCT,
                       storyPoints: (ev.points || existingIssue?.storyPoints || 0),
                       parentKey,
+                      parentLabels: existingIssue?.parentLabels || [],
                       epicLabels: existingIssue?.epicLabels || [],
                       changelog
                     });
@@ -468,7 +469,9 @@
         }));
 
         issueDetails.forEach(issue => {
-          issue.epicLabels = epicLabelMap.get(issue.parentKey) || [];
+          const labels = epicLabelMap.get(issue.parentKey) || [];
+          issue.parentLabels = labels;
+          issue.epicLabels = labels;
         });
 
         const sprintsArr = Object.values(combined).sort((a, b) => new Date(a.startDate) - new Date(b.startDate));

--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -72,7 +72,9 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
   filtered.forEach(issue => {
     const issueKey = issue.key || '';
     const parentKey = issue.parentKey || issue.epicKey || (issue.parent && issue.parent.key) || '';
-    const labels = Array.isArray(issue.epicLabels) ? issue.epicLabels : [];
+    const labels = Array.isArray(issue.parentLabels)
+      ? issue.parentLabels
+      : (Array.isArray(issue.epicLabels) ? issue.epicLabels : []);
     if (typeof console !== 'undefined' && typeof console.log === 'function') {
       console.log(`${issueKey} - ${parentKey} - [${labels.join(', ')}]`);
     }
@@ -101,9 +103,12 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
       .sort((a, b) => new Date(a.at) - new Date(b.at));
     const doneEntry = statusChanges.find(c => /done/i.test(c.to));
     const completion = doneEntry ? new Date(doneEntry.at) : null;
+    const labels = Array.isArray(issue.parentLabels)
+      ? issue.parentLabels
+      : (Array.isArray(issue.epicLabels) ? issue.epicLabels : []);
     return {
-      isPi: checkFn(issue.epicLabels || [], piLabelTemplate),
-      piId: extractPiId(issue.epicLabels || [], piLabelTemplate),
+      isPi: checkFn(labels, piLabelTemplate),
+      piId: extractPiId(labels, piLabelTemplate),
       storyPoints: issue.storyPoints || 0,
       sprintTimeline: sprintChanges,
       completionTime: completion

--- a/test/epicLabelsConsole.test.js
+++ b/test/epicLabelsConsole.test.js
@@ -14,7 +14,7 @@ const assert = require('assert');
       product: 'ALL',
       storyPoints: 3,
       parentKey: 'EP-1',
-      epicLabels: ['L1'],
+      parentLabels: ['L1'],
       changelog: [
         { field: 'Sprint', from: '', to: '1', at: '2022-12-20' }
       ]
@@ -25,7 +25,7 @@ const assert = require('assert');
       product: 'ALL',
       storyPoints: 5,
       parentKey: 'EP-2',
-      epicLabels: ['L2'],
+      parentLabels: ['L2'],
       changelog: [
         { field: 'Sprint', from: '', to: '1', at: '2022-12-21' }
       ]


### PR DESCRIPTION
## Summary
- propagate parent labels into issue data for the PI plan vs complete chart
- allow chart computation to prefer parent labels when classifying PI relevance
- adjust tests to exercise parent key and label logging

## Testing
- `node test/epicLabelsConsole.test.js`
- `node test/piPlanVsCompleteChart.test.js`
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f4da585288325b5638735a5a04a94