### PR TITLE
Include closed issues in PI distribution

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -412,6 +412,7 @@
                       parentKey,
                       parentLabels: existingIssue?.parentLabels || [],
                       epicLabels: existingIssue?.epicLabels || [],
+                      resolutionDate,
                       changelog
                     });
                   }

--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -101,8 +101,10 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
     const statusChanges = (issue.changelog || [])
       .filter(c => c.field === 'Status')
       .sort((a, b) => new Date(a.at) - new Date(b.at));
-    const doneEntry = statusChanges.find(c => /done/i.test(c.to));
-    const completion = doneEntry ? new Date(doneEntry.at) : null;
+    const doneEntry = statusChanges.find(c => /(done|closed|resolved)/i.test(c.to));
+    const completion = doneEntry
+      ? new Date(doneEntry.at)
+      : (issue.resolutionDate ? new Date(issue.resolutionDate) : null);
     const labels = Array.isArray(issue.parentLabels)
       ? issue.parentLabels
       : (Array.isArray(issue.epicLabels) ? issue.epicLabels : []);

--- a/test/piPlanVsCompleteChart.test.js
+++ b/test/piPlanVsCompleteChart.test.js
@@ -40,6 +40,17 @@ const assert = require('assert');
         { field: 'Sprint', from: '1', to: '2', at: '2024-01-09' },
         { field: 'Status', from: 'To Do', to: 'Done', at: '2024-01-13' }
       ]
+    },
+    {
+      team: 'ALL',
+      product: 'ALL',
+      storyPoints: 2,
+      epicLabels: ['2024_PI2_committed'],
+      resolutionDate: '2024-01-13',
+      changelog: [
+        { field: 'Sprint', from: '', to: '2', at: '2023-12-30' },
+        { field: 'Status', from: 'To Do', to: 'In Progress', at: '2024-01-10' }
+      ]
     }
   ];
 
@@ -56,9 +67,9 @@ const assert = require('assert');
     piBuckets
   });
 
-  assert.deepStrictEqual(series.plannedPi, [16, 0]);
+  assert.deepStrictEqual(series.plannedPi, [16, 2]);
   assert.deepStrictEqual(series.plannedNonPi, [0, 0]);
-  assert.deepStrictEqual(series.completedPi, [5, 8]);
+  assert.deepStrictEqual(series.completedPi, [5, 10]);
   assert.deepStrictEqual(series.completedNonPi, [0, 3]);
   console.log('piPlanVsCompleteChart tests passed');
 })();


### PR DESCRIPTION
## Summary
- include resolution date when storing issue details
- treat closed/resolved statuses as completed in PI charts
- add test covering resolution-only completion

## Testing
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f534f64488325a483ebb3a8bcf57f