### PR TITLE
Add disruption report table for parent labels

### DIFF
--- a/disruption.html
+++ b/disruption.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Disruption Parent Labels</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', Arial, sans-serif; margin:20px; }
+    table { border-collapse: collapse; width:100%; margin-top:20px; }
+    th, td { border:1px solid #e5e7eb; padding:6px 10px; text-align:left; }
+    th { background:#e0e7ef; }
+  </style>
+</head>
+<body>
+  <h1>Parent Labels by Sprint</h1>
+  <div>
+    <label>Jira Domain: <input id="jiraDomain" value="aldi-sued.atlassian.net" size="30"></label>
+    <label style="margin-left:10px;">Board: <input id="boardNum" size="6" placeholder="id"></label>
+    <button id="loadBtn">Load Data</button>
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th>Sprint</th>
+        <th>Issue</th>
+        <th>Parent</th>
+        <th>Parent Labels</th>
+      </tr>
+    </thead>
+    <tbody id="tableBody"></tbody>
+  </table>
+  <script>
+    async function fetchSprintIssues(domain, boardNum) {
+      const sprintUrl = `https://${domain}/rest/agile/1.0/board/${boardNum}/sprint?state=closed`;
+      const sprintResp = await fetch(sprintUrl, { credentials: 'include' });
+      const sprintData = sprintResp.ok ? await sprintResp.json() : { values: [] };
+      const rows = [];
+      for (const sprint of (sprintData.values || [])) {
+        const reportUrl = `https://${domain}/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId=${boardNum}&sprintId=${sprint.id}`;
+        const reportResp = await fetch(reportUrl, { credentials: 'include' });
+        if (!reportResp.ok) continue;
+        const reportData = await reportResp.json();
+        const issues = [
+          ...(reportData.contents?.completedIssues || []),
+          ...(reportData.contents?.issuesNotCompletedInCurrentSprint || []),
+          ...(reportData.contents?.puntedIssues || [])
+        ];
+        for (const issue of issues) {
+          const issueKey = issue.key;
+          const issueResp = await fetch(`https://${domain}/rest/api/3/issue/${issueKey}?fields=parent`, { credentials: 'include' });
+          if (!issueResp.ok) continue;
+          const issueData = await issueResp.json();
+          const parentKey = issueData.fields?.parent?.key;
+          let labels = [];
+          if (parentKey) {
+            const parentResp = await fetch(`https://${domain}/rest/api/3/issue/${parentKey}?fields=labels`, { credentials: 'include' });
+            if (parentResp.ok) {
+              const parentData = await parentResp.json();
+              labels = parentData.fields?.labels || [];
+            }
+          }
+          rows.push({ sprint: sprint.name, issue: issueKey, parent: parentKey || '', labels });
+        }
+      }
+      return rows;
+    }
+
+    document.getElementById('loadBtn').addEventListener('click', async () => {
+      const domain = document.getElementById('jiraDomain').value.trim();
+      const board = document.getElementById('boardNum').value.trim();
+      if (!domain || !board) {
+        alert('Enter Jira domain and board id');
+        return;
+      }
+      const body = document.getElementById('tableBody');
+      body.innerHTML = '';
+      try {
+        const rows = await fetchSprintIssues(domain, board);
+        rows.forEach(r => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${r.sprint}</td><td>${r.issue}</td><td>${r.parent}</td><td>${r.labels.join(', ')}</td>`;
+          body.appendChild(tr);
+        });
+      } catch (e) {
+        console.error(e);
+        alert('Failed to load data');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `disruption.html` page to list sprint issues with their parents and parent labels
- fetch sprint and issue details from Jira APIs to populate the table

## Testing
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f5c4cc9208325a2a98b7a77bdd251