### PR TITLE
Use sprint throughput in disruption report

### DIFF
--- a/index_disruption.html
+++ b/index_disruption.html
@@ -471,14 +471,9 @@ function renderVelocityStats(allSprints) {
     let totalCompleted = 0;
     let totalCycle = 0;
     let cycleCount = 0;
-    let earliestStart = null;
-    let latestEnd = null;
+    const sprintCount = (allSprints || []).length;
 
     (allSprints || []).forEach(s => {
-      const start = s.startDate ? new Date(s.startDate) : null;
-      const end = s.completeDate ? new Date(s.completeDate) : (s.endDate ? new Date(s.endDate) : null);
-      if (start && (!earliestStart || start < earliestStart)) earliestStart = start;
-      if (end && (!latestEnd || end > latestEnd)) latestEnd = end;
       (s.events || []).forEach(ev => {
         if (ev.completedDate) {
           totalCompleted++;
@@ -490,13 +485,12 @@ function renderVelocityStats(allSprints) {
       });
     });
 
-    const weeks = (earliestStart && latestEnd) ? (latestEnd - earliestStart) / (1000 * 60 * 60 * 24 * 7) : 0;
-    const weeklyThroughput = weeks ? totalCompleted / weeks : 0;
+    const sprintThroughput = sprintCount ? totalCompleted / sprintCount : 0;
     const meanCycleTime = cycleCount ? totalCycle / cycleCount : 0;
 
     const html = '<h2>Throughput & Cycle Time</h2>' +
-      '<table><thead><tr><th>Weekly Throughput</th><th>Mean Cycle Time (days)</th></tr></thead><tbody>' +
-      `<tr><td>${weeklyThroughput.toFixed(2)}</td><td>${meanCycleTime.toFixed(2)}</td></tr></tbody></table>`;
+      '<table><thead><tr><th>Sprint Throughput</th><th>Mean Cycle Time (days)</th></tr></thead><tbody>' +
+      `<tr><td>${sprintThroughput.toFixed(2)}</td><td>${meanCycleTime.toFixed(2)}</td></tr></tbody></table>`;
     wrap.innerHTML = html;
   }
 


### PR DESCRIPTION
## Summary
- compute throughput per sprint instead of per week in disruption report
- display sprint throughput alongside mean cycle time

## Testing
- ⚠️ `npm test` (missing script: "test")
- ✅ `node test/disruption.test.js`
- ✅ `node test/piPlanVsCompleteChart.test.js`
- ✅ `node test/epicLabelsConsole.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5b325b1bc83258ad34f323afd3bec