### PR TITLE
Show completion progress on PI plan vs complete chart

### DIFF
--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -234,7 +234,7 @@ export function renderPiPlanVsCompleteChart({ canvasId, team, product, sprints =
             offset: -4,
             color: '#000',
             font: { weight: 'bold' },
-            formatter: (v, ctx) => series.plannedTotals[ctx.dataIndex]
+            formatter: (v, ctx) => `${series.completedTotals[ctx.dataIndex]} of ${series.plannedTotals[ctx.dataIndex]}`
           }
         },
         {
@@ -246,14 +246,7 @@ export function renderPiPlanVsCompleteChart({ canvasId, team, product, sprints =
           borderWidth: 1,
           borderRadius: 6,
           order: 1,
-          datalabels: {
-            anchor: 'start',
-            align: 'end',
-            offset: -4,
-            color: '#000',
-            font: { weight: 'bold' },
-            formatter: (v, ctx) => series.completedTotals[ctx.dataIndex]
-          }
+          datalabels: { display: false }
         },
         {
           label: 'Completed PI contributions',


### PR DESCRIPTION
## Summary
- Label each bar with `completed of planned` story points for quick comparison
- Hide redundant labels on completed non-PI dataset

## Testing
- `node test/piPlanVsCompleteChart.test.js`
- `node test/epicLabelsConsole.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6da9aa9b08325a4d9aea5714ba2c0