### PR TITLE
Unify disruption chart units and format

### DIFF
--- a/test.html
+++ b/test.html
@@ -717,7 +717,7 @@ function renderCharts(displaySprints, allSprints) {
           { label: 'Type Changed Issues', data: typeChangedCount, backgroundColor: '#f59e0b', borderColor: '#f59e0b' },
           { label: 'Moved Out Issues', data: movedOutCount, backgroundColor: '#10b981', borderColor: '#10b981' },
           { label: 'Throughput per Sprint', data: throughputPerSprint, backgroundColor: '#f97316', borderColor: '#f97316' },
-          { label: 'Cycle Time per Sprint', data: cycleTimePerSprint, type: 'line', borderColor: '#8b5cf6', backgroundColor: '#8b5cf6', yAxisID: 'y1' }
+          { label: 'Cycle Time per Sprint', data: cycleTimePerSprint, type: 'bar', backgroundColor: '#8b5cf6', borderColor: '#8b5cf6', yAxisID: 'y1' }
         ]
       },
       options: {
@@ -725,7 +725,7 @@ function renderCharts(displaySprints, allSprints) {
         maintainAspectRatio: false,
         scales: {
           x: { offset: true },
-          y: { beginAtZero: true, title: { display: true, text: 'Issue Count / Blocked Days' } },
+          y: { beginAtZero: true, title: { display: true, text: 'Issue Count / Days' } },
           y1: { beginAtZero: true, position: 'right', title: { display: true, text: 'Cycle Time (days)' } }
         },
         plugins: {


### PR DESCRIPTION
## Summary
- Rename disruption chart axis to use generic "Issue Count / Days"
- Show cycle time as bar instead of line for consistent units

## Testing
- `npm test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a81838b94083258189592b028d3bd7