### PR TITLE
Remove redundant secondary y-axis

### DIFF
--- a/test.html
+++ b/test.html
@@ -717,7 +717,7 @@ function renderCharts(displaySprints, allSprints) {
           { label: 'Type Changed Issues', data: typeChangedCount, backgroundColor: '#f59e0b', borderColor: '#f59e0b' },
           { label: 'Moved Out Issues', data: movedOutCount, backgroundColor: '#10b981', borderColor: '#10b981' },
           { label: 'Throughput per Sprint', data: throughputPerSprint, backgroundColor: '#f97316', borderColor: '#f97316' },
-          { label: 'Cycle Time per Sprint', data: cycleTimePerSprint, type: 'bar', backgroundColor: '#8b5cf6', borderColor: '#8b5cf6', yAxisID: 'y1' }
+          { label: 'Cycle Time per Sprint', data: cycleTimePerSprint, type: 'bar', backgroundColor: '#8b5cf6', borderColor: '#8b5cf6' }
         ]
       },
       options: {
@@ -725,8 +725,7 @@ function renderCharts(displaySprints, allSprints) {
         maintainAspectRatio: false,
         scales: {
           x: { offset: true },
-          y: { beginAtZero: true, title: { display: true, text: 'Issue Count / Days' } },
-          y1: { beginAtZero: true, position: 'right', title: { display: true, text: 'Cycle Time (days)' } }
+          y: { beginAtZero: true, title: { display: true, text: 'Issue Count / Days' } }
         },
         plugins: {
           legend: { position: 'bottom' },


### PR DESCRIPTION
## Summary
- Use the primary y-axis for cycle time in the disruption chart and drop the unused secondary axis in `test.html`.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68a81f201e9c8325b7e8cc4d23c8948f