### PR TITLE
Handle new sprint naming pattern

### DIFF
--- a/index_topicmix.html
+++ b/index_topicmix.html
@@ -47,11 +47,15 @@ function switchVersion(v){ window.location.href = v; }
 
 const PI_LABEL_RE = /\b\d{4}_PI\d+_committed\b/i;
 const MAIN_DRIVER_RE = /^main[-_ ]?driver$/i;
-const SPRINT_KEY_RE = /\bPI\d+[-_ ]?\d+\b/i;
+const SPRINT_KEY_RE = /\b(?:\d{4}[-_ ]?)?PI\d+[-_ ]?\d+(?:\|\d+)?\b/i;
 
 function extractSprintKey(name) {
   const m = (name || '').match(SPRINT_KEY_RE);
-  return m ? m[0].replace(/[-_ ]/, '-') : null;
+  if (!m) return null;
+  let key = m[0];
+  key = key.replace(/(\d{4})[- ]PI/, '$1_PI');
+  key = key.replace(/(PI\d+)[-_ ](\d+)/, '$1-$2');
+  return key;
 }
 
 let availableBoards = [];

--- a/test/extractSprintKey.test.js
+++ b/test/extractSprintKey.test.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+
+const SPRINT_KEY_RE = /\b(?:\d{4}[-_ ]?)?PI\d+[-_ ]?\d+(?:\|\d+)?\b/i;
+
+function extractSprintKey(name) {
+  const m = (name || '').match(SPRINT_KEY_RE);
+  if (!m) return null;
+  let key = m[0];
+  key = key.replace(/(\d{4})[- ]PI/, '$1_PI');
+  key = key.replace(/(PI\d+)[-_ ](\d+)/, '$1-$2');
+  return key;
+}
+
+(function() {
+  assert.strictEqual(extractSprintKey('2025_PI3-3|4 indicator'), '2025_PI3-3|4');
+  assert.strictEqual(extractSprintKey('PI4 2'), 'PI4-2');
+  assert.strictEqual(extractSprintKey('2025-PI5_1'), '2025_PI5-1');
+  console.log('extractSprintKey tests passed');
+})();


### PR DESCRIPTION
## Summary
- allow sprint regex to match optional year and combined indicators like `2025_PI3-3|4`
- standardize sprint key extraction logic
- add tests for sprint key parsing

## Testing
- `node test/piPlanVsCompleteChart.test.js`
- `node test/extractSprintKey.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aec23399588325964c841f8fc0e943