### PR TITLE
Normalize sprint naming variants

### DIFF
--- a/index_topicmix.html
+++ b/index_topicmix.html
@@ -47,15 +47,20 @@ function switchVersion(v){ window.location.href = v; }
 
 const PI_LABEL_RE = /\b\d{4}_PI\d+_committed\b/i;
 const MAIN_DRIVER_RE = /^main[-_ ]?driver$/i;
-const SPRINT_KEY_RE = /\b(?:\d{4}[-_ ]?)?PI\d+[-_ ]?\d+(?:\|\d+)?\b/i;
+const SPRINT_KEY_RE = /\b(?:(\d{4})[-_ ]?)?(?:PI)?(\d+)[-_ ]?(\d+)(?:[|/](\d+))?\b/i;
 
 function extractSprintKey(name) {
   const m = (name || '').match(SPRINT_KEY_RE);
   if (!m) return null;
-  let key = m[0];
-  key = key.replace(/(\d{4})[- ]PI/, '$1_PI');
-  key = key.replace(/(PI\d+)[-_ ](\d+)/, '$1-$2');
-  return key;
+  const year = m[1] ? m[1] + '_' : '';
+  const pi = m[2];
+  let sprint = m[3] || '';
+  if (m[4]) {
+    sprint = m[3];
+  } else if (sprint.length > 1) {
+    sprint = sprint[0];
+  }
+  return `${year}PI${pi}-${sprint}`;
 }
 
 let availableBoards = [];

--- a/test/extractSprintKey.test.js
+++ b/test/extractSprintKey.test.js
@@ -1,19 +1,27 @@
 const assert = require('assert');
 
-const SPRINT_KEY_RE = /\b(?:\d{4}[-_ ]?)?PI\d+[-_ ]?\d+(?:\|\d+)?\b/i;
+const SPRINT_KEY_RE = /\b(?:(\d{4})[-_ ]?)?(?:PI)?(\d+)[-_ ]?(\d+)(?:[|/](\d+))?\b/i;
 
 function extractSprintKey(name) {
   const m = (name || '').match(SPRINT_KEY_RE);
   if (!m) return null;
-  let key = m[0];
-  key = key.replace(/(\d{4})[- ]PI/, '$1_PI');
-  key = key.replace(/(PI\d+)[-_ ](\d+)/, '$1-$2');
-  return key;
+  const year = m[1] ? m[1] + '_' : '';
+  const pi = m[2];
+  let sprint = m[3] || '';
+  if (m[4]) {
+    sprint = m[3];
+  } else if (sprint.length > 1) {
+    sprint = sprint[0];
+  }
+  return `${year}PI${pi}-${sprint}`;
 }
 
 (function() {
-  assert.strictEqual(extractSprintKey('2025_PI3-3|4 indicator'), '2025_PI3-3|4');
-  assert.strictEqual(extractSprintKey('PI4 2'), 'PI4-2');
+  assert.strictEqual(extractSprintKey('3-1'), 'PI3-1');
+  assert.strictEqual(extractSprintKey('2025_3-1'), '2025_PI3-1');
+  assert.strictEqual(extractSprintKey('2025_PI3-12'), '2025_PI3-1');
+  assert.strictEqual(extractSprintKey('PI4 3/4'), 'PI4-3');
   assert.strictEqual(extractSprintKey('2025-PI5_1'), '2025_PI5-1');
+  assert.strictEqual(extractSprintKey('PI6-56 extra'), 'PI6-5');
   console.log('extractSprintKey tests passed');
 })();


### PR DESCRIPTION
## Summary
- broaden sprint name pattern to accept year prefixes, optional PI text, and slash or pipe separators
- collapse multi-number sprint identifiers to the first sprint when deriving keys
- expand tests to cover new sprint naming formats

## Testing
- `node test/extractSprintKey.test.js`
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aec4f552b4832596dcfd012f2881dd