### PR TITLE
Normalize sprint keys without year prefix

### DIFF
--- a/index_topicmix.html
+++ b/index_topicmix.html
@@ -47,20 +47,22 @@ function switchVersion(v){ window.location.href = v; }
 
 const PI_LABEL_RE = /\b\d{4}_PI\d+_committed\b/i;
 const MAIN_DRIVER_RE = /^main[-_ ]?driver$/i;
-const SPRINT_KEY_RE = /\b(?:(\d{4})[-_ ]?)?(?:PI)?(\d+)[-_ ]?(\d+)(?:[|/](\d+))?\b/i;
+// Match sprint names that include optional year prefixes (e.g., "2025_PI3-1")
+// but ignore the year when constructing a normalized key. This ensures that
+// sprints named both "PI3-1" and "2025_PI3-1" are treated as the same sprint.
+const SPRINT_KEY_RE = /\b(?:\d{4}[-_ ]?)?(?:PI)?(\d+)[-_ ]?(\d+)(?:[|/](\d+))?\b/i;
 
 function extractSprintKey(name) {
   const m = (name || '').match(SPRINT_KEY_RE);
   if (!m) return null;
-  const year = m[1] ? m[1] + '_' : '';
-  const pi = m[2];
-  let sprint = m[3] || '';
-  if (m[4]) {
-    sprint = m[3];
+  const pi = m[1];
+  let sprint = m[2] || '';
+  if (m[3]) {
+    sprint = m[2];
   } else if (sprint.length > 1) {
     sprint = sprint[0];
   }
-  return `${year}PI${pi}-${sprint}`;
+  return `PI${pi}-${sprint}`;
 }
 
 let availableBoards = [];

--- a/test/extractSprintKey.test.js
+++ b/test/extractSprintKey.test.js
@@ -1,27 +1,26 @@
 const assert = require('assert');
 
-const SPRINT_KEY_RE = /\b(?:(\d{4})[-_ ]?)?(?:PI)?(\d+)[-_ ]?(\d+)(?:[|/](\d+))?\b/i;
+const SPRINT_KEY_RE = /\b(?:\d{4}[-_ ]?)?(?:PI)?(\d+)[-_ ]?(\d+)(?:[|/](\d+))?\b/i;
 
 function extractSprintKey(name) {
   const m = (name || '').match(SPRINT_KEY_RE);
   if (!m) return null;
-  const year = m[1] ? m[1] + '_' : '';
-  const pi = m[2];
-  let sprint = m[3] || '';
-  if (m[4]) {
-    sprint = m[3];
+  const pi = m[1];
+  let sprint = m[2] || '';
+  if (m[3]) {
+    sprint = m[2];
   } else if (sprint.length > 1) {
     sprint = sprint[0];
   }
-  return `${year}PI${pi}-${sprint}`;
+  return `PI${pi}-${sprint}`;
 }
 
 (function() {
   assert.strictEqual(extractSprintKey('3-1'), 'PI3-1');
-  assert.strictEqual(extractSprintKey('2025_3-1'), '2025_PI3-1');
-  assert.strictEqual(extractSprintKey('2025_PI3-12'), '2025_PI3-1');
+  assert.strictEqual(extractSprintKey('2025_3-1'), 'PI3-1');
+  assert.strictEqual(extractSprintKey('2025_PI3-12'), 'PI3-1');
   assert.strictEqual(extractSprintKey('PI4 3/4'), 'PI4-3');
-  assert.strictEqual(extractSprintKey('2025-PI5_1'), '2025_PI5-1');
+  assert.strictEqual(extractSprintKey('2025-PI5_1'), 'PI5-1');
   assert.strictEqual(extractSprintKey('PI6-56 extra'), 'PI6-5');
   console.log('extractSprintKey tests passed');
 })();


### PR DESCRIPTION
## Summary
- Normalize sprint keys so that optional year prefixes are ignored, allowing sprints named `PIx-y` and `2025_PIx-y` to be grouped together
- Update sprint key extraction tests to reflect year-agnostic keys

## Testing
- `node test/extractSprintKey.test.js`
- `node test/piPlanVsCompleteChart.test.js`
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aec92c2e1c8325bb2406d43b078dde