### PR TITLE
Fix KPI report board selection

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -170,7 +170,9 @@
       boardChoices.setChoices(boards.map(b => ({ value: b.id, label: b.name })), 'value', 'label', true);
       boardChoices.removeActiveItems();
       boards.forEach(b => boardChoices.setChoiceByValue(String(b.id)));
-      loadDisruption();
+      const show = boards.length ? '' : 'none';
+      document.getElementById('boardLabel').style.display = show;
+      document.getElementById('loadBtn').style.display = show;
     } catch (e) {
       Logger.error('Failed to load boards', e);
     }


### PR DESCRIPTION
## Summary
- Ensure board and load controls are visible in KPI report
- Remove auto-loading so users can select boards and trigger report

## Testing
- ⚠️ `npm test` (missing script)


------
https://chatgpt.com/codex/tasks/task_e_68b54653eb00832591277820e2b6fc22