### PR TITLE
Auto-load KPI report charts for all teams

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -173,6 +173,9 @@
       const show = boards.length ? '' : 'none';
       document.getElementById('boardLabel').style.display = show;
       document.getElementById('loadBtn').style.display = show;
+      if (boards.length) {
+        loadDisruption();
+      }
     } catch (e) {
       Logger.error('Failed to load boards', e);
     }


### PR DESCRIPTION
## Summary
- Automatically load disruption KPI charts in KPI_Report to show all boards by default

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5484d2f008325a76619ed2b77d63f