### PR TITLE
Fix KPI report to show last six sprints per board

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -157,7 +157,7 @@
     const wrap = document.getElementById('sprintList');
     if (!wrap) return;
     wrap.innerHTML = sprints.map(s =>
-      `<span class="sprint-item">${s.name}</span>`
+      `<span class="sprint-item">[${s.board}] ${s.name}</span>`
     ).join('');
   }
 
@@ -423,13 +423,15 @@
                                          .reduce((sum, ev) => sum + ev.points, 0);
                 initiallyPlannedSource = 'sum of events not added after start';
               }
-              const existing = combined[s.name] || { id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
+              const key = `${boardNum}-${s.id}`;
+              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
               existing.id = existing.id || s.id;
+              existing.board = boardNum;
               existing.startDate = existing.startDate || s.startDate;
               existing.events = existing.events.concat(events);
               existing.initiallyPlanned += initiallyPlanned || 0;
               existing.completed += completed || 0;
-              combined[s.name] = existing;
+              combined[key] = existing;
             } catch (e) {
               Logger.error('sprint fetch failed', e);
             }
@@ -453,7 +455,7 @@
       const metrics = Disruption.calculateDisruptionMetrics(sprint.events);
       const detailsId = `details-${idx}`;
       html += `<tr>
-        <td>${sprint.name}</td>
+        <td>[${sprint.board}] ${sprint.name}</td>
         <td title="${sprint.initiallyPlannedSource}">${sprint.initiallyPlanned || 0}</td>
         <td title="${sprint.completedSource}">${sprint.completed || 0}</td>
         <td title="${metrics.pulledInIssues.join(', ')}">${metrics.pulledIn || 0} (${metrics.pulledInCount || 0})</td>
@@ -769,7 +771,13 @@ function renderCharts(displaySprints, allSprints) {
     Logger.info('Loading disruption report for boards', boards.join(','));
     const { sprints: fetchedSprints } = await fetchDisruptionData(jiraDomain, boards);
     allSprints = fetchedSprints;
-    sprints = fetchedSprints.slice(-DISPLAY_SPRINT_COUNT);
+    const byBoard = {};
+    fetchedSprints.forEach(s => {
+      if (!byBoard[s.board]) byBoard[s.board] = [];
+      byBoard[s.board].push(s);
+    });
+    Object.values(byBoard).forEach(arr => arr.sort((a, b) => new Date(a.startDate) - new Date(b.startDate)));
+    sprints = Object.values(byBoard).flatMap(arr => arr.slice(-DISPLAY_SPRINT_COUNT));
     renderTable(sprints);
     renderSprintList();
     document.getElementById('sprintRow').style.display = sprints.length ? '' : 'none';


### PR DESCRIPTION
## Summary
- separate sprints by board when fetching disruption data
- show board identifier with sprint name in sprint list and metrics table
- slice last six sprints for each board when loading report

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b54acd7a108325a1529cddb0be34af