### PR TITLE
Round up blocked days and cycle time

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -434,7 +434,7 @@
         <td title="${sprint.initiallyPlannedSource}">${sprint.initiallyPlanned || 0}</td>
         <td title="${sprint.completedSource}">${sprint.completed || 0}</td>
         <td title="${metrics.pulledInIssues.join(', ')}">${metrics.pulledIn || 0} (${metrics.pulledInCount || 0})</td>
-        <td title="${metrics.blockedIssues.join(', ')}">${Number(metrics.blockedDays || 0).toFixed(1)} (${metrics.blockedCount || 0})</td>
+        <td title="${metrics.blockedIssues.join(', ')}">${(Math.ceil((metrics.blockedDays || 0) * 10) / 10).toFixed(1)} (${metrics.blockedCount || 0})</td>
         <td title="${metrics.movedOutIssues.join(', ')}">${metrics.movedOut || 0} (${metrics.movedOutCount || 0})</td>
         <td><button class="btn details-toggle" onclick="toggleDetails('${detailsId}', this)">Show Details</button></td>
       </tr>`;
@@ -478,7 +478,7 @@ function renderVelocityStats(allSprints) {
 
     const html = '<h2>Throughput & Cycle Time</h2>' +
       '<table><thead><tr><th>Sprint Throughput</th><th>Mean Cycle Time (days)</th></tr></thead><tbody>' +
-      `<tr><td>${sprintThroughput.toFixed(2)}</td><td>${meanCycleTime.toFixed(2)}</td></tr></tbody></table>`;
+      `<tr><td>${sprintThroughput.toFixed(2)}</td><td>${(Math.ceil(meanCycleTime * 10) / 10).toFixed(1)}</td></tr></tbody></table>`;
     wrap.innerHTML = html;
   }
 
@@ -490,7 +490,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const plannedSP = plannedSPAll.slice(-displaySprints.length);
   const metricsArr = displaySprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
   const pulledInCount = metricsArr.map(m => m.pulledInCount || 0);
-  const blockedDays = metricsArr.map(m => m.blockedDays || 0);
+  const blockedDays = metricsArr.map(m => Math.ceil((m.blockedDays || 0) * 10) / 10);
   const blockedCount = metricsArr.map(m => m.blockedCount || 0);
   const movedOutCount = metricsArr.map(m => m.movedOutCount || 0);
 

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -425,7 +425,7 @@
         <td title="${sprint.initiallyPlannedSource}">${sprint.initiallyPlanned || 0}</td>
         <td title="${sprint.completedSource}">${sprint.completed || 0}</td>
         <td title="${metrics.pulledInIssues.join(', ')}">${metrics.pulledIn || 0} (${metrics.pulledInCount || 0})</td>
-        <td title="${metrics.blockedIssues.join(', ')}">${Number(metrics.blockedDays || 0).toFixed(1)} (${metrics.blockedCount || 0})</td>
+        <td title="${metrics.blockedIssues.join(', ')}">${(Math.ceil((metrics.blockedDays || 0) * 10) / 10).toFixed(1)} (${metrics.blockedCount || 0})</td>
         <td title="${metrics.movedOutIssues.join(', ')}">${metrics.movedOut || 0} (${metrics.movedOutCount || 0})</td>
         <td><button class="btn details-toggle" onclick="toggleDetails('${detailsId}', this)">Show Details</button></td>
       </tr>`;
@@ -469,7 +469,7 @@ function renderVelocityStats(allSprints) {
 
     const html = '<h2>Throughput & Cycle Time</h2>' +
       '<table><thead><tr><th>Sprint Throughput</th><th>Mean Cycle Time (days)</th></tr></thead><tbody>' +
-      `<tr><td>${sprintThroughput.toFixed(2)}</td><td>${meanCycleTime.toFixed(2)}</td></tr></tbody></table>`;
+      `<tr><td>${sprintThroughput.toFixed(2)}</td><td>${(Math.ceil(meanCycleTime * 10) / 10).toFixed(1)}</td></tr></tbody></table>`;
     wrap.innerHTML = html;
   }
 
@@ -481,7 +481,7 @@ function renderCharts(displaySprints, allSprints) {
   const plannedSP = plannedSPAll.slice(-displaySprints.length);
   const metricsArr = displaySprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
   const pulledInCount = metricsArr.map(m => m.pulledInCount || 0);
-  const blockedDays = metricsArr.map(m => m.blockedDays || 0);
+  const blockedDays = metricsArr.map(m => Math.ceil((m.blockedDays || 0) * 10) / 10);
   const blockedCount = metricsArr.map(m => m.blockedCount || 0);
   const movedOutCount = metricsArr.map(m => m.movedOutCount || 0);
 


### PR DESCRIPTION
## Summary
- Round up Blocked Days values to one decimal place in disruption and KPI reports
- Round up mean Cycle Time to one decimal place
- Ensure chart data uses rounded Blocked Days

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b56c6731788325aee6e19d4fc4bb92