### PR TITLE
Fix KPI report totals display

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -638,6 +638,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
           borderColor: plannedOtherColor,
           stack: 'planned',
           datalabels: {
+            display: true,
             anchor: 'end',
             align: 'start',
             offset: -4,


### PR DESCRIPTION
## Summary
- show totals for Initially Planned & Completed chart in KPI report

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b59a67adac83259a2a066784fbfecc