### PR TITLE
feat: include date and report type in PDF downloads

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -867,7 +867,8 @@ function renderCharts(displaySprints, allSprints) {
         y += height + 10;
       }
     }
-    pdf.save('KPI_Report.pdf');
+    const dateStr = new Date().toISOString().split('T')[0];
+    pdf.save(`KPI_Report_${dateStr}.pdf`);
   }
 
   document.getElementById('versionSelect').value = 'KPI_Report.html';

--- a/index.html
+++ b/index.html
@@ -981,7 +981,8 @@ function addTooltipListeners() {
           if (i>0) pdf.addPage();
           pdf.addImage(img, 'PNG', margin, margin, width, height);
         }
-        pdf.save('Stakeholder_StatusReport.pdf');
+        const dateStr = new Date().toISOString().split('T')[0];
+        pdf.save(`Stakeholder_StatusReport_Velocity_${dateStr}.pdf`);
       })();
     }
   </script>

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -768,7 +768,8 @@ function renderCharts(displaySprints, allSprints) {
       pdf.addImage(img, 'PNG', margin, y, width, height);
       y += height + 10;
     });
-    pdf.save('Disruption_Report.pdf');
+    const dateStr = new Date().toISOString().split('T')[0];
+    pdf.save(`Disruption_Report_${dateStr}.pdf`);
     charts.forEach(ch => {
       if (ch && ch.options.plugins?.datalabels) {
         ch.options.plugins.datalabels.display = false;

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -1006,7 +1006,8 @@ function addTooltipListeners() {
           if (i>0) pdf.addPage();
           pdf.addImage(img, 'PNG', margin, margin, width, height);
         }
-        pdf.save('Stakeholder_StatusReport.pdf');
+        const dateStr = new Date().toISOString().split('T')[0];
+        pdf.save(`Stakeholder_StatusReport_Throughput_${dateStr}.pdf`);
       })();
     }
   </script>

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -1045,7 +1045,8 @@ function addTooltipListeners() {
           if (i>0) pdf.addPage();
           pdf.addImage(img, 'PNG', margin, margin, width, height);
         }
-        pdf.save('Stakeholder_StatusReport.pdf');
+        const dateStr = new Date().toISOString().split('T')[0];
+        pdf.save(`Stakeholder_StatusReport_WeeklyThroughput_${dateStr}.pdf`);
       })();
     }
   </script>

--- a/test.html
+++ b/test.html
@@ -796,7 +796,8 @@ function renderCharts(displaySprints, allSprints) {
       pdf.addImage(img, 'PNG', margin, y, width, height);
       y += height + 10;
     });
-    pdf.save('Disruption_Report.pdf');
+    const dateStr = new Date().toISOString().split('T')[0];
+    pdf.save(`Disruption_Report_${dateStr}.pdf`);
     charts.forEach(ch => {
       if (ch && ch.options.plugins?.datalabels) {
         ch.options.plugins.datalabels.display = false;


### PR DESCRIPTION
## Summary
- append current date and report type to exported PDF filenames across all reports

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b59e2361fc8325bff427ab2f22dc60