### PR TITLE
Recognize BF-prefixed PI labels in reports

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -136,7 +136,7 @@
   let sprints = [];
   let allSprints = [];
   let epicCache = new Map();
-  const PI_LABEL_RE = /\b\d{4}_PI\d+_committed\b/i;
+  const PI_LABEL_RE = /\b(?:BF_)?\d{4}_PI\d+_committ?ed\b/i;
 
 
   function filterRecentSprints(allSprints, excludeIds = [], desiredCount = DISPLAY_SPRINT_COUNT) {

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -137,7 +137,7 @@
   let sprints = [];
   let allSprints = [];
   let epicCache = new Map();
-  const PI_LABEL_RE = /\b\d{4}_PI\d+_committed\b/i;
+  const PI_LABEL_RE = /\b(?:BF_)?\d{4}_PI\d+_committ?ed\b/i;
 
 
   function filterRecentSprints(allSprints, excludeIds = [], desiredCount = DISPLAY_SPRINT_COUNT) {


### PR DESCRIPTION
## Summary
- extend PI label detection regex to allow `BF_` prefix and single-`t` "commited" spelling in Disruption and KPI reports

## Testing
- `npm run build:css`
- `node test/piPlanVsCompleteChart.test.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5bf263f1c83259cc34d3101a974b7