### PR TITLE
Improve chart resolution in exported PDFs

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -828,6 +828,16 @@ function renderCharts(displaySprints, allSprints) {
     Logger.info('Disruption report rendered');
   }
 
+  function canvasToHighResDataURL(canvas, scale = 2) {
+    const tmp = document.createElement('canvas');
+    tmp.width = canvas.width * scale;
+    tmp.height = canvas.height * scale;
+    const ctx = tmp.getContext('2d');
+    ctx.scale(scale, scale);
+    ctx.drawImage(canvas, 0, 0);
+    return tmp.toDataURL('image/png');
+  }
+
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
@@ -863,7 +873,7 @@ function renderCharts(displaySprints, allSprints) {
         pdf.setFontSize(12);
         pdf.text(`${boardTitle} - ${chartTitleEl.textContent.trim()}`, margin, y);
         y += 14;
-        pdf.addImage(canvas.toDataURL('image/png'), 'PNG', margin, y, width, height);
+        pdf.addImage(canvasToHighResDataURL(canvas), 'PNG', margin, y, width, height);
         y += height + 10;
       }
     }

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -742,6 +742,16 @@ function renderCharts(displaySprints, allSprints) {
     Logger.info('Disruption report rendered');
   }
 
+  function canvasToHighResDataURL(canvas, scale = 2) {
+    const tmp = document.createElement('canvas');
+    tmp.width = canvas.width * scale;
+    tmp.height = canvas.height * scale;
+    const ctx = tmp.getContext('2d');
+    ctx.scale(scale, scale);
+    ctx.drawImage(canvas, 0, 0);
+    return tmp.toDataURL('image/png');
+  }
+
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
@@ -758,7 +768,7 @@ function renderCharts(displaySprints, allSprints) {
     const margin = 20;
     let y = margin;
     canvases.forEach(cv => {
-      const img = cv.toDataURL('image/png');
+      const img = canvasToHighResDataURL(cv);
       const width = pageWidth - margin * 2;
       const height = cv.height * width / cv.width;
       if (y + height > pageHeight - margin) {

--- a/test.html
+++ b/test.html
@@ -770,6 +770,16 @@ function renderCharts(displaySprints, allSprints) {
     Logger.info('Disruption report rendered');
   }
 
+  function canvasToHighResDataURL(canvas, scale = 2) {
+    const tmp = document.createElement('canvas');
+    tmp.width = canvas.width * scale;
+    tmp.height = canvas.height * scale;
+    const ctx = tmp.getContext('2d');
+    ctx.scale(scale, scale);
+    ctx.drawImage(canvas, 0, 0);
+    return tmp.toDataURL('image/png');
+  }
+
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
@@ -786,7 +796,7 @@ function renderCharts(displaySprints, allSprints) {
     const margin = 20;
     let y = margin;
     canvases.forEach(cv => {
-      const img = cv.toDataURL('image/png');
+      const img = canvasToHighResDataURL(cv);
       const width = pageWidth - margin * 2;
       const height = cv.height * width / cv.width;
       if (y + height > pageHeight - margin) {


### PR DESCRIPTION
## Summary
- render charts to high-resolution images before embedding in PDFs
- apply high-res export to KPI, disruption, and test reports

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2c76f848325832d1f27c62a7987