### PR TITLE
Revert initial plan completion label and show initial plan completed values

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -647,8 +647,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
             formatter: (v, ctx) => {
               const i = ctx.dataIndex;
               const plannedTotal = (plannedPI[i] || 0) + (plannedOther[i] || 0);
-              const initCompleted = initialCompleted[i] || 0;
-              return `${initCompleted} of ${plannedTotal}`;
+              return plannedTotal;
             }
           }
         },
@@ -668,7 +667,17 @@ function renderBoardCharts(displaySprints, allSprints, container) {
           borderColor: completedOtherColor,
           stack: 'completed',
           datalabels: {
-            display: false
+            display: true,
+            anchor: 'end',
+            align: 'top',
+            offset: -4,
+            color: '#000',
+            font: { weight: 'bold' },
+            formatter: (v, ctx) => {
+              const i = ctx.dataIndex;
+              const completedTotal = (completedPI[i] || 0) + (completedOther[i] || 0);
+              return completedTotal;
+            }
           }
         },
       ]


### PR DESCRIPTION
## Summary
- Restore data labels for "Initial Plan completed" so orange bar displays its value
- Keep KPI chart labels focused on planned totals

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b68ed4aa948325b0c433b4c8a3ddb4