### PR TITLE
Avoid double-counting on BF boards

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -202,6 +202,7 @@
       try {
         await Promise.all(boardNums.map(async boardNum => {
           const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
+          const isBfBoard = ['6347', '6390'].includes(String(boardNum));
           const resp = await fetch(url, { credentials: 'include' });
           let data = {};
           if (resp.ok) {
@@ -246,7 +247,7 @@
               const r = await fetch(surl, { credentials: 'include' });
               if (!r.ok) return;
               const d = await r.json();
-              const events = [];
+              let events = [];
               const collect = (arr, completed = false) => {
                 (arr || []).forEach(it => {
                   events.push({
@@ -262,6 +263,9 @@
               collect(d.contents.completedIssues, true);
               collect(d.contents.issuesNotCompletedInCurrentSprint, false);
               collect(d.contents.puntedIssues, false);
+              if (isBfBoard) {
+                events = events.filter(ev => ev.key && ev.key.startsWith('BF-'));
+              }
 
               const entry = data.velocityStatEntries?.[s.id] || {};
               let completed = entry.completed?.value || 0;
@@ -393,7 +397,14 @@
                 } catch (e) {}
               }));
 
-              if (!initiallyPlanned) {
+              if (isBfBoard) {
+                completed = events.filter(ev => ev.completed)
+                                   .reduce((sum, ev) => sum + ev.points, 0);
+                initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
+                                         .reduce((sum, ev) => sum + ev.points, 0);
+                completedSource = 'filtered events';
+                initiallyPlannedSource = 'filtered events';
+              } else if (!initiallyPlanned) {
                 initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
                                          .reduce((sum, ev) => sum + ev.points, 0);
                 initiallyPlannedSource = 'sum of events not added after start';

--- a/disruption.html
+++ b/disruption.html
@@ -36,6 +36,7 @@
       const sprintResp = await fetch(sprintUrl, { credentials: 'include' });
       const sprintData = sprintResp.ok ? await sprintResp.json() : { values: [] };
       const rows = [];
+      const isBfBoard = ['6347', '6390'].includes(String(boardNum));
       for (const sprint of (sprintData.values || [])) {
         const reportUrl = `https://${domain}/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId=${boardNum}&sprintId=${sprint.id}`;
         const reportResp = await fetch(reportUrl, { credentials: 'include' });
@@ -48,6 +49,7 @@
         ];
         for (const issue of issues) {
           const issueKey = issue.key;
+          if (isBfBoard && !issueKey.startsWith('BF-')) continue;
           const issueResp = await fetch(`https://${domain}/rest/api/3/issue/${issueKey}?fields=parent`, { credentials: 'include' });
           if (!issueResp.ok) continue;
           const issueData = await issueResp.json();

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -195,6 +195,7 @@
       try {
         await Promise.all(boardNums.map(async boardNum => {
           const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
+          const isBfBoard = ['6347', '6390'].includes(String(boardNum));
           const resp = await fetch(url, { credentials: 'include' });
           let data = {};
           if (resp.ok) {
@@ -239,7 +240,7 @@
               const r = await fetch(surl, { credentials: 'include' });
               if (!r.ok) return;
               const d = await r.json();
-              const events = [];
+              let events = [];
               const collect = (arr, completed = false) => {
                 (arr || []).forEach(it => {
                   events.push({
@@ -255,6 +256,9 @@
               collect(d.contents.completedIssues, true);
               collect(d.contents.issuesNotCompletedInCurrentSprint, false);
               collect(d.contents.puntedIssues, false);
+              if (isBfBoard) {
+                events = events.filter(ev => ev.key && ev.key.startsWith('BF-'));
+              }
 
               const entry = data.velocityStatEntries?.[s.id] || {};
               let completed = entry.completed?.value || 0;
@@ -386,7 +390,14 @@
                 } catch (e) {}
               }));
 
-              if (!initiallyPlanned) {
+              if (isBfBoard) {
+                completed = events.filter(ev => ev.completed)
+                                   .reduce((sum, ev) => sum + ev.points, 0);
+                initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
+                                         .reduce((sum, ev) => sum + ev.points, 0);
+                completedSource = 'filtered events';
+                initiallyPlannedSource = 'filtered events';
+              } else if (!initiallyPlanned) {
                 initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
                                          .reduce((sum, ev) => sum + ev.points, 0);
                 initiallyPlannedSource = 'sum of events not added after start';


### PR DESCRIPTION
## Summary
- Filter BF Team Papillon (6347) and BF Team Vlinder (6390) boards to only include BF-* issues
- Recompute initially planned and completed values from filtered events for these boards
- Apply the same BF-only filter in the standalone disruption page

## Testing
- ⚠️ `npm test` (no test script)
- ✅ `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b699d14b088325a9b65a4d61fd133d