### PR TITLE
Improve PDF chart image quality

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -835,12 +835,14 @@ function renderCharts(displaySprints, allSprints) {
     Logger.info('Disruption report rendered');
   }
 
-  function canvasToHighResDataURL(canvas, scale = 2) {
+  function canvasToHighResDataURL(canvas, scale = 4) {
     const tmp = document.createElement('canvas');
     tmp.width = canvas.width * scale;
     tmp.height = canvas.height * scale;
     const ctx = tmp.getContext('2d');
     ctx.scale(scale, scale);
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
     ctx.drawImage(canvas, 0, 0);
     return tmp.toDataURL('image/png');
   }

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -742,12 +742,14 @@ function renderCharts(displaySprints, allSprints) {
     Logger.info('Disruption report rendered');
   }
 
-  function canvasToHighResDataURL(canvas, scale = 2) {
+  function canvasToHighResDataURL(canvas, scale = 4) {
     const tmp = document.createElement('canvas');
     tmp.width = canvas.width * scale;
     tmp.height = canvas.height * scale;
     const ctx = tmp.getContext('2d');
     ctx.scale(scale, scale);
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
     ctx.drawImage(canvas, 0, 0);
     return tmp.toDataURL('image/png');
   }

--- a/test.html
+++ b/test.html
@@ -770,12 +770,14 @@ function renderCharts(displaySprints, allSprints) {
     Logger.info('Disruption report rendered');
   }
 
-  function canvasToHighResDataURL(canvas, scale = 2) {
+  function canvasToHighResDataURL(canvas, scale = 4) {
     const tmp = document.createElement('canvas');
     tmp.width = canvas.width * scale;
     tmp.height = canvas.height * scale;
     const ctx = tmp.getContext('2d');
     ctx.scale(scale, scale);
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
     ctx.drawImage(canvas, 0, 0);
     return tmp.toDataURL('image/png');
   }


### PR DESCRIPTION
## Summary
- Increase resolution of exported charts by upscaling canvas to 4x and enabling high quality smoothing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b69a4ff7f08325ba3ffd913e6a6437