### PR TITLE
Hide disabled legend items in PDF export

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -868,6 +868,18 @@ function renderCharts(displaySprints, allSprints) {
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
+    const charts = [piMixChart, completedChart, disruptionChart];
+    charts.forEach(ch => {
+      if (!ch) return;
+      const legend = ch.options.plugins?.legend || (ch.options.plugins.legend = {});
+      const labels = legend.labels || (legend.labels = {});
+      ch._origLegendFilter = labels.filter;
+      labels.filter = item => item.text && !item.hidden;
+      if (ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = true;
+      }
+      ch.update();
+    });
     const includePi = document.getElementById('includePi')?.checked;
     const includeDisruption = document.getElementById('includeDisruption')?.checked;
     const includeRating = document.getElementById('includeRating')?.checked;
@@ -906,6 +918,18 @@ function renderCharts(displaySprints, allSprints) {
     }
     const dateStr = new Date().toISOString().split('T')[0];
     pdf.save(`KPI_Report_${dateStr}.pdf`);
+    charts.forEach(ch => {
+      if (!ch) return;
+      const legendLabels = ch.options.plugins?.legend?.labels;
+      if (legendLabels) {
+        legendLabels.filter = ch._origLegendFilter;
+        delete ch._origLegendFilter;
+      }
+      if (ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = false;
+      }
+      ch.update();
+    });
   }
 
   document.getElementById('versionSelect').value = 'KPI_Report.html';

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -777,10 +777,15 @@ function renderCharts(displaySprints, allSprints) {
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
     const charts = [piMixChartInstance, completedChartInstance, disruptionChartInstance];
     charts.forEach(ch => {
-      if (ch && ch.options.plugins?.datalabels) {
+      if (!ch) return;
+      const legend = ch.options.plugins?.legend || (ch.options.plugins.legend = {});
+      const labels = legend.labels || (legend.labels = {});
+      ch._origLegendFilter = labels.filter;
+      labels.filter = item => item.text && !item.hidden;
+      if (ch.options.plugins?.datalabels) {
         ch.options.plugins.datalabels.display = true;
-        ch.update();
       }
+      ch.update();
     });
     const canvases = document.querySelectorAll('#chartSection canvas');
     const pageWidth = pdf.internal.pageSize.getWidth();
@@ -801,10 +806,16 @@ function renderCharts(displaySprints, allSprints) {
     const dateStr = new Date().toISOString().split('T')[0];
     pdf.save(`Disruption_Report_${dateStr}.pdf`);
     charts.forEach(ch => {
-      if (ch && ch.options.plugins?.datalabels) {
-        ch.options.plugins.datalabels.display = false;
-        ch.update();
+      if (!ch) return;
+      const legendLabels = ch.options.plugins?.legend?.labels;
+      if (legendLabels) {
+        legendLabels.filter = ch._origLegendFilter;
+        delete ch._origLegendFilter;
       }
+      if (ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = false;
+      }
+      ch.update();
     });
   }
 


### PR DESCRIPTION
## Summary
- Omit hidden datasets from legends during PDF export
- Restore original legend state after PDF generation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6b7001e148325ad0e96ddacbff535