### PR TITLE
Fix KPI Report PDF export

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -868,7 +868,7 @@ function renderCharts(displaySprints, allSprints) {
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
-    const charts = [piMixChart, completedChart, disruptionChart];
+    const charts = chartInstances;
     charts.forEach(ch => {
       if (!ch) return;
       const legend = ch.options.plugins?.legend || (ch.options.plugins.legend = {});


### PR DESCRIPTION
## Summary
- use existing chartInstances in KPI Report's exportPDF to avoid undefined reference errors

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b6ba7a0f0483258b50fb733efc6d89