### PR TITLE
Remove crossed-out legend entries in exported PDFs

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -874,7 +874,7 @@ function renderCharts(displaySprints, allSprints) {
       const legend = ch.options.plugins?.legend || (ch.options.plugins.legend = {});
       const labels = legend.labels || (legend.labels = {});
       ch._origLegendFilter = labels.filter;
-      labels.filter = item => item.text && !item.hidden;
+      labels.filter = item => item.text && ch.isDatasetVisible(item.datasetIndex);
       if (ch.options.plugins?.datalabels) {
         ch.options.plugins.datalabels.display = true;
       }

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -781,7 +781,7 @@ function renderCharts(displaySprints, allSprints) {
       const legend = ch.options.plugins?.legend || (ch.options.plugins.legend = {});
       const labels = legend.labels || (legend.labels = {});
       ch._origLegendFilter = labels.filter;
-      labels.filter = item => item.text && !item.hidden;
+      labels.filter = item => item.text && ch.isDatasetVisible(item.datasetIndex);
       if (ch.options.plugins?.datalabels) {
         ch.options.plugins.datalabels.display = true;
       }


### PR DESCRIPTION
## Summary
- Fix PDF export to exclude hidden datasets from chart legends

## Testing
- `node test/disruption.test.js && node test/epicLabelsConsole.test.js && node test/extractSprintKey.test.js && node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6bccfd8b4832581eb7068030b7259