### PR TITLE
Hide 'Initial Plan completed' legend in PDFs

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -669,7 +669,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
             }
           }
         },
-        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted', datalabels: {
+        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted', hidden: true, datalabels: {
             display: true,
             anchor: 'end',
             align: 'top',
@@ -866,12 +866,8 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function stripHiddenDatasets(chart) {
-    const legend = chart.options.plugins?.legend || (chart.options.plugins.legend = {});
-    const labels = legend.labels || (legend.labels = {});
-    chart._origLegendFilter = labels.filter;
-    labels.filter = item => chart.isDatasetVisible(item.datasetIndex);
     chart._origDatasets = chart.data.datasets;
-    chart.data.datasets = chart.data.datasets.filter((_, i) => chart.isDatasetVisible(i));
+    chart.data.datasets = chart.data.datasets.filter((ds, i) => chart.isDatasetVisible(i));
     const dl = chart.options.plugins?.datalabels;
     if (dl) {
       chart._origDataLabelDisplay = dl.display;
@@ -881,11 +877,6 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function restoreHiddenDatasets(chart) {
-    const legendLabels = chart.options.plugins?.legend?.labels;
-    if (legendLabels && chart._origLegendFilter !== undefined) {
-      legendLabels.filter = chart._origLegendFilter;
-      delete chart._origLegendFilter;
-    }
     if (chart._origDatasets) {
       chart.data.datasets = chart._origDatasets;
       delete chart._origDatasets;

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -631,7 +631,7 @@ function renderCharts(displaySprints, allSprints) {
       datasets: [
         { label: 'Initially Planned PI contributions', data: plannedPI, backgroundColor: plannedPIFill, borderColor: plannedPIColor, stack: 'planned' },
         { label: 'Initially Planned other', data: plannedOther, backgroundColor: plannedOtherFill, borderColor: plannedOtherColor, stack: 'planned' },
-        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted' },
+        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted', hidden: true },
         { label: 'Completed PI contributions', data: completedPI, backgroundColor: completedPIColor, borderColor: completedPIColor, stack: 'completed' },
         { label: 'Completed other', data: completedOther, backgroundColor: completedOtherColor, borderColor: completedOtherColor, stack: 'completed' },
       ]
@@ -773,12 +773,8 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function stripHiddenDatasets(chart) {
-    const legend = chart.options.plugins?.legend || (chart.options.plugins.legend = {});
-    const labels = legend.labels || (legend.labels = {});
-    chart._origLegendFilter = labels.filter;
-    labels.filter = item => chart.isDatasetVisible(item.datasetIndex);
     chart._origDatasets = chart.data.datasets;
-    chart.data.datasets = chart.data.datasets.filter((_, i) => chart.isDatasetVisible(i));
+    chart.data.datasets = chart.data.datasets.filter((ds, i) => chart.isDatasetVisible(i));
     const dl = chart.options.plugins?.datalabels;
     if (dl) {
       chart._origDataLabelDisplay = dl.display;
@@ -788,11 +784,6 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function restoreHiddenDatasets(chart) {
-    const legendLabels = chart.options.plugins?.legend?.labels;
-    if (legendLabels && chart._origLegendFilter !== undefined) {
-      legendLabels.filter = chart._origLegendFilter;
-      delete chart._origLegendFilter;
-    }
     if (chart._origDatasets) {
       chart.data.datasets = chart._origDatasets;
       delete chart._origDatasets;

--- a/test.html
+++ b/test.html
@@ -646,7 +646,7 @@ function renderCharts(displaySprints, allSprints) {
       datasets: [
         { label: 'Initially Planned PI contributions', data: plannedPI, backgroundColor: plannedPIFill, borderColor: plannedPIColor, stack: 'planned' },
         { label: 'Initially Planned other', data: plannedOther, backgroundColor: plannedOtherFill, borderColor: plannedOtherColor, stack: 'planned' },
-        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted' },
+        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted', hidden: true },
         { label: 'Completed PI contributions', data: completedPI, backgroundColor: completedPIColor, borderColor: completedPIColor, stack: 'completed' },
         { label: 'Completed other', data: completedOther, backgroundColor: completedOtherColor, borderColor: completedOtherColor, stack: 'completed' },
       ]
@@ -790,12 +790,8 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function stripHiddenDatasets(chart) {
-    const legend = chart.options.plugins?.legend || (chart.options.plugins.legend = {});
-    const labels = legend.labels || (legend.labels = {});
-    chart._origLegendFilter = labels.filter;
-    labels.filter = item => chart.isDatasetVisible(item.datasetIndex);
     chart._origDatasets = chart.data.datasets;
-    chart.data.datasets = chart.data.datasets.filter((_, i) => chart.isDatasetVisible(i));
+    chart.data.datasets = chart.data.datasets.filter((ds, i) => chart.isDatasetVisible(i));
     const dl = chart.options.plugins?.datalabels;
     if (dl) {
       chart._origDataLabelDisplay = dl.display;
@@ -805,11 +801,6 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function restoreHiddenDatasets(chart) {
-    const legendLabels = chart.options.plugins?.legend?.labels;
-    if (legendLabels && chart._origLegendFilter !== undefined) {
-      legendLabels.filter = chart._origLegendFilter;
-      delete chart._origLegendFilter;
-    }
     if (chart._origDatasets) {
       chart.data.datasets = chart._origDatasets;
       delete chart._origDatasets;


### PR DESCRIPTION
## Summary
- Drop hidden datasets from PDF exports so `Initial Plan completed` only disappears when it's hidden in the UI
- Restore default chart legend rendering in HTML pages

## Testing
- `npm run build:css` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c60c34648325b5a8f2a9dec3214b