### PR TITLE
Revert PDF export legend handling

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -669,7 +669,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
             }
           }
         },
-        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted', hidden: true, datalabels: {
+        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted', datalabels: {
             display: true,
             anchor: 'end',
             align: 'top',
@@ -866,8 +866,12 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function stripHiddenDatasets(chart) {
+    const legend = chart.options.plugins?.legend || (chart.options.plugins.legend = {});
+    const labels = legend.labels || (legend.labels = {});
+    chart._origLegendFilter = labels.filter;
+    labels.filter = item => chart.isDatasetVisible(item.datasetIndex);
     chart._origDatasets = chart.data.datasets;
-    chart.data.datasets = chart.data.datasets.filter((ds, i) => chart.isDatasetVisible(i));
+    chart.data.datasets = chart.data.datasets.filter((_, i) => chart.isDatasetVisible(i));
     const dl = chart.options.plugins?.datalabels;
     if (dl) {
       chart._origDataLabelDisplay = dl.display;
@@ -877,6 +881,11 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function restoreHiddenDatasets(chart) {
+    const legendLabels = chart.options.plugins?.legend?.labels;
+    if (legendLabels && chart._origLegendFilter !== undefined) {
+      legendLabels.filter = chart._origLegendFilter;
+      delete chart._origLegendFilter;
+    }
     if (chart._origDatasets) {
       chart.data.datasets = chart._origDatasets;
       delete chart._origDatasets;

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -631,7 +631,7 @@ function renderCharts(displaySprints, allSprints) {
       datasets: [
         { label: 'Initially Planned PI contributions', data: plannedPI, backgroundColor: plannedPIFill, borderColor: plannedPIColor, stack: 'planned' },
         { label: 'Initially Planned other', data: plannedOther, backgroundColor: plannedOtherFill, borderColor: plannedOtherColor, stack: 'planned' },
-        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted', hidden: true },
+        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted' },
         { label: 'Completed PI contributions', data: completedPI, backgroundColor: completedPIColor, borderColor: completedPIColor, stack: 'completed' },
         { label: 'Completed other', data: completedOther, backgroundColor: completedOtherColor, borderColor: completedOtherColor, stack: 'completed' },
       ]
@@ -773,8 +773,12 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function stripHiddenDatasets(chart) {
+    const legend = chart.options.plugins?.legend || (chart.options.plugins.legend = {});
+    const labels = legend.labels || (legend.labels = {});
+    chart._origLegendFilter = labels.filter;
+    labels.filter = item => chart.isDatasetVisible(item.datasetIndex);
     chart._origDatasets = chart.data.datasets;
-    chart.data.datasets = chart.data.datasets.filter((ds, i) => chart.isDatasetVisible(i));
+    chart.data.datasets = chart.data.datasets.filter((_, i) => chart.isDatasetVisible(i));
     const dl = chart.options.plugins?.datalabels;
     if (dl) {
       chart._origDataLabelDisplay = dl.display;
@@ -784,6 +788,11 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function restoreHiddenDatasets(chart) {
+    const legendLabels = chart.options.plugins?.legend?.labels;
+    if (legendLabels && chart._origLegendFilter !== undefined) {
+      legendLabels.filter = chart._origLegendFilter;
+      delete chart._origLegendFilter;
+    }
     if (chart._origDatasets) {
       chart.data.datasets = chart._origDatasets;
       delete chart._origDatasets;

--- a/test.html
+++ b/test.html
@@ -646,7 +646,7 @@ function renderCharts(displaySprints, allSprints) {
       datasets: [
         { label: 'Initially Planned PI contributions', data: plannedPI, backgroundColor: plannedPIFill, borderColor: plannedPIColor, stack: 'planned' },
         { label: 'Initially Planned other', data: plannedOther, backgroundColor: plannedOtherFill, borderColor: plannedOtherColor, stack: 'planned' },
-        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted', hidden: true },
+        { label: 'Initial Plan completed', data: initialCompleted, backgroundColor: initialCompletedColor, borderColor: initialCompletedColor, stack: 'initialCompleted' },
         { label: 'Completed PI contributions', data: completedPI, backgroundColor: completedPIColor, borderColor: completedPIColor, stack: 'completed' },
         { label: 'Completed other', data: completedOther, backgroundColor: completedOtherColor, borderColor: completedOtherColor, stack: 'completed' },
       ]
@@ -790,8 +790,12 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function stripHiddenDatasets(chart) {
+    const legend = chart.options.plugins?.legend || (chart.options.plugins.legend = {});
+    const labels = legend.labels || (legend.labels = {});
+    chart._origLegendFilter = labels.filter;
+    labels.filter = item => chart.isDatasetVisible(item.datasetIndex);
     chart._origDatasets = chart.data.datasets;
-    chart.data.datasets = chart.data.datasets.filter((ds, i) => chart.isDatasetVisible(i));
+    chart.data.datasets = chart.data.datasets.filter((_, i) => chart.isDatasetVisible(i));
     const dl = chart.options.plugins?.datalabels;
     if (dl) {
       chart._origDataLabelDisplay = dl.display;
@@ -801,6 +805,11 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function restoreHiddenDatasets(chart) {
+    const legendLabels = chart.options.plugins?.legend?.labels;
+    if (legendLabels && chart._origLegendFilter !== undefined) {
+      legendLabels.filter = chart._origLegendFilter;
+      delete chart._origLegendFilter;
+    }
     if (chart._origDatasets) {
       chart.data.datasets = chart._origDatasets;
       delete chart._origDatasets;


### PR DESCRIPTION
## Summary
- Revert merge of PR #268 that attempted to hide legends for 'Initial Plan completed' in PDFs
- Restore previous PDF export logic for KPI, disruption, and test reports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b6d38eaa6c8325b2a41fd320954910