### PR TITLE
Refine chart PDF export

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -865,44 +865,41 @@ function renderCharts(displaySprints, allSprints) {
     return tmp.toDataURL('image/png');
   }
 
-  function stripHiddenDatasets(chart) {
-    const legend = chart.options.plugins?.legend || (chart.options.plugins.legend = {});
-    const labels = legend.labels || (legend.labels = {});
-    chart._origLegendFilter = labels.filter;
-    labels.filter = item => chart.isDatasetVisible(item.datasetIndex);
-    chart._origDatasets = chart.data.datasets;
-    chart.data.datasets = chart.data.datasets.filter((_, i) => chart.isDatasetVisible(i));
-    const dl = chart.options.plugins?.datalabels;
-    if (dl) {
-      chart._origDataLabelDisplay = dl.display;
-      dl.display = true;
+  function chartToPdfImage(chart) {
+    const config = JSON.parse(JSON.stringify(chart.config));
+    const hidden = new Set();
+    if (config.data && Array.isArray(config.data.datasets)) {
+      config.data.datasets = config.data.datasets.filter(ds => {
+        if (ds.hiddenForPdf) {
+          hidden.add(ds.label);
+          return false;
+        }
+        return true;
+      });
     }
-    chart.update();
-  }
-
-  function restoreHiddenDatasets(chart) {
-    const legendLabels = chart.options.plugins?.legend?.labels;
-    if (legendLabels && chart._origLegendFilter !== undefined) {
-      legendLabels.filter = chart._origLegendFilter;
-      delete chart._origLegendFilter;
+    const legend = config.options?.plugins?.legend;
+    if (legend) {
+      const labels = legend.labels || (legend.labels = {});
+      const origFilter = labels.filter;
+      labels.filter = (item, data) => {
+        if (hidden.has(item.text)) return false;
+        return origFilter ? origFilter(item, data) : true;
+      };
     }
-    if (chart._origDatasets) {
-      chart.data.datasets = chart._origDatasets;
-      delete chart._origDatasets;
-    }
-    const dl = chart.options.plugins?.datalabels;
-    if (dl && chart._origDataLabelDisplay !== undefined) {
-      dl.display = chart._origDataLabelDisplay;
-      delete chart._origDataLabelDisplay;
-    }
-    chart.update();
+    const tmpCanvas = document.createElement('canvas');
+    tmpCanvas.width = chart.canvas.width;
+    tmpCanvas.height = chart.canvas.height;
+    const tmpChart = new Chart(tmpCanvas.getContext('2d'), config);
+    const img = canvasToHighResDataURL(tmpCanvas);
+    tmpChart.destroy();
+    tmpCanvas.remove();
+    return img;
   }
 
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
     const charts = chartInstances;
-    charts.forEach(ch => ch && stripHiddenDatasets(ch));
     const includePi = document.getElementById('includePi')?.checked;
     const includeDisruption = document.getElementById('includeDisruption')?.checked;
     const includeRating = document.getElementById('includeRating')?.checked;
@@ -935,13 +932,14 @@ function renderCharts(displaySprints, allSprints) {
         pdf.setFontSize(12);
         pdf.text(`${boardTitle} - ${chartTitleEl.textContent.trim()}`, margin, y);
         y += 14;
-        pdf.addImage(canvasToHighResDataURL(canvas), 'PNG', margin, y, width, height);
+        const chart = Chart.getChart(canvas);
+        const img = chart ? chartToPdfImage(chart) : canvasToHighResDataURL(canvas);
+        pdf.addImage(img, 'PNG', margin, y, width, height);
         y += height + 10;
       }
     }
     const dateStr = new Date().toISOString().split('T')[0];
     pdf.save(`KPI_Report_${dateStr}.pdf`);
-    charts.forEach(ch => ch && restoreHiddenDatasets(ch));
   }
 
   document.getElementById('versionSelect').value = 'KPI_Report.html';

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -772,51 +772,48 @@ function renderCharts(displaySprints, allSprints) {
     return tmp.toDataURL('image/png');
   }
 
-  function stripHiddenDatasets(chart) {
-    const legend = chart.options.plugins?.legend || (chart.options.plugins.legend = {});
-    const labels = legend.labels || (legend.labels = {});
-    chart._origLegendFilter = labels.filter;
-    labels.filter = item => chart.isDatasetVisible(item.datasetIndex);
-    chart._origDatasets = chart.data.datasets;
-    chart.data.datasets = chart.data.datasets.filter((_, i) => chart.isDatasetVisible(i));
-    const dl = chart.options.plugins?.datalabels;
-    if (dl) {
-      chart._origDataLabelDisplay = dl.display;
-      dl.display = true;
+  function chartToPdfImage(chart) {
+    const config = JSON.parse(JSON.stringify(chart.config));
+    const hidden = new Set();
+    if (config.data && Array.isArray(config.data.datasets)) {
+      config.data.datasets = config.data.datasets.filter(ds => {
+        if (ds.hiddenForPdf) {
+          hidden.add(ds.label);
+          return false;
+        }
+        return true;
+      });
     }
-    chart.update();
-  }
-
-  function restoreHiddenDatasets(chart) {
-    const legendLabels = chart.options.plugins?.legend?.labels;
-    if (legendLabels && chart._origLegendFilter !== undefined) {
-      legendLabels.filter = chart._origLegendFilter;
-      delete chart._origLegendFilter;
+    const legend = config.options?.plugins?.legend;
+    if (legend) {
+      const labels = legend.labels || (legend.labels = {});
+      const origFilter = labels.filter;
+      labels.filter = (item, data) => {
+        if (hidden.has(item.text)) return false;
+        return origFilter ? origFilter(item, data) : true;
+      };
     }
-    if (chart._origDatasets) {
-      chart.data.datasets = chart._origDatasets;
-      delete chart._origDatasets;
-    }
-    const dl = chart.options.plugins?.datalabels;
-    if (dl && chart._origDataLabelDisplay !== undefined) {
-      dl.display = chart._origDataLabelDisplay;
-      delete chart._origDataLabelDisplay;
-    }
-    chart.update();
+    const tmpCanvas = document.createElement('canvas');
+    tmpCanvas.width = chart.canvas.width;
+    tmpCanvas.height = chart.canvas.height;
+    const tmpChart = new Chart(tmpCanvas.getContext('2d'), config);
+    const img = canvasToHighResDataURL(tmpCanvas);
+    tmpChart.destroy();
+    tmpCanvas.remove();
+    return img;
   }
 
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
-    const charts = [piMixChartInstance, completedChartInstance, disruptionChartInstance];
-    charts.forEach(ch => ch && stripHiddenDatasets(ch));
-    const canvases = document.querySelectorAll('#chartSection canvas');
+    const charts = [piMixChartInstance, completedChartInstance, disruptionChartInstance].filter(Boolean);
     const pageWidth = pdf.internal.pageSize.getWidth();
     const pageHeight = pdf.internal.pageSize.getHeight();
     const margin = 20;
     let y = margin;
-    canvases.forEach(cv => {
-      const img = canvasToHighResDataURL(cv);
+    charts.forEach(ch => {
+      const cv = ch.canvas;
+      const img = chartToPdfImage(ch);
       const width = pageWidth - margin * 2;
       const height = cv.height * width / cv.width;
       if (y + height > pageHeight - margin) {
@@ -828,7 +825,6 @@ function renderCharts(displaySprints, allSprints) {
     });
     const dateStr = new Date().toISOString().split('T')[0];
     pdf.save(`Disruption_Report_${dateStr}.pdf`);
-    charts.forEach(ch => ch && restoreHiddenDatasets(ch));
   }
 
   document.getElementById('versionSelect').value = 'index_disruption.html';

--- a/index_topicmix.html
+++ b/index_topicmix.html
@@ -6,6 +6,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="public/tailwind.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <style>
     body { background:#f7f8fa; font-family:'Inter',Arial,sans-serif; margin:0;padding:0; }
     .main { max-width:950px; margin:30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
@@ -34,6 +35,9 @@
     <label>Select Sprint:
       <select id="sprintSelect"></select>
     </label>
+  </div>
+  <div style="margin-top:10px;">
+    <button class="btn" onclick="exportPDF()">Download PDF</button>
   </div>
   <div id="loadingMessage" style="display:none; font-weight:bold; margin:10px 0;"></div>
   <div id="chartSection" class="chart-section" style="display:none;">
@@ -232,6 +236,64 @@ function renderChart() {
     }
   });
   document.getElementById('chartSection').style.display = '';
+}
+
+function canvasToHighResDataURL(canvas, scale = 4) {
+  const tmp = document.createElement('canvas');
+  tmp.width = canvas.width * scale;
+  tmp.height = canvas.height * scale;
+  const ctx = tmp.getContext('2d');
+  ctx.scale(scale, scale);
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
+  ctx.drawImage(canvas, 0, 0);
+  return tmp.toDataURL('image/png');
+}
+
+function chartToPdfImage(chart) {
+  const config = JSON.parse(JSON.stringify(chart.config));
+  const hidden = new Set();
+  if (config.data && Array.isArray(config.data.datasets)) {
+    config.data.datasets = config.data.datasets.filter(ds => {
+      if (ds.hiddenForPdf) {
+        hidden.add(ds.label);
+        return false;
+      }
+      return true;
+    });
+  }
+  const legend = config.options?.plugins?.legend;
+  if (legend) {
+    const labels = legend.labels || (legend.labels = {});
+    const origFilter = labels.filter;
+    labels.filter = (item, data) => {
+      if (hidden.has(item.text)) return false;
+      return origFilter ? origFilter(item, data) : true;
+    };
+  }
+  const tmpCanvas = document.createElement('canvas');
+  tmpCanvas.width = chart.canvas.width;
+  tmpCanvas.height = chart.canvas.height;
+  const tmpChart = new Chart(tmpCanvas.getContext('2d'), config);
+  const img = canvasToHighResDataURL(tmpCanvas);
+  tmpChart.destroy();
+  tmpCanvas.remove();
+  return img;
+}
+
+function exportPDF() {
+  const { jsPDF } = window.jspdf;
+  const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
+  const chart = topicMixChartInstance;
+  if (!chart) { alert('No chart to export'); return; }
+  const pageWidth = pdf.internal.pageSize.getWidth();
+  const margin = 20;
+  const width = pageWidth - margin * 2;
+  const height = chart.canvas.height * width / chart.canvas.width;
+  const img = chartToPdfImage(chart);
+  pdf.addImage(img, 'PNG', margin, margin, width, height);
+  const dateStr = new Date().toISOString().split('T')[0];
+  pdf.save(`TopicMix_Report_${dateStr}.pdf`);
 }
 
 async function loadTopicMix() {


### PR DESCRIPTION
## Summary
- clone chart config and filter hidden datasets before generating PDF images
- rebuild export routines to render temporary charts and avoid legend/hidden data leakage
- add PDF export support for topic mix report with matching chart handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b6d9d4fdf883259951afddb9b36e96