### PR TITLE
Ensure charts render before PDF export

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -868,7 +868,7 @@ function renderCharts(displaySprints, allSprints) {
     return tmp.toDataURL('image/png');
   }
 
-  function chartToPdfImage(chart) {
+  async function chartToPdfImage(chart) {
     if (!chart?.canvas?.width || !chart?.canvas?.height) {
       return null;
     }
@@ -899,13 +899,18 @@ function renderCharts(displaySprints, allSprints) {
       return null;
     }
     const tmpChart = new Chart(tmpCanvas.getContext('2d'), config);
+    if (typeof tmpChart.render === 'function') {
+      await tmpChart.render();
+    } else {
+      await new Promise(r => requestAnimationFrame(r));
+    }
     const img = canvasToHighResDataURL(tmpCanvas);
     tmpChart.destroy();
     tmpCanvas.remove();
     return img;
   }
 
-  function exportPDF() {
+  async function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
     const charts = chartInstances;
@@ -945,7 +950,7 @@ function renderCharts(displaySprints, allSprints) {
         pdf.text(`${boardTitle} - ${chartTitleEl.textContent.trim()}`, margin, y);
         y += 14;
         const chart = Chart.getChart(canvas);
-        const img = chart ? chartToPdfImage(chart) : canvasToHighResDataURL(canvas);
+        const img = chart ? await chartToPdfImage(chart) : canvasToHighResDataURL(canvas);
         if (img) {
           pdf.addImage(img, 'PNG', margin, y, width, height);
           y += height + 10;

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -772,7 +772,7 @@ function renderCharts(displaySprints, allSprints) {
     return tmp.toDataURL('image/png');
   }
 
-  function chartToPdfImage(chart) {
+  async function chartToPdfImage(chart) {
     const config = JSON.parse(JSON.stringify(chart.config));
     const hidden = new Set();
     if (config.data && Array.isArray(config.data.datasets)) {
@@ -797,13 +797,18 @@ function renderCharts(displaySprints, allSprints) {
     tmpCanvas.width = chart.canvas.width;
     tmpCanvas.height = chart.canvas.height;
     const tmpChart = new Chart(tmpCanvas.getContext('2d'), config);
+    if (typeof tmpChart.render === 'function') {
+      await tmpChart.render();
+    } else {
+      await new Promise(r => requestAnimationFrame(r));
+    }
     const img = canvasToHighResDataURL(tmpCanvas);
     tmpChart.destroy();
     tmpCanvas.remove();
     return img;
   }
 
-  function exportPDF() {
+  async function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
     const charts = [piMixChartInstance, completedChartInstance, disruptionChartInstance].filter(Boolean);
@@ -811,9 +816,9 @@ function renderCharts(displaySprints, allSprints) {
     const pageHeight = pdf.internal.pageSize.getHeight();
     const margin = 20;
     let y = margin;
-    charts.forEach(ch => {
+    for (const ch of charts) {
       const cv = ch.canvas;
-      const img = chartToPdfImage(ch);
+      const img = await chartToPdfImage(ch);
       const width = pageWidth - margin * 2;
       const height = cv.height * width / cv.width;
       if (y + height > pageHeight - margin) {
@@ -822,7 +827,7 @@ function renderCharts(displaySprints, allSprints) {
       }
       pdf.addImage(img, 'PNG', margin, y, width, height);
       y += height + 10;
-    });
+    }
     const dateStr = new Date().toISOString().split('T')[0];
     pdf.save(`Disruption_Report_${dateStr}.pdf`);
   }

--- a/index_topicmix.html
+++ b/index_topicmix.html
@@ -250,7 +250,7 @@ function canvasToHighResDataURL(canvas, scale = 4) {
   return tmp.toDataURL('image/png');
 }
 
-function chartToPdfImage(chart) {
+async function chartToPdfImage(chart) {
   const config = JSON.parse(JSON.stringify(chart.config));
   const hidden = new Set();
   if (config.data && Array.isArray(config.data.datasets)) {
@@ -275,13 +275,18 @@ function chartToPdfImage(chart) {
   tmpCanvas.width = chart.canvas.width;
   tmpCanvas.height = chart.canvas.height;
   const tmpChart = new Chart(tmpCanvas.getContext('2d'), config);
+  if (typeof tmpChart.render === 'function') {
+    await tmpChart.render();
+  } else {
+    await new Promise(r => requestAnimationFrame(r));
+  }
   const img = canvasToHighResDataURL(tmpCanvas);
   tmpChart.destroy();
   tmpCanvas.remove();
   return img;
 }
 
-function exportPDF() {
+async function exportPDF() {
   const { jsPDF } = window.jspdf;
   const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
   const chart = topicMixChartInstance;
@@ -290,7 +295,7 @@ function exportPDF() {
   const margin = 20;
   const width = pageWidth - margin * 2;
   const height = chart.canvas.height * width / chart.canvas.width;
-  const img = chartToPdfImage(chart);
+  const img = await chartToPdfImage(chart);
   pdf.addImage(img, 'PNG', margin, margin, width, height);
   const dateStr = new Date().toISOString().split('T')[0];
   pdf.save(`TopicMix_Report_${dateStr}.pdf`);


### PR DESCRIPTION
## Summary
- Wait for charts to finish rendering before capturing images for PDF export
- Convert PDF export helpers to async/await across KPI, disruption, and topic mix reports

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b6dd30be0c8325bc5eae7cf84c100c