### PR TITLE
Revert recent PDF chart export changes

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -854,9 +854,6 @@ function renderCharts(displaySprints, allSprints) {
   }
 
   function canvasToHighResDataURL(canvas, scale = 4) {
-    if (!canvas.width || !canvas.height) {
-      return null;
-    }
     const tmp = document.createElement('canvas');
     tmp.width = canvas.width * scale;
     tmp.height = canvas.height * scale;
@@ -868,52 +865,21 @@ function renderCharts(displaySprints, allSprints) {
     return tmp.toDataURL('image/png');
   }
 
-  async function chartToPdfImage(chart) {
-    if (!chart?.canvas?.width || !chart?.canvas?.height) {
-      return null;
-    }
-    const config = JSON.parse(JSON.stringify(chart.config));
-    const hidden = new Set();
-    if (config.data && Array.isArray(config.data.datasets)) {
-      config.data.datasets = config.data.datasets.filter(ds => {
-        if (ds.hiddenForPdf) {
-          hidden.add(ds.label);
-          return false;
-        }
-        return true;
-      });
-    }
-    const legend = config.options?.plugins?.legend;
-    if (legend) {
-      const labels = legend.labels || (legend.labels = {});
-      const origFilter = labels.filter;
-      labels.filter = (item, data) => {
-        if (hidden.has(item.text)) return false;
-        return origFilter ? origFilter(item, data) : true;
-      };
-    }
-    const tmpCanvas = document.createElement('canvas');
-    tmpCanvas.width = chart.canvas.width;
-    tmpCanvas.height = chart.canvas.height;
-    if (!tmpCanvas.width || !tmpCanvas.height) {
-      return null;
-    }
-    const tmpChart = new Chart(tmpCanvas.getContext('2d'), config);
-    if (typeof tmpChart.render === 'function') {
-      await tmpChart.render();
-    } else {
-      await new Promise(r => requestAnimationFrame(r));
-    }
-    const img = canvasToHighResDataURL(tmpCanvas);
-    tmpChart.destroy();
-    tmpCanvas.remove();
-    return img;
-  }
-
-  async function exportPDF() {
+  function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
-    const charts = chartInstances;
+    const charts = [piMixChart, completedChart, disruptionChart];
+    charts.forEach(ch => {
+      if (!ch) return;
+      const legend = ch.options.plugins?.legend || (ch.options.plugins.legend = {});
+      const labels = legend.labels || (legend.labels = {});
+      ch._origLegendFilter = labels.filter;
+      labels.filter = item => item.text && !item.hidden;
+      if (ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = true;
+      }
+      ch.update();
+    });
     const includePi = document.getElementById('includePi')?.checked;
     const includeDisruption = document.getElementById('includeDisruption')?.checked;
     const includeRating = document.getElementById('includeRating')?.checked;
@@ -937,9 +903,6 @@ function renderCharts(displaySprints, allSprints) {
             (type === 'rating' && !includeRating)) {
           continue;
         }
-        if (!canvas.width || !canvas.height) {
-          continue;
-        }
         const width = pageWidth - margin * 2;
         const height = canvas.height * width / canvas.width;
         if (y + 14 + height > pageHeight - margin) {
@@ -949,16 +912,24 @@ function renderCharts(displaySprints, allSprints) {
         pdf.setFontSize(12);
         pdf.text(`${boardTitle} - ${chartTitleEl.textContent.trim()}`, margin, y);
         y += 14;
-        const chart = Chart.getChart(canvas);
-        const img = chart ? await chartToPdfImage(chart) : canvasToHighResDataURL(canvas);
-        if (img) {
-          pdf.addImage(img, 'PNG', margin, y, width, height);
-          y += height + 10;
-        }
+        pdf.addImage(canvasToHighResDataURL(canvas), 'PNG', margin, y, width, height);
+        y += height + 10;
       }
     }
     const dateStr = new Date().toISOString().split('T')[0];
     pdf.save(`KPI_Report_${dateStr}.pdf`);
+    charts.forEach(ch => {
+      if (!ch) return;
+      const legendLabels = ch.options.plugins?.legend?.labels;
+      if (legendLabels) {
+        legendLabels.filter = ch._origLegendFilter;
+        delete ch._origLegendFilter;
+      }
+      if (ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = false;
+      }
+      ch.update();
+    });
   }
 
   document.getElementById('versionSelect').value = 'KPI_Report.html';

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -772,53 +772,28 @@ function renderCharts(displaySprints, allSprints) {
     return tmp.toDataURL('image/png');
   }
 
-  async function chartToPdfImage(chart) {
-    const config = JSON.parse(JSON.stringify(chart.config));
-    const hidden = new Set();
-    if (config.data && Array.isArray(config.data.datasets)) {
-      config.data.datasets = config.data.datasets.filter(ds => {
-        if (ds.hiddenForPdf) {
-          hidden.add(ds.label);
-          return false;
-        }
-        return true;
-      });
-    }
-    const legend = config.options?.plugins?.legend;
-    if (legend) {
-      const labels = legend.labels || (legend.labels = {});
-      const origFilter = labels.filter;
-      labels.filter = (item, data) => {
-        if (hidden.has(item.text)) return false;
-        return origFilter ? origFilter(item, data) : true;
-      };
-    }
-    const tmpCanvas = document.createElement('canvas');
-    tmpCanvas.width = chart.canvas.width;
-    tmpCanvas.height = chart.canvas.height;
-    const tmpChart = new Chart(tmpCanvas.getContext('2d'), config);
-    if (typeof tmpChart.render === 'function') {
-      await tmpChart.render();
-    } else {
-      await new Promise(r => requestAnimationFrame(r));
-    }
-    const img = canvasToHighResDataURL(tmpCanvas);
-    tmpChart.destroy();
-    tmpCanvas.remove();
-    return img;
-  }
-
-  async function exportPDF() {
+  function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
-    const charts = [piMixChartInstance, completedChartInstance, disruptionChartInstance].filter(Boolean);
+    const charts = [piMixChartInstance, completedChartInstance, disruptionChartInstance];
+    charts.forEach(ch => {
+      if (!ch) return;
+      const legend = ch.options.plugins?.legend || (ch.options.plugins.legend = {});
+      const labels = legend.labels || (legend.labels = {});
+      ch._origLegendFilter = labels.filter;
+      labels.filter = item => item.text && !item.hidden;
+      if (ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = true;
+      }
+      ch.update();
+    });
+    const canvases = document.querySelectorAll('#chartSection canvas');
     const pageWidth = pdf.internal.pageSize.getWidth();
     const pageHeight = pdf.internal.pageSize.getHeight();
     const margin = 20;
     let y = margin;
-    for (const ch of charts) {
-      const cv = ch.canvas;
-      const img = await chartToPdfImage(ch);
+    canvases.forEach(cv => {
+      const img = canvasToHighResDataURL(cv);
       const width = pageWidth - margin * 2;
       const height = cv.height * width / cv.width;
       if (y + height > pageHeight - margin) {
@@ -827,9 +802,21 @@ function renderCharts(displaySprints, allSprints) {
       }
       pdf.addImage(img, 'PNG', margin, y, width, height);
       y += height + 10;
-    }
+    });
     const dateStr = new Date().toISOString().split('T')[0];
     pdf.save(`Disruption_Report_${dateStr}.pdf`);
+    charts.forEach(ch => {
+      if (!ch) return;
+      const legendLabels = ch.options.plugins?.legend?.labels;
+      if (legendLabels) {
+        legendLabels.filter = ch._origLegendFilter;
+        delete ch._origLegendFilter;
+      }
+      if (ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = false;
+      }
+      ch.update();
+    });
   }
 
   document.getElementById('versionSelect').value = 'index_disruption.html';

--- a/index_topicmix.html
+++ b/index_topicmix.html
@@ -6,7 +6,6 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="public/tailwind.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <style>
     body { background:#f7f8fa; font-family:'Inter',Arial,sans-serif; margin:0;padding:0; }
     .main { max-width:950px; margin:30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
@@ -35,9 +34,6 @@
     <label>Select Sprint:
       <select id="sprintSelect"></select>
     </label>
-  </div>
-  <div style="margin-top:10px;">
-    <button class="btn" onclick="exportPDF()">Download PDF</button>
   </div>
   <div id="loadingMessage" style="display:none; font-weight:bold; margin:10px 0;"></div>
   <div id="chartSection" class="chart-section" style="display:none;">
@@ -236,69 +232,6 @@ function renderChart() {
     }
   });
   document.getElementById('chartSection').style.display = '';
-}
-
-function canvasToHighResDataURL(canvas, scale = 4) {
-  const tmp = document.createElement('canvas');
-  tmp.width = canvas.width * scale;
-  tmp.height = canvas.height * scale;
-  const ctx = tmp.getContext('2d');
-  ctx.scale(scale, scale);
-  ctx.imageSmoothingEnabled = true;
-  ctx.imageSmoothingQuality = 'high';
-  ctx.drawImage(canvas, 0, 0);
-  return tmp.toDataURL('image/png');
-}
-
-async function chartToPdfImage(chart) {
-  const config = JSON.parse(JSON.stringify(chart.config));
-  const hidden = new Set();
-  if (config.data && Array.isArray(config.data.datasets)) {
-    config.data.datasets = config.data.datasets.filter(ds => {
-      if (ds.hiddenForPdf) {
-        hidden.add(ds.label);
-        return false;
-      }
-      return true;
-    });
-  }
-  const legend = config.options?.plugins?.legend;
-  if (legend) {
-    const labels = legend.labels || (legend.labels = {});
-    const origFilter = labels.filter;
-    labels.filter = (item, data) => {
-      if (hidden.has(item.text)) return false;
-      return origFilter ? origFilter(item, data) : true;
-    };
-  }
-  const tmpCanvas = document.createElement('canvas');
-  tmpCanvas.width = chart.canvas.width;
-  tmpCanvas.height = chart.canvas.height;
-  const tmpChart = new Chart(tmpCanvas.getContext('2d'), config);
-  if (typeof tmpChart.render === 'function') {
-    await tmpChart.render();
-  } else {
-    await new Promise(r => requestAnimationFrame(r));
-  }
-  const img = canvasToHighResDataURL(tmpCanvas);
-  tmpChart.destroy();
-  tmpCanvas.remove();
-  return img;
-}
-
-async function exportPDF() {
-  const { jsPDF } = window.jspdf;
-  const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
-  const chart = topicMixChartInstance;
-  if (!chart) { alert('No chart to export'); return; }
-  const pageWidth = pdf.internal.pageSize.getWidth();
-  const margin = 20;
-  const width = pageWidth - margin * 2;
-  const height = chart.canvas.height * width / chart.canvas.width;
-  const img = await chartToPdfImage(chart);
-  pdf.addImage(img, 'PNG', margin, margin, width, height);
-  const dateStr = new Date().toISOString().split('T')[0];
-  pdf.save(`TopicMix_Report_${dateStr}.pdf`);
 }
 
 async function loadTopicMix() {

--- a/test.html
+++ b/test.html
@@ -789,44 +789,16 @@ function renderCharts(displaySprints, allSprints) {
     return tmp.toDataURL('image/png');
   }
 
-  function stripHiddenDatasets(chart) {
-    const legend = chart.options.plugins?.legend || (chart.options.plugins.legend = {});
-    const labels = legend.labels || (legend.labels = {});
-    chart._origLegendFilter = labels.filter;
-    labels.filter = item => chart.isDatasetVisible(item.datasetIndex);
-    chart._origDatasets = chart.data.datasets;
-    chart.data.datasets = chart.data.datasets.filter((_, i) => chart.isDatasetVisible(i));
-    const dl = chart.options.plugins?.datalabels;
-    if (dl) {
-      chart._origDataLabelDisplay = dl.display;
-      dl.display = true;
-    }
-    chart.update();
-  }
-
-  function restoreHiddenDatasets(chart) {
-    const legendLabels = chart.options.plugins?.legend?.labels;
-    if (legendLabels && chart._origLegendFilter !== undefined) {
-      legendLabels.filter = chart._origLegendFilter;
-      delete chart._origLegendFilter;
-    }
-    if (chart._origDatasets) {
-      chart.data.datasets = chart._origDatasets;
-      delete chart._origDatasets;
-    }
-    const dl = chart.options.plugins?.datalabels;
-    if (dl && chart._origDataLabelDisplay !== undefined) {
-      dl.display = chart._origDataLabelDisplay;
-      delete chart._origDataLabelDisplay;
-    }
-    chart.update();
-  }
-
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
     const charts = [piMixChartInstance, completedChartInstance, disruptionChartInstance];
-    charts.forEach(ch => ch && stripHiddenDatasets(ch));
+    charts.forEach(ch => {
+      if (ch && ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = true;
+        ch.update();
+      }
+    });
     const canvases = document.querySelectorAll('#chartSection canvas');
     const pageWidth = pdf.internal.pageSize.getWidth();
     const pageHeight = pdf.internal.pageSize.getHeight();
@@ -845,7 +817,12 @@ function renderCharts(displaySprints, allSprints) {
     });
     const dateStr = new Date().toISOString().split('T')[0];
     pdf.save(`Disruption_Report_${dateStr}.pdf`);
-    charts.forEach(ch => ch && restoreHiddenDatasets(ch));
+    charts.forEach(ch => {
+      if (ch && ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = false;
+        ch.update();
+      }
+    });
   }
 
   document.getElementById('versionSelect').value = 'index_disruption.html';


### PR DESCRIPTION
## Summary
- Revert fixes and features related to chart PDF export, returning KPI_Report and related pages to their previous state.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6e0989250832585be6d6e08e5c5f8