### PR TITLE
Fix exportPDF reference to undefined piMixChart

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -868,7 +868,7 @@ function renderCharts(displaySprints, allSprints) {
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
-    const charts = [piMixChart, completedChart, disruptionChart];
+    const charts = [...chartInstances];
     charts.forEach(ch => {
       if (!ch) return;
       const legend = ch.options.plugins?.legend || (ch.options.plugins.legend = {});


### PR DESCRIPTION
## Summary
- avoid ReferenceError by using `chartInstances` when exporting PDF charts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b6e2693934832598ad45f8765fa9a1