### PR TITLE
Handle type change disruptions

### DIFF
--- a/src/disruption.js
+++ b/src/disruption.js
@@ -22,12 +22,15 @@
       pulledIn: 0,
       blockedDays: 0,
       movedOut: 0,
+      typeChanged: 0,
       pulledInIssues: new Set(),
       blockedIssues: new Set(),
       movedOutIssues: new Set(),
+      typeChangedIssues: new Set(),
       pulledInCount: 0,
       blockedCount: 0,
-      movedOutCount: 0
+      movedOutCount: 0,
+      typeChangedCount: 0
     };
 
     // Track which categories each issue has already contributed to so the same
@@ -64,16 +67,24 @@
         metrics.movedOutIssues.add(ev.key);
         rec.movedOut = true;
       }
+
+      if (ev.typeChanged && !rec.typeChanged) {
+        metrics.typeChanged += pts;
+        metrics.typeChangedIssues.add(ev.key);
+        rec.typeChanged = true;
+      }
     });
 
     metrics.pulledInCount = metrics.pulledInIssues.size;
     metrics.blockedCount = metrics.blockedIssues.size;
     metrics.movedOutCount = metrics.movedOutIssues.size;
+    metrics.typeChangedCount = metrics.typeChangedIssues.size;
 
     // Convert sets back to arrays for downstream consumers
     metrics.pulledInIssues = Array.from(metrics.pulledInIssues);
     metrics.blockedIssues = Array.from(metrics.blockedIssues);
     metrics.movedOutIssues = Array.from(metrics.movedOutIssues);
+    metrics.typeChangedIssues = Array.from(metrics.typeChangedIssues);
 
     logger.debug('Calculated metrics', metrics);
     return metrics;

--- a/test/disruption.test.js
+++ b/test/disruption.test.js
@@ -28,4 +28,17 @@ const { calculateDisruptionMetrics } = require('../src/disruption');
   assert.deepStrictEqual(metrics.movedOutIssues, ['ST-3']);
 })();
 
+// Test typeChanged issues contribute correctly and are de-duplicated
+(() => {
+  const events = [
+    { key: 'ST-4', points: 3, typeChanged: true },
+    { key: 'ST-4', points: 3, typeChanged: true },
+    { key: 'ST-5', points: 8, typeChanged: true }
+  ];
+  const metrics = calculateDisruptionMetrics(events);
+  assert.strictEqual(metrics.typeChanged, 11);
+  assert.strictEqual(metrics.typeChangedCount, 2);
+  assert.deepStrictEqual(metrics.typeChangedIssues.sort(), ['ST-4', 'ST-5']);
+})();
+
 console.log('disruption tests passed');


### PR DESCRIPTION
## Summary
- add type change metrics to disruption calculation to prevent undefined arrays
- verify that type changed issues are counted and deduped in metrics

## Testing
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b82a38ec948325b78e9d6b5fb274bc