### PR TITLE
Filter BF boards to BF-only issues

### DIFF
--- a/test.html
+++ b/test.html
@@ -206,6 +206,7 @@
       try {
         await Promise.all(boardNums.map(async boardNum => {
           const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
+          const isBfBoard = ['6347', '6390'].includes(String(boardNum));
           const resp = await fetch(url, { credentials: 'include' });
           let data = {};
           if (resp.ok) {
@@ -250,7 +251,7 @@
               const r = await fetch(surl, { credentials: 'include' });
               if (!r.ok) return;
               const d = await r.json();
-              const events = [];
+              let events = [];
               const collect = (arr, completed = false) => {
                 (arr || []).forEach(it => {
                   events.push({
@@ -272,6 +273,10 @@
                   events.push({ key: k, points: 0, addedAfterStart: false, blocked: false, movedOut: true, completed: false });
                 }
               });
+
+              if (isBfBoard) {
+                events = events.filter(ev => ev.key && ev.key.startsWith('BF-'));
+              }
 
               const entry = data.velocityStatEntries?.[s.id] || {};
               let completed = entry.completed?.value || 0;


### PR DESCRIPTION
## Summary
- Limit Papillon (6347) and Vlinder (6390) boards to BF-ticket data when generating disruption metrics

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b850577134832588f18108bac0f92b