### PR TITLE
Use sprint-close story points for completed metrics

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -369,6 +369,21 @@
                     ev.cycleTime = Kpis.calculateWorkDays(devStart, new Date(resolutionDate));
                   }
 
+                  let pointsAtClose = ev.points || 0;
+                  if (sprintEnd) {
+                    for (const h of sortedHist) {
+                      const date = new Date(h.created);
+                      if (date > sprintEnd) break;
+                      for (const item of h.items || []) {
+                        if (item.field === 'Story Points' || item.field === 'Story point estimate') {
+                          const val = Number(item.toString || item.to);
+                          if (!isNaN(val)) pointsAtClose = val;
+                        }
+                      }
+                    }
+                  }
+                  ev.completedPoints = pointsAtClose;
+
                   for (const h of histories) {
                     const chDate = new Date(h.created);
                     if (sprintStart && chDate >= sprintStart) {
@@ -400,10 +415,10 @@
               }));
 
               const completed = events.filter(ev => ev.completed && !ev.movedOut)
-                                      .reduce((sum, ev) => sum + ev.points, 0);
+                                      .reduce((sum, ev) => sum + (ev.completedPoints ?? ev.points), 0);
               const initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
                                             .reduce((sum, ev) => sum + ev.points, 0);
-              const completedSource = 'sum of completed events (excluding moved out)';
+              const completedSource = 'sum of completed events at sprint close (excluding moved out)';
               const initiallyPlannedSource = 'sum of events not added after start';
 
               const key = `${boardNum}-${s.id}`;
@@ -502,8 +517,9 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const blockedCount = metricsArr.map(m => m.blockedCount || 0);
   const movedOutCount = metricsArr.map(m => m.movedOutCount || 0);
 
-  function sumSP(events, pred) {
-    return (events || []).reduce((sum, ev) => sum + (pred(ev) ? (ev.points || 0) : 0), 0);
+  function sumSP(events, pred, useCompleted = false) {
+    return (events || []).reduce((sum, ev) =>
+      sum + (pred(ev) ? (useCompleted ? (ev.completedPoints ?? ev.points || 0) : (ev.points || 0)) : 0), 0);
   }
   const plannedPI = displaySprints.map(s =>
     sumSP(s.events, ev => !ev.addedAfterStart && !ev.movedOut && ev.piRelevant)
@@ -512,7 +528,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
     Math.max(0, (s.initiallyPlanned || 0) - plannedPI[i])
   );
   const completedPI = displaySprints.map(s =>
-    sumSP(s.events, ev => ev.completed && ev.piRelevant)
+    sumSP(s.events, ev => ev.completed && ev.piRelevant, true)
   );
   const completedOther = displaySprints.map((s, i) =>
     Math.max(0, (s.completed || 0) - completedPI[i])
@@ -521,7 +537,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const initialCompleted = displaySprints.map(s =>
     (s.events || [])
       .filter(ev => !ev.addedAfterStart && !ev.movedOut && ev.completed)
-      .reduce((sum, ev) => sum + (ev.points || 0), 0)
+      .reduce((sum, ev) => sum + (ev.completedPoints ?? ev.points || 0), 0)
   );
 
   const throughputPerSprint = displaySprints.map(s =>

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -368,6 +368,21 @@
                     ev.cycleTime = Kpis.calculateWorkDays(devStart, new Date(resolutionDate));
                   }
 
+                  let pointsAtClose = ev.points || 0;
+                  if (sprintEnd) {
+                    for (const h of sortedHist) {
+                      const date = new Date(h.created);
+                      if (date > sprintEnd) break;
+                      for (const item of h.items || []) {
+                        if (item.field === 'Story Points' || item.field === 'Story point estimate') {
+                          const val = Number(item.toString || item.to);
+                          if (!isNaN(val)) pointsAtClose = val;
+                        }
+                      }
+                    }
+                  }
+                  ev.completedPoints = pointsAtClose;
+
                   for (const h of histories) {
                     const chDate = new Date(h.created);
                     if (sprintStart && chDate >= sprintStart) {
@@ -399,10 +414,10 @@
               }));
 
               const completed = events.filter(ev => ev.completed && !ev.movedOut)
-                                      .reduce((sum, ev) => sum + ev.points, 0);
+                                      .reduce((sum, ev) => sum + (ev.completedPoints ?? ev.points), 0);
               const initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
                                             .reduce((sum, ev) => sum + ev.points, 0);
-              const completedSource = 'sum of completed events (excluding moved out)';
+              const completedSource = 'sum of completed events at sprint close (excluding moved out)';
               const initiallyPlannedSource = 'sum of events not added after start';
               const key = `${boardNum}-${s.id}`;
               const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
@@ -500,8 +515,9 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const blockedCount = metricsArr.map(m => m.blockedCount || 0);
   const movedOutCount = metricsArr.map(m => m.movedOutCount || 0);
 
-  function sumSP(events, pred) {
-    return (events || []).reduce((sum, ev) => sum + (pred(ev) ? (ev.points || 0) : 0), 0);
+  function sumSP(events, pred, useCompleted = false) {
+    return (events || []).reduce((sum, ev) =>
+      sum + (pred(ev) ? (useCompleted ? (ev.completedPoints ?? ev.points || 0) : (ev.points || 0)) : 0), 0);
   }
   const plannedPI = displaySprints.map(s =>
     sumSP(s.events, ev => !ev.addedAfterStart && !ev.movedOut && ev.piRelevant)
@@ -510,7 +526,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
     Math.max(0, (s.initiallyPlanned || 0) - plannedPI[i])
   );
   const completedPI = displaySprints.map(s =>
-    sumSP(s.events, ev => ev.completed && ev.piRelevant)
+    sumSP(s.events, ev => ev.completed && ev.piRelevant, true)
   );
   const completedOther = displaySprints.map((s, i) =>
     Math.max(0, (s.completed || 0) - completedPI[i])


### PR DESCRIPTION
## Summary
- Compute story points at sprint close for each issue using changelog
- Sum completed story points with these values in KPI reports

## Testing
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/extractSprintKey.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b950e4b1308325bfbb3428e1298c7f