### PR TITLE
Include moved-out issues in planned story points

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -554,7 +554,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
 
   }
   const plannedPI = displaySprints.map(s =>
-    sumSP(s.events, ev => !ev.addedAfterStart && !ev.movedOut && ev.piRelevant, 'initialPoints')
+    sumSP(s.events, ev => !ev.addedAfterStart && ev.piRelevant, 'initialPoints')
   );
   const plannedOther = displaySprints.map((s, i) =>
     Math.max(0, (s.initiallyPlanned || 0) - plannedPI[i])

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -552,7 +552,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
 
   }
   const plannedPI = displaySprints.map(s =>
-    sumSP(s.events, ev => !ev.addedAfterStart && !ev.movedOut && ev.piRelevant, 'initialPoints')
+    sumSP(s.events, ev => !ev.addedAfterStart && ev.piRelevant, 'initialPoints')
   );
   const plannedOther = displaySprints.map((s, i) =>
     Math.max(0, (s.initiallyPlanned || 0) - plannedPI[i])


### PR DESCRIPTION
## Summary
- Ensure PI planned totals include issues moved out of the sprint
- Match KPI and no-initial variants when calculating planned story points

## Testing
- `node test/disruption.test.js && node test/epicLabelsConsole.test.js && node test/extractSprintKey.test.js && node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9543a94908325a2fffff54e99c1ca