### PR TITLE
Include moved-out non-PI issues in planned totals

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -556,8 +556,8 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const plannedPI = displaySprints.map(s =>
     sumSP(s.events, ev => !ev.addedAfterStart && ev.piRelevant, 'initialPoints')
   );
-  const plannedOther = displaySprints.map((s, i) =>
-    Math.max(0, (s.initiallyPlanned || 0) - plannedPI[i])
+  const plannedOther = displaySprints.map(s =>
+    sumSP(s.events, ev => !ev.addedAfterStart && !ev.piRelevant, 'initialPoints')
   );
   const completedPI = displaySprints.map(s =>
     sumSP(s.events, ev => ev.completed && ev.piRelevant, true)

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -554,8 +554,8 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const plannedPI = displaySprints.map(s =>
     sumSP(s.events, ev => !ev.addedAfterStart && ev.piRelevant, 'initialPoints')
   );
-  const plannedOther = displaySprints.map((s, i) =>
-    Math.max(0, (s.initiallyPlanned || 0) - plannedPI[i])
+  const plannedOther = displaySprints.map(s =>
+    sumSP(s.events, ev => !ev.addedAfterStart && !ev.piRelevant, 'initialPoints')
   );
   const completedPI = displaySprints.map(s =>
     sumSP(s.events, ev => ev.completed && ev.piRelevant, true)


### PR DESCRIPTION
## Summary
- Ensure initially planned totals include non-PI issues moved out of sprints

## Testing
- `node test/extractSprintKey.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9570c1570832581c9d30ebaa4acce