### PR TITLE
Account for stories moved out of sprint

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -263,7 +263,10 @@
               collect(d.contents.completedIssues, true);
               collect(d.contents.issuesNotCompletedInCurrentSprint, false);
               collect(d.contents.puntedIssues, false);
-              (d.contents.issueKeysRemovedFromSprint || []).forEach(k => {
+              // Include issues that were removed from the sprint. These appear only as
+              // keys in the sprint report, so convert them into events so they are
+              // fetched and processed like other issues.
+              (d.contents?.issueKeysRemovedFromSprint || []).forEach(k => {
                 if (!k) return;
                 const existing = events.find(e => e.key === k);
                 if (existing) {

--- a/disruption.html
+++ b/disruption.html
@@ -47,6 +47,12 @@
           ...(reportData.contents?.issuesNotCompletedInCurrentSprint || []),
           ...(reportData.contents?.puntedIssues || [])
         ];
+        // Include issues that were removed from the sprint. These appear only as
+        // keys in the sprint report, so convert them to issue objects to reuse
+        // the same processing logic below.
+        (reportData.contents?.issueKeysRemovedFromSprint || []).forEach(key => {
+          if (key) issues.push({ key });
+        });
         for (const issue of issues) {
           const issueKey = issue.key;
           if (isBfBoard && !issueKey.startsWith('BF-')) continue;

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -263,7 +263,10 @@
               collect(d.contents.completedIssues, true);
               collect(d.contents.issuesNotCompletedInCurrentSprint, false);
               collect(d.contents.puntedIssues, false);
-              (d.contents.issueKeysRemovedFromSprint || []).forEach(k => {
+              // Include issues that were removed from the sprint. These appear only as
+              // keys in the sprint report, so convert them into events so they are
+              // fetched and processed like other issues.
+              (d.contents?.issueKeysRemovedFromSprint || []).forEach(k => {
                 if (!k) return;
                 const existing = events.find(e => e.key === k);
                 if (existing) {


### PR DESCRIPTION
## Summary
- include issues removed from a sprint in parent-label disruption report

## Testing
- `node test/disruption.test.js && node test/piPlanVsCompleteChart.test.js && node test/epicLabelsConsole.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b95d78e10083259a788dd6459e9558