### PR TITLE
Fix planned story points calculation in KPI reports

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -303,7 +303,7 @@
                     ev.blocked = ev.blocked || !!(id.fields?.flagged && id.fields.flagged.length);
                     ev.blocked = ev.blocked || currentStatus.toLowerCase().includes('block');
                     // Determine story points at sprint start
-                    let initialPoints = 0;
+                    let initialPoints = ev.points || 0;
                     if (histories && sprintStart) {
                       const sortedHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
                       for (const h of sortedHist) {
@@ -317,8 +317,6 @@
                           }
                         }
                       }
-                    } else {
-                      initialPoints = ev.points || 0;
                     }
                     ev.initialPoints = initialPoints;
                     piRelevant = false;

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -302,7 +302,7 @@
                     ev.blocked = ev.blocked || !!(id.fields?.flagged && id.fields.flagged.length);
                     ev.blocked = ev.blocked || currentStatus.toLowerCase().includes('block');
                     // Determine story points at sprint start
-                    let initialPoints = 0;
+                    let initialPoints = ev.points || 0;
                     if (histories && sprintStart) {
                       const sortedHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
                       for (const h of sortedHist) {
@@ -316,8 +316,6 @@
                           }
                         }
                       }
-                    } else {
-                      initialPoints = ev.points || 0;
                     }
                     ev.initialPoints = initialPoints;
                     piRelevant = false;


### PR DESCRIPTION
## Summary
- ensure KPI reports count story points for issues present at sprint start even if incomplete

## Testing
- `for f in test/*.test.js; do node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68b95e1c7bec8325be9c672851e03031