### PR TITLE
Fix completed PI contribution display in KPI report charts

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -547,7 +547,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
     return (events || []).reduce((sum, ev) => {
       if (!pred(ev)) return sum;
       let val = ev[field];
-      if (field === 'initialPoints' && (val === undefined || val === null)) {
+      if ((field === 'initialPoints' || field === 'completedPoints') && (val === undefined || val === null)) {
         val = ev.points;
       }
       return sum + (val || 0);
@@ -561,7 +561,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
     sumSP(s.events, ev => !ev.addedAfterStart && !ev.piRelevant, 'initialPoints')
   );
   const completedPI = displaySprints.map(s =>
-    sumSP(s.events, ev => ev.completed && ev.piRelevant, true)
+    sumSP(s.events, ev => ev.completed && ev.piRelevant, 'completedPoints')
   );
   const completedOther = displaySprints.map((s, i) =>
     Math.max(0, (s.completed || 0) - completedPI[i])

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -546,7 +546,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
     return (events || []).reduce((sum, ev) => {
       if (!pred(ev)) return sum;
       let val = ev[field];
-      if (field === 'initialPoints' && (val === undefined || val === null)) {
+      if ((field === 'initialPoints' || field === 'completedPoints') && (val === undefined || val === null)) {
         val = ev.points;
       }
       return sum + (val || 0);
@@ -560,7 +560,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
     sumSP(s.events, ev => !ev.addedAfterStart && !ev.piRelevant, 'initialPoints')
   );
   const completedPI = displaySprints.map(s =>
-    sumSP(s.events, ev => ev.completed && ev.piRelevant, true)
+    sumSP(s.events, ev => ev.completed && ev.piRelevant, 'completedPoints')
   );
   const completedOther = displaySprints.map((s, i) =>
     Math.max(0, (s.completed || 0) - completedPI[i])


### PR DESCRIPTION
## Summary
- ensure completed PI contributions chart uses story points
- normalize sumSP helper to fall back to `points` for completed points

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b962a3a61483258cf3cc2a870b890d