### PR TITLE
Handle sprint removals in timeline

### DIFF
--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -94,9 +94,10 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
         if (fromId !== undefined) {
           sprintChanges.push({ at: new Date(at.getTime() - 1), sprintId: fromId });
         }
-        if (toId !== undefined) {
-          sprintChanges.push({ at, sprintId: toId });
-        }
+        // Always record the target sprint change even if `to` is empty or null.
+        // This ensures we capture when an issue is removed from a sprint so that
+        // later lookups know the issue is no longer assigned to any sprint.
+        sprintChanges.push({ at, sprintId: toId });
       });
     const statusChanges = (issue.changelog || [])
       .filter(c => c.field === 'Status')

--- a/test/piPlanVsCompleteChart.test.js
+++ b/test/piPlanVsCompleteChart.test.js
@@ -51,6 +51,16 @@ const assert = require('assert');
         { field: 'Sprint', from: '', to: '2', at: '2023-12-30' },
         { field: 'Status', from: 'To Do', to: 'In Progress', at: '2024-01-10' }
       ]
+    },
+    {
+      team: 'ALL',
+      product: 'ALL',
+      storyPoints: 13,
+      epicLabels: ['2024_PI1_committed'],
+      changelog: [
+        { field: 'Sprint', from: '', to: '1', at: '2023-12-15' },
+        { field: 'Sprint', from: '1', to: '', at: '2023-12-25' }
+      ]
     }
   ];
 


### PR DESCRIPTION
## Summary
- Always record sprint field changes even when the target sprint is empty to capture removals
- Add regression test ensuring stories removed before a sprint are not counted as planned

## Testing
- `for f in test/*.test.js; do node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68b9698650fc8325a75dbc67d9d0a751