### PR TITLE
Fix initial plan metrics for pulled-in issues

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -447,6 +447,23 @@
               existing.board = boardNum;
               existing.startDate = existing.startDate || s.startDate;
               existing.events = existing.events.concat(events);
+              const merged = {};
+              existing.events.forEach(ev => {
+                if (!ev || !ev.key) return;
+                const cur = merged[ev.key] || {};
+                cur.key = ev.key;
+                cur.points = cur.points || ev.points;
+                cur.initialPoints = ev.initialPoints ?? cur.initialPoints;
+                cur.completedPoints = ev.completedPoints ?? cur.completedPoints;
+                cur.addedAfterStart = cur.addedAfterStart || ev.addedAfterStart;
+                cur.blocked = cur.blocked || ev.blocked;
+                cur.blockedDays = Math.max(cur.blockedDays || 0, ev.blockedDays || 0);
+                cur.movedOut = cur.movedOut || ev.movedOut;
+                cur.completed = cur.completed || ev.completed;
+                cur.piRelevant = cur.piRelevant || ev.piRelevant;
+                merged[ev.key] = cur;
+              });
+              existing.events = Object.values(merged);
               existing.initiallyPlanned = existing.events
                 .filter(ev => !ev.addedAfterStart)
                 .reduce((sum, ev) => {
@@ -488,8 +505,12 @@
       const otherNotCompleted = events
         .filter(ev => !ev.piRelevant && !ev.completed && !ev.movedOut)
         .map(ev => ev.key);
-      const initiallyPlannedIssues = events.filter(ev => !ev.addedAfterStart).map(ev => ev.key);
-      const completedIssues = events.filter(ev => ev.completed && !ev.movedOut).map(ev => ev.key);
+      const initiallyPlannedIssues = Array.from(new Set(
+        events.filter(ev => !ev.addedAfterStart).map(ev => ev.key)
+      ));
+      const completedIssues = Array.from(new Set(
+        events.filter(ev => ev.completed && !ev.movedOut).map(ev => ev.key)
+      ));
       html += `<tr>
         <td>[${sprint.board}] ${sprint.name}</td>
         <td title="${sprint.initiallyPlannedSource}">${sprint.initiallyPlanned || 0}</td>

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -446,6 +446,23 @@
               existing.board = boardNum;
               existing.startDate = existing.startDate || s.startDate;
               existing.events = existing.events.concat(events);
+              const merged = {};
+              existing.events.forEach(ev => {
+                if (!ev || !ev.key) return;
+                const cur = merged[ev.key] || {};
+                cur.key = ev.key;
+                cur.points = cur.points || ev.points;
+                cur.initialPoints = ev.initialPoints ?? cur.initialPoints;
+                cur.completedPoints = ev.completedPoints ?? cur.completedPoints;
+                cur.addedAfterStart = cur.addedAfterStart || ev.addedAfterStart;
+                cur.blocked = cur.blocked || ev.blocked;
+                cur.blockedDays = Math.max(cur.blockedDays || 0, ev.blockedDays || 0);
+                cur.movedOut = cur.movedOut || ev.movedOut;
+                cur.completed = cur.completed || ev.completed;
+                cur.piRelevant = cur.piRelevant || ev.piRelevant;
+                merged[ev.key] = cur;
+              });
+              existing.events = Object.values(merged);
               existing.initiallyPlanned = existing.events
                 .filter(ev => !ev.addedAfterStart)
                 .reduce((sum, ev) => {
@@ -487,8 +504,12 @@
       const otherNotCompleted = events
         .filter(ev => !ev.piRelevant && !ev.completed && !ev.movedOut)
         .map(ev => ev.key);
-      const initiallyPlannedIssues = events.filter(ev => !ev.addedAfterStart).map(ev => ev.key);
-      const completedIssues = events.filter(ev => ev.completed && !ev.movedOut).map(ev => ev.key);
+      const initiallyPlannedIssues = Array.from(new Set(
+        events.filter(ev => !ev.addedAfterStart).map(ev => ev.key)
+      ));
+      const completedIssues = Array.from(new Set(
+        events.filter(ev => ev.completed && !ev.movedOut).map(ev => ev.key)
+      ));
       html += `<tr>
         <td>[${sprint.board}] ${sprint.name}</td>
         <td title="${sprint.initiallyPlannedSource}">${sprint.initiallyPlanned || 0}</td>


### PR DESCRIPTION
## Summary
- avoid counting pulled-in issues as initially planned by deduplicating sprint events per issue
- show unique issue keys in initially planned and completed lists

## Testing
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/extractSprintKey.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b96c0a1b3c8325bf4840601cbb6866