### PR TITLE
Avoid counting pulled-in issues as initially planned

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -252,12 +252,16 @@
               if (!r.ok) return;
               const d = await r.json();
               let events = [];
+              const addedKeySet = new Set(
+                d.contents?.issueKeysAddedAfterSprintStart || d.contents?.issueKeysAddedAfterStart || []
+              );
               const collect = (arr, completed = false) => {
                 (arr || []).forEach(it => {
+                  const added = addedKeySet.has(it.key) || it.addedAfterSprintStart || it.addedDuringSprint;
                   events.push({
                     key: it.key,
                     points: it.estimateStatistic?.statFieldValue?.value || 0,
-                    addedAfterStart: false,
+                    addedAfterStart: !!added,
                     blocked: !!it.flagged,
                     movedOut: false,
                     completed
@@ -276,8 +280,16 @@
                 if (existing) {
                   existing.movedOut = true;
                   existing.completed = false;
+                  existing.addedAfterStart = existing.addedAfterStart || addedKeySet.has(k);
                 } else {
-                  events.push({ key: k, points: 0, addedAfterStart: false, blocked: false, movedOut: true, completed: false });
+                  events.push({
+                    key: k,
+                    points: 0,
+                    addedAfterStart: addedKeySet.has(k),
+                    blocked: false,
+                    movedOut: true,
+                    completed: false
+                  });
                 }
               });
               if (isBfBoard) {

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -252,12 +252,16 @@
               if (!r.ok) return;
               const d = await r.json();
               let events = [];
+              const addedKeySet = new Set(
+                d.contents?.issueKeysAddedAfterSprintStart || d.contents?.issueKeysAddedAfterStart || []
+              );
               const collect = (arr, completed = false) => {
                 (arr || []).forEach(it => {
+                  const added = addedKeySet.has(it.key) || it.addedAfterSprintStart || it.addedDuringSprint;
                   events.push({
                     key: it.key,
                     points: it.estimateStatistic?.statFieldValue?.value || 0,
-                    addedAfterStart: false,
+                    addedAfterStart: !!added,
                     blocked: !!it.flagged,
                     movedOut: false,
                     completed
@@ -276,8 +280,16 @@
                 if (existing) {
                   existing.movedOut = true;
                   existing.completed = false;
+                  existing.addedAfterStart = existing.addedAfterStart || addedKeySet.has(k);
                 } else {
-                  events.push({ key: k, points: 0, addedAfterStart: false, blocked: false, movedOut: true, completed: false });
+                  events.push({
+                    key: k,
+                    points: 0,
+                    addedAfterStart: addedKeySet.has(k),
+                    blocked: false,
+                    movedOut: true,
+                    completed: false
+                  });
                 }
               });
               if (isBfBoard) {


### PR DESCRIPTION
## Summary
- Use sprint report metadata to flag issues added mid-sprint so they aren't counted as initially planned

## Testing
- `node test/disruption.test.js`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b96e1c5bf08325a6da6d09f5e15c82