### PR TITLE
Fix throughput aggregation in KPI reports

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -475,6 +475,8 @@
                 cur.blockedDays = Math.max(cur.blockedDays || 0, ev.blockedDays || 0);
                 cur.movedOut = cur.movedOut || ev.movedOut;
                 cur.completed = cur.completed || ev.completed;
+                cur.completedDate = cur.completedDate || ev.completedDate;
+                cur.cycleTime = cur.cycleTime || ev.cycleTime;
                 cur.piRelevant = cur.piRelevant || ev.piRelevant;
                 merged[ev.key] = cur;
               });

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -474,6 +474,8 @@
                 cur.blockedDays = Math.max(cur.blockedDays || 0, ev.blockedDays || 0);
                 cur.movedOut = cur.movedOut || ev.movedOut;
                 cur.completed = cur.completed || ev.completed;
+                cur.completedDate = cur.completedDate || ev.completedDate;
+                cur.cycleTime = cur.cycleTime || ev.cycleTime;
                 cur.piRelevant = cur.piRelevant || ev.piRelevant;
                 merged[ev.key] = cur;
               });


### PR DESCRIPTION
## Summary
- preserve completedDate and cycleTime when merging sprint issue data
- ensure throughput values render on KPI report pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b96f6f7c288325a8703df968b4b5aa