### PR TITLE
Fix initially planned issue calculation in KPI reports

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -453,15 +453,24 @@
                 } catch (e) {}
               }));
 
+              const completed = events.filter(ev => ev.completed && !ev.movedOut)
+                .reduce((sum, ev) => sum + (ev.completedPoints ?? ev.points), 0);
+              const initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
+                .reduce((sum, ev) => {
+                  const init = ev.initialPoints;
+                  return sum + (init != null ? init : (ev.points || 0));
+                }, 0);
               const completedSource = 'sum of completed events (excluding moved out)';
               const initiallyPlannedSource = 'sum of story points at sprint start for events not added after start';
 
               const key = `${boardNum}-${s.id}`;
-              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlannedSource, completedSource };
+              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
               existing.id = existing.id || s.id;
               existing.board = boardNum;
               existing.startDate = existing.startDate || s.startDate;
               existing.events = existing.events.concat(events);
+              existing.initiallyPlanned += initiallyPlanned || 0;
+              existing.completed += completed || 0;
               const merged = {};
               existing.events.forEach(ev => {
                 if (!ev || !ev.key) return;

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -452,15 +452,24 @@
                 } catch (e) {}
               }));
 
+              const completed = events.filter(ev => ev.completed && !ev.movedOut)
+                .reduce((sum, ev) => sum + (ev.completedPoints ?? ev.points), 0);
+              const initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
+                .reduce((sum, ev) => {
+                  const init = ev.initialPoints;
+                  return sum + (init != null ? init : (ev.points || 0));
+                }, 0);
               const completedSource = 'sum of completed events (excluding moved out)';
               const initiallyPlannedSource = 'sum of story points at sprint start for events not added after start';
 
               const key = `${boardNum}-${s.id}`;
-              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlannedSource, completedSource };
+              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
               existing.id = existing.id || s.id;
               existing.board = boardNum;
               existing.startDate = existing.startDate || s.startDate;
               existing.events = existing.events.concat(events);
+              existing.initiallyPlanned += initiallyPlanned || 0;
+              existing.completed += completed || 0;
               const merged = {};
               existing.events.forEach(ev => {
                 if (!ev || !ev.key) return;


### PR DESCRIPTION
## Summary
- Recalculate completed and initially planned story points before merging sprint events
- Aggregate sprint metrics with sources for KPI reports

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b9702be86c8325b576ffe031ee20f6