### PR TITLE
Revert initial plan metrics changes in KPI reports

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -453,24 +453,15 @@
                 } catch (e) {}
               }));
 
-              const completed = events.filter(ev => ev.completed && !ev.movedOut)
-                .reduce((sum, ev) => sum + (ev.completedPoints ?? ev.points), 0);
-              const initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
-                .reduce((sum, ev) => {
-                  const init = ev.initialPoints;
-                  return sum + (init != null ? init : (ev.points || 0));
-                }, 0);
               const completedSource = 'sum of completed events (excluding moved out)';
               const initiallyPlannedSource = 'sum of story points at sprint start for events not added after start';
 
               const key = `${boardNum}-${s.id}`;
-              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
+              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlannedSource, completedSource };
               existing.id = existing.id || s.id;
               existing.board = boardNum;
               existing.startDate = existing.startDate || s.startDate;
               existing.events = existing.events.concat(events);
-              existing.initiallyPlanned += initiallyPlanned || 0;
-              existing.completed += completed || 0;
               const merged = {};
               existing.events.forEach(ev => {
                 if (!ev || !ev.key) return;

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -452,24 +452,15 @@
                 } catch (e) {}
               }));
 
-              const completed = events.filter(ev => ev.completed && !ev.movedOut)
-                .reduce((sum, ev) => sum + (ev.completedPoints ?? ev.points), 0);
-              const initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
-                .reduce((sum, ev) => {
-                  const init = ev.initialPoints;
-                  return sum + (init != null ? init : (ev.points || 0));
-                }, 0);
               const completedSource = 'sum of completed events (excluding moved out)';
               const initiallyPlannedSource = 'sum of story points at sprint start for events not added after start';
 
               const key = `${boardNum}-${s.id}`;
-              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
+              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlannedSource, completedSource };
               existing.id = existing.id || s.id;
               existing.board = boardNum;
               existing.startDate = existing.startDate || s.startDate;
               existing.events = existing.events.concat(events);
-              existing.initiallyPlanned += initiallyPlanned || 0;
-              existing.completed += completed || 0;
               const merged = {};
               existing.events.forEach(ev => {
                 if (!ev || !ev.key) return;


### PR DESCRIPTION
## Summary
- remove early aggregation of completed and initially planned story points
- restore initially planned and completed calculations on deduplicated sprint events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b9718ca5048325a0a286a4f836112b