### PR TITLE
Derive planned points from sprint-start snapshot

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -462,18 +462,10 @@
                 completed = d.contents?.completedIssuesEstimateSum?.value || 0;
                 completedSource = 'completedIssuesEstimateSum';
               }
-              let initiallyPlanned = entry.estimated?.value || 0;
-              let initiallyPlannedSource = 'velocityStatEntries.estimated';
-              if (!initiallyPlanned) {
-                initiallyPlanned = d.contents?.allIssuesEstimateSum?.value;
-                initiallyPlannedSource = 'allIssuesEstimateSum';
-              }
-              if (!initiallyPlanned) {
-                initiallyPlanned = events
+                const initiallyPlanned = events
                   .filter(ev => !ev.addedAfterStart)
                   .reduce((sum, ev) => sum + (ev.points || 0), 0);
-                initiallyPlannedSource = 'sum of events not added after start';
-              }
+                const initiallyPlannedSource = 'sum of events not added after start';
 
               const key = `${boardNum}-${s.id}`;
               const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -267,16 +267,16 @@
               }
 
               const entry = data.velocityStatEntries?.[s.id] || {};
-              let completed = entry.completed?.value || 0;
-              let completedSource = 'velocityStatEntries.completed';
-              if (!completed) {
-                completed = d.contents?.completedIssuesEstimateSum?.value || 0;
-                completedSource = 'completedIssuesEstimateSum';
-              }
-              let initiallyPlanned = entry.estimated?.value || 0;
-              let initiallyPlannedSource = 'velocityStatEntries.estimated';
-              const sprintStart = s.startDate ? new Date(s.startDate) : null;
-              const sprintEnd = s.completeDate ? new Date(s.completeDate) : (s.endDate ? new Date(s.endDate) : null);
+                let completed = entry.completed?.value || 0;
+                let completedSource = 'velocityStatEntries.completed';
+                if (!completed) {
+                  completed = d.contents?.completedIssuesEstimateSum?.value || 0;
+                  completedSource = 'completedIssuesEstimateSum';
+                }
+                let initiallyPlanned;
+                let initiallyPlannedSource;
+                const sprintStart = s.startDate ? new Date(s.startDate) : null;
+                const sprintEnd = s.completeDate ? new Date(s.completeDate) : (s.endDate ? new Date(s.endDate) : null);
 
               await Promise.all(events.map(async ev => {
                 try {
@@ -397,18 +397,18 @@
                 } catch (e) {}
               }));
 
-              if (isBfBoard) {
-                completed = events.filter(ev => ev.completed)
-                                   .reduce((sum, ev) => sum + ev.points, 0);
-                initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
-                                         .reduce((sum, ev) => sum + ev.points, 0);
-                completedSource = 'filtered events';
-                initiallyPlannedSource = 'filtered events';
-              } else if (!initiallyPlanned) {
-                initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
-                                         .reduce((sum, ev) => sum + ev.points, 0);
-                initiallyPlannedSource = 'sum of events not added after start';
-              }
+                if (isBfBoard) {
+                  completed = events.filter(ev => ev.completed)
+                                     .reduce((sum, ev) => sum + ev.points, 0);
+                  initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
+                                           .reduce((sum, ev) => sum + ev.points, 0);
+                  completedSource = 'filtered events';
+                  initiallyPlannedSource = 'filtered events';
+                } else {
+                  initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
+                                           .reduce((sum, ev) => sum + ev.points, 0);
+                  initiallyPlannedSource = 'sum of events not added after start';
+                }
               const existing = combined[s.name] || { id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
               existing.id = existing.id || s.id;
               existing.startDate = existing.startDate || s.startDate;

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -461,18 +461,10 @@
                 completed = d.contents?.completedIssuesEstimateSum?.value || 0;
                 completedSource = 'completedIssuesEstimateSum';
               }
-              let initiallyPlanned = entry.estimated?.value || 0;
-              let initiallyPlannedSource = 'velocityStatEntries.estimated';
-              if (!initiallyPlanned) {
-                initiallyPlanned = d.contents?.allIssuesEstimateSum?.value;
-                initiallyPlannedSource = 'allIssuesEstimateSum';
-              }
-              if (!initiallyPlanned) {
-                initiallyPlanned = events
+                const initiallyPlanned = events
                   .filter(ev => !ev.addedAfterStart)
                   .reduce((sum, ev) => sum + (ev.points || 0), 0);
-                initiallyPlannedSource = 'sum of events not added after start';
-              }
+                const initiallyPlannedSource = 'sum of events not added after start';
 
               const key = `${boardNum}-${s.id}`;
               const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };

--- a/test.html
+++ b/test.html
@@ -285,8 +285,8 @@
                 completed = d.contents?.completedIssuesEstimateSum?.value || 0;
                 completedSource = 'completedIssuesEstimateSum';
               }
-              let initiallyPlanned = entry.estimated?.value || 0;
-              let initiallyPlannedSource = 'velocityStatEntries.estimated';
+              let initiallyPlanned;
+              let initiallyPlannedSource;
               const sprintStart = s.startDate ? new Date(s.startDate) : null;
               const sprintEnd = s.completeDate ? new Date(s.completeDate) : (s.endDate ? new Date(s.endDate) : null);
 
@@ -417,11 +417,9 @@
                 } catch (e) {}
               }));
 
-              if (!initiallyPlanned) {
                 initiallyPlanned = events.filter(ev => !ev.addedAfterStart)
                                          .reduce((sum, ev) => sum + ev.points, 0);
                 initiallyPlannedSource = 'sum of events not added after start';
-              }
               const existing = combined[s.name] || { id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
               existing.id = existing.id || s.id;
               existing.startDate = existing.startDate || s.startDate;


### PR DESCRIPTION
## Summary
- Derive initially planned story points by summing events that were in the sprint at start instead of relying on Jira velocity stats, avoiding misclassification when issues are backdated
- Apply the new calculation across KPI and disruption reports

## Testing
- `node test/epicLabelsConsole.test.js`
- `node test/piPlanVsCompleteChart.test.js`
- `node test/extractSprintKey.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b975e3ed588325a62794fd66d5bd0d