### PR TITLE
Account for issues removed mid-sprint in KPI reports

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -435,9 +435,13 @@
                         const sprintName = s.name || '';
                         const fromHas = from.includes(sprintIdStr) || from.includes(sprintName);
                         const toHas = to.includes(sprintIdStr) || to.includes(sprintName);
-                        if (fromHas && !toHas) ev.movedOut = true;
-                        if (sprintStart && chDate >= sprintStart && !fromHas && toHas) {
-                          ev.addedAfterStart = true;
+                        if (fromHas && !toHas) {
+                          ev.movedOut = true;
+                          if (sprintStart && chDate < sprintStart) ev.removedBeforeStart = true;
+                        }
+                        if (!fromHas && toHas) {
+                          if (sprintStart && chDate < sprintStart) ev.removedBeforeStart = false;
+                          if (sprintStart && chDate >= sprintStart) ev.addedAfterStart = true;
                         }
                       }
                     }
@@ -468,10 +472,11 @@
                 initiallyPlanned = d.contents?.allIssuesEstimateSum?.value;
                 initiallyPlannedSource = 'allIssuesEstimateSum';
               }
-              if (!initiallyPlanned) {
-                initiallyPlanned = events
-                  .filter(ev => !ev.addedAfterStart)
-                  .reduce((sum, ev) => sum + (ev.points || 0), 0);
+              const plannedFromIssues = events
+                .filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart)
+                .reduce((sum, ev) => sum + (ev.initialPoints ?? ev.points || 0), 0);
+              if (!initiallyPlanned || plannedFromIssues > initiallyPlanned) {
+                initiallyPlanned = plannedFromIssues;
                 initiallyPlannedSource = 'sum of events not added after start';
               }
 
@@ -516,7 +521,7 @@
         .filter(ev => !ev.piRelevant && !ev.completed && !ev.movedOut)
         .map(ev => ev.key);
       const initiallyPlannedIssues = Array.from(new Set(
-        events.filter(ev => !ev.addedAfterStart).map(ev => ev.key)
+        events.filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart).map(ev => ev.key)
       ));
       const completedIssues = Array.from(new Set(
         events.filter(ev => ev.completed && !ev.movedOut).map(ev => ev.key)
@@ -589,7 +594,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const completedSPAll = (allSprints || displaySprints).map(s => s.completed || 0);
   const completedSP = completedSPAll.slice(-displaySprints.length);
   const plannedSPAll = (allSprints || displaySprints).map(s =>
-    sumSP(s.events, ev => !ev.addedAfterStart, 'initialPoints')
+    sumSP(s.events, ev => !ev.addedAfterStart && !ev.removedBeforeStart, 'initialPoints')
   );
   const plannedSP = plannedSPAll.slice(-displaySprints.length);
   const metricsArr = displaySprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
@@ -611,10 +616,10 @@ function renderBoardCharts(displaySprints, allSprints, container) {
 
   }
   const plannedPI = displaySprints.map(s =>
-    sumSP(s.events, ev => !ev.addedAfterStart && ev.piRelevant, 'initialPoints')
+    sumSP(s.events, ev => !ev.addedAfterStart && !ev.removedBeforeStart && ev.piRelevant, 'initialPoints')
   );
   const plannedOther = displaySprints.map(s =>
-    sumSP(s.events, ev => !ev.addedAfterStart && !ev.piRelevant, 'initialPoints')
+    sumSP(s.events, ev => !ev.addedAfterStart && !ev.removedBeforeStart && !ev.piRelevant, 'initialPoints')
   );
   const completedPI = displaySprints.map(s =>
     sumSP(s.events, ev => ev.completed && ev.piRelevant, 'completedPoints')
@@ -625,7 +630,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
 
   const initialCompleted = displaySprints.map(s =>
     (s.events || [])
-      .filter(ev => !ev.addedAfterStart && !ev.movedOut && ev.completed)
+      .filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart && !ev.movedOut && ev.completed)
       .reduce((sum, ev) => sum + (ev.completedPoints ?? ev.points || 0), 0)
   );
 

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -434,9 +434,13 @@
                         const sprintName = s.name || '';
                         const fromHas = from.includes(sprintIdStr) || from.includes(sprintName);
                         const toHas = to.includes(sprintIdStr) || to.includes(sprintName);
-                        if (fromHas && !toHas) ev.movedOut = true;
-                        if (sprintStart && chDate >= sprintStart && !fromHas && toHas) {
-                          ev.addedAfterStart = true;
+                        if (fromHas && !toHas) {
+                          ev.movedOut = true;
+                          if (sprintStart && chDate < sprintStart) ev.removedBeforeStart = true;
+                        }
+                        if (!fromHas && toHas) {
+                          if (sprintStart && chDate < sprintStart) ev.removedBeforeStart = false;
+                          if (sprintStart && chDate >= sprintStart) ev.addedAfterStart = true;
                         }
                       }
                     }
@@ -467,10 +471,11 @@
                 initiallyPlanned = d.contents?.allIssuesEstimateSum?.value;
                 initiallyPlannedSource = 'allIssuesEstimateSum';
               }
-              if (!initiallyPlanned) {
-                initiallyPlanned = events
-                  .filter(ev => !ev.addedAfterStart)
-                  .reduce((sum, ev) => sum + (ev.points || 0), 0);
+              const plannedFromIssues = events
+                .filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart)
+                .reduce((sum, ev) => sum + (ev.initialPoints ?? ev.points || 0), 0);
+              if (!initiallyPlanned || plannedFromIssues > initiallyPlanned) {
+                initiallyPlanned = plannedFromIssues;
                 initiallyPlannedSource = 'sum of events not added after start';
               }
 
@@ -515,7 +520,7 @@
         .filter(ev => !ev.piRelevant && !ev.completed && !ev.movedOut)
         .map(ev => ev.key);
       const initiallyPlannedIssues = Array.from(new Set(
-        events.filter(ev => !ev.addedAfterStart).map(ev => ev.key)
+        events.filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart).map(ev => ev.key)
       ));
       const completedIssues = Array.from(new Set(
         events.filter(ev => ev.completed && !ev.movedOut).map(ev => ev.key)
@@ -588,7 +593,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const completedSPAll = (allSprints || displaySprints).map(s => s.completed || 0);
   const completedSP = completedSPAll.slice(-displaySprints.length);
   const plannedSPAll = (allSprints || displaySprints).map(s =>
-    sumSP(s.events, ev => !ev.addedAfterStart, 'initialPoints')
+    sumSP(s.events, ev => !ev.addedAfterStart && !ev.removedBeforeStart, 'initialPoints')
   );
   const plannedSP = plannedSPAll.slice(-displaySprints.length);
   const metricsArr = displaySprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
@@ -610,10 +615,10 @@ function renderBoardCharts(displaySprints, allSprints, container) {
 
   }
   const plannedPI = displaySprints.map(s =>
-    sumSP(s.events, ev => !ev.addedAfterStart && ev.piRelevant, 'initialPoints')
+    sumSP(s.events, ev => !ev.addedAfterStart && !ev.removedBeforeStart && ev.piRelevant, 'initialPoints')
   );
   const plannedOther = displaySprints.map(s =>
-    sumSP(s.events, ev => !ev.addedAfterStart && !ev.piRelevant, 'initialPoints')
+    sumSP(s.events, ev => !ev.addedAfterStart && !ev.removedBeforeStart && !ev.piRelevant, 'initialPoints')
   );
   const completedPI = displaySprints.map(s =>
     sumSP(s.events, ev => ev.completed && ev.piRelevant, 'completedPoints')

--- a/src/disruption.js
+++ b/src/disruption.js
@@ -59,7 +59,7 @@
         rec.blocked = true;
       }
 
-      if (ev.movedOut && !rec.movedOut) {
+      if (ev.movedOut && !ev.removedBeforeStart && !rec.movedOut) {
         metrics.movedOut += pts;
         metrics.movedOutIssues.add(ev.key);
         rec.movedOut = true;

--- a/test/disruption.test.js
+++ b/test/disruption.test.js
@@ -28,4 +28,15 @@ const { calculateDisruptionMetrics } = require('../src/disruption');
   assert.deepStrictEqual(metrics.movedOutIssues, ['ST-3']);
 })();
 
+// Test moved out before sprint start is ignored
+(() => {
+  const events = [
+    { key: 'ST-4', points: 4, movedOut: true, removedBeforeStart: true }
+  ];
+  const metrics = calculateDisruptionMetrics(events);
+  assert.strictEqual(metrics.movedOut, 0);
+  assert.strictEqual(metrics.movedOutCount, 0);
+  assert.deepStrictEqual(metrics.movedOutIssues, []);
+})();
+
 console.log('disruption tests passed');


### PR DESCRIPTION
## Summary
- Include sprint removal timestamps when determining initially planned work
- Exclude issues removed before sprint start from disruption and planning metrics
- Add tests covering removed-before-start cases

## Testing
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/extractSprintKey.test.js`
- `node test/piPlanVsCompleteChart.test.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9773921d8832599ae73640d047554