### PR TITLE
Fix nullish coalescing usage in KPI report

### DIFF
--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -474,7 +474,7 @@
               }
               const plannedFromIssues = events
                 .filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart)
-                .reduce((sum, ev) => sum + (ev.initialPoints ?? ev.points || 0), 0);
+                .reduce((sum, ev) => sum + (ev.initialPoints ?? ev.points ?? 0), 0);
               if (!initiallyPlanned || plannedFromIssues > initiallyPlanned) {
                 initiallyPlanned = plannedFromIssues;
                 initiallyPlannedSource = 'sum of events not added after start';


### PR DESCRIPTION
## Summary
- Avoid mix of nullish coalescing and logical OR in `kpi_report_no_initial.html`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_68b9797522a08325a58cda4da63ea011