### PR TITLE
Fix nullish coalescing syntax error in KPI reports

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -475,7 +475,7 @@
               }
               const plannedFromIssues = events
                 .filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart)
-                .reduce((sum, ev) => sum + (ev.initialPoints ?? ev.points || 0), 0);
+                  .reduce((sum, ev) => sum + ((ev.initialPoints ?? ev.points) || 0), 0);
               if (!initiallyPlanned || plannedFromIssues > initiallyPlanned) {
                 initiallyPlanned = plannedFromIssues;
                 initiallyPlannedSource = 'sum of events not added after start';
@@ -633,7 +633,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const initialCompleted = displaySprints.map(s =>
     (s.events || [])
       .filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart && !ev.movedOut && ev.completed)
-      .reduce((sum, ev) => sum + (ev.completedPoints ?? ev.points || 0), 0)
+      .reduce((sum, ev) => sum + ((ev.completedPoints ?? ev.points) || 0), 0)
   );
 
   const throughputPerSprint = displaySprints.map(s =>

--- a/kpi_report_manual.html
+++ b/kpi_report_manual.html
@@ -476,7 +476,7 @@
               }
               const plannedFromIssues = events
                 .filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart)
-                .reduce((sum, ev) => sum + (ev.initialPoints ?? ev.points || 0), 0);
+                .reduce((sum, ev) => sum + ((ev.initialPoints ?? ev.points) || 0), 0);
               if (!initiallyPlanned || plannedFromIssues > initiallyPlanned) {
                 initiallyPlanned = plannedFromIssues;
                 initiallyPlannedSource = 'sum of events not added after start';


### PR DESCRIPTION
## Summary
- avoid runtime syntax errors by parenthesizing nullish coalescing and logical OR when summing initial sprint points
- apply the same fix to completed point calculations in KPI reports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b97b6e43f08325b071edb4d7fa4573