### PR TITLE
Handle sprint removals in planned metrics

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -325,6 +325,7 @@
                     let initialPoints = 0;
                     if (histories && sprintStart) {
                       const sortedHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
+                      let found = false;
                       for (const h of sortedHist) {
                         const chDate = new Date(h.created);
                         if (chDate > sprintStart) break;
@@ -332,9 +333,15 @@
                           const fieldName = (item.field || '').toLowerCase();
                           if (fieldName === 'story points' || fieldName === 'customfield_10002') {
                             const val = Number(item.toString || item.to);
-                            if (!isNaN(val)) initialPoints = val;
+                            if (!isNaN(val)) {
+                              initialPoints = val;
+                              found = true;
+                            }
                           }
                         }
+                      }
+                      if (!found) {
+                        initialPoints = ev.points || 0;
                       }
                     } else {
                       initialPoints = ev.points || 0;

--- a/kpi_report_manual.html
+++ b/kpi_report_manual.html
@@ -326,6 +326,7 @@
                     let initialPoints = 0;
                     if (histories && sprintStart) {
                       const sortedHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
+                      let found = false;
                       for (const h of sortedHist) {
                         const chDate = new Date(h.created);
                         if (chDate > sprintStart) break;
@@ -333,9 +334,15 @@
                           const fieldName = (item.field || '').toLowerCase();
                           if (fieldName === 'story points' || fieldName === 'customfield_10002') {
                             const val = Number(item.toString || item.to);
-                            if (!isNaN(val)) initialPoints = val;
+                            if (!isNaN(val)) {
+                              initialPoints = val;
+                              found = true;
+                            }
                           }
                         }
+                      }
+                      if (!found) {
+                        initialPoints = ev.points || 0;
                       }
                     } else {
                       initialPoints = ev.points || 0;

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -324,6 +324,7 @@
                     let initialPoints = 0;
                     if (histories && sprintStart) {
                       const sortedHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
+                      let found = false;
                       for (const h of sortedHist) {
                         const chDate = new Date(h.created);
                         if (chDate > sprintStart) break;
@@ -331,9 +332,15 @@
                           const fieldName = (item.field || '').toLowerCase();
                           if (fieldName === 'story points' || fieldName === 'customfield_10002') {
                             const val = Number(item.toString || item.to);
-                            if (!isNaN(val)) initialPoints = val;
+                            if (!isNaN(val)) {
+                              initialPoints = val;
+                              found = true;
+                            }
                           }
                         }
+                      }
+                      if (!found) {
+                        initialPoints = ev.points || 0;
                       }
                     } else {
                       initialPoints = ev.points || 0;

--- a/src/piPlanVsCompleteChart.mjs
+++ b/src/piPlanVsCompleteChart.mjs
@@ -84,6 +84,7 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
 
   const processed = filtered.map(issue => {
     const sprintChanges = [];
+    let firstSprintChange = true;
     (issue.changelog || [])
       .filter(c => c.field === 'Sprint')
       .sort((a, b) => new Date(a.at) - new Date(b.at))
@@ -91,6 +92,12 @@ export function computeBucketSeries({ team, product, sprints = [], issues = [], 
         const at = new Date(c.at);
         const fromId = normalizeSprintId(c.from);
         const toId = normalizeSprintId(c.to);
+        if (firstSprintChange) {
+          firstSprintChange = false;
+          if (fromId !== undefined) {
+            sprintChanges.push({ at: new Date(0), sprintId: fromId });
+          }
+        }
         if (fromId !== undefined) {
           sprintChanges.push({ at: new Date(at.getTime() - 1), sprintId: fromId });
         }

--- a/test/piPlanVsCompleteChart.test.js
+++ b/test/piPlanVsCompleteChart.test.js
@@ -61,6 +61,15 @@ const assert = require('assert');
         { field: 'Sprint', from: '', to: '1', at: '2023-12-15' },
         { field: 'Sprint', from: '1', to: '', at: '2023-12-25' }
       ]
+    },
+    {
+      team: 'ALL',
+      product: 'ALL',
+      storyPoints: 7,
+      epicLabels: ['2024_PI1_committed'],
+      changelog: [
+        { field: 'Sprint', from: '1', to: '', at: '2024-01-03' }
+      ]
     }
   ];
 
@@ -77,7 +86,7 @@ const assert = require('assert');
     piBuckets
   });
 
-  assert.deepStrictEqual(series.plannedPi, [16, 2]);
+  assert.deepStrictEqual(series.plannedPi, [23, 2]);
   assert.deepStrictEqual(series.plannedNonPi, [0, 0]);
   assert.deepStrictEqual(series.completedPi, [5, 10]);
   assert.deepStrictEqual(series.completedNonPi, [0, 3]);


### PR DESCRIPTION
## Summary
- ensure issues removed after sprint start still count toward initial plan by seeding sprint timeline with starting sprint
- add test covering removal without prior sprint addition
- default KPI reports to current story points when no pre-sprint changelog exists so removed stories remain planned

## Testing
- `node test/piPlanVsCompleteChart.test.js`
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/extractSprintKey.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b97b39d2ac83258a1119dbe7cf8ae1