### PR TITLE
Use sprint-start story points for initial KPI plan

### DIFF
--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -479,19 +479,10 @@
                 completedSource = 'completedIssuesEstimateSum';
               }
 
-              let initiallyPlanned = entry.estimated?.value || 0;
-              let initiallyPlannedSource = 'velocityStatEntries.estimated';
-              if (!initiallyPlanned) {
-                initiallyPlanned = d.contents?.allIssuesEstimateSum?.value;
-                initiallyPlannedSource = 'allIssuesEstimateSum';
-              }
-              const plannedFromIssues = events
+              const initiallyPlanned = events
                 .filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart)
                 .reduce((sum, ev) => sum + (ev.initialPoints ?? ev.points ?? 0), 0);
-              if (!initiallyPlanned || plannedFromIssues > initiallyPlanned) {
-                initiallyPlanned = plannedFromIssues;
-                initiallyPlannedSource = 'sum of events not added after start';
-              }
+              const initiallyPlannedSource = 'sum of events not added after start';
 
 
               const key = `${boardNum}-${s.id}`;


### PR DESCRIPTION
## Summary
- Compute initially planned story points from issues present at sprint start
- Capture story point values at sprint start to ignore later re-estimates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b97f5755448325bf0e194f171365f0