### PR TITLE
Capture sprint start estimates in KPI reports

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -317,29 +317,25 @@
                     ev.blocked = ev.blocked || !!(id.fields?.flagged && id.fields.flagged.length);
                     ev.blocked = ev.blocked || currentStatus.toLowerCase().includes('block');
                     // Determine story points at sprint start
-                    let initialPoints = 0;
+                    let initialPoints = ev.points || 0;
                     if (histories && sprintStart) {
                       const sortedHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
-                      let found = false;
-                      for (const h of sortedHist) {
+                      outer: for (const h of sortedHist) {
                         const chDate = new Date(h.created);
-                        if (chDate > sprintStart) break;
                         for (const item of h.items || []) {
                           const fieldName = (item.field || '').toLowerCase();
                           if (fieldName === 'story points' || fieldName === 'customfield_10002') {
-                            const val = Number(item.toString || item.to);
-                            if (!isNaN(val)) {
-                              initialPoints = val;
-                              found = true;
+                            const toVal = Number(item.toString || item.to);
+                            const fromVal = Number(item.fromString || item.from);
+                            if (chDate <= sprintStart) {
+                              if (!isNaN(toVal)) initialPoints = toVal;
+                            } else {
+                              initialPoints = !isNaN(fromVal) ? fromVal : 0;
+                              break outer;
                             }
                           }
                         }
                       }
-                      if (!found) {
-                        initialPoints = ev.points || 0;
-                      }
-                    } else {
-                      initialPoints = ev.points || 0;
                     }
                     ev.initialPoints = initialPoints;
                     piRelevant = false;
@@ -480,19 +476,10 @@
                 completedSource = 'completedIssuesEstimateSum';
               }
 
-              let initiallyPlanned = entry.estimated?.value || 0;
-              let initiallyPlannedSource = 'velocityStatEntries.estimated';
-              if (!initiallyPlanned) {
-                initiallyPlanned = d.contents?.allIssuesEstimateSum?.value;
-                initiallyPlannedSource = 'allIssuesEstimateSum';
-              }
-              const plannedFromIssues = events
+              const initiallyPlanned = events
                 .filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart)
-                  .reduce((sum, ev) => sum + ((ev.initialPoints ?? ev.points) || 0), 0);
-              if (!initiallyPlanned || plannedFromIssues > initiallyPlanned) {
-                initiallyPlanned = plannedFromIssues;
-                initiallyPlannedSource = 'sum of events not added after start';
-              }
+                .reduce((sum, ev) => sum + (ev.initialPoints ?? ev.points ?? 0), 0);
+              const initiallyPlannedSource = 'sum of events not added after start';
 
 
               const key = `${boardNum}-${s.id}`;

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -316,29 +316,25 @@
                     ev.blocked = ev.blocked || !!(id.fields?.flagged && id.fields.flagged.length);
                     ev.blocked = ev.blocked || currentStatus.toLowerCase().includes('block');
                     // Determine story points at sprint start
-                    let initialPoints = 0;
+                    let initialPoints = ev.points || 0;
                     if (histories && sprintStart) {
                       const sortedHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
-                      let found = false;
-                      for (const h of sortedHist) {
+                      outer: for (const h of sortedHist) {
                         const chDate = new Date(h.created);
-                        if (chDate > sprintStart) break;
                         for (const item of h.items || []) {
                           const fieldName = (item.field || '').toLowerCase();
                           if (fieldName === 'story points' || fieldName === 'customfield_10002') {
-                            const val = Number(item.toString || item.to);
-                            if (!isNaN(val)) {
-                              initialPoints = val;
-                              found = true;
+                            const toVal = Number(item.toString || item.to);
+                            const fromVal = Number(item.fromString || item.from);
+                            if (chDate <= sprintStart) {
+                              if (!isNaN(toVal)) initialPoints = toVal;
+                            } else {
+                              initialPoints = !isNaN(fromVal) ? fromVal : 0;
+                              break outer;
                             }
                           }
                         }
                       }
-                      if (!found) {
-                        initialPoints = ev.points || 0;
-                      }
-                    } else {
-                      initialPoints = ev.points || 0;
                     }
                     ev.initialPoints = initialPoints;
                     piRelevant = false;


### PR DESCRIPTION
## Summary
- derive initial story point snapshot from issue history at sprint start
- compute initially planned points solely from sprint-start issues

## Testing
- `node test/disruption.test.js && node test/epicLabelsConsole.test.js && node test/extractSprintKey.test.js && node test/piPlanVsCompleteChart.test.js`
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_68b9891e5fdc8325be854efe1ab66f2c