### PR TITLE
Remove initially planned line from rating zone charts

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -595,10 +595,6 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const sprintLabels = displaySprints.map(s => s.name);
   const completedSPAll = (allSprints || displaySprints).map(s => s.completed || 0);
   const completedSP = completedSPAll.slice(-displaySprints.length);
-  const plannedSPAll = (allSprints || displaySprints).map(s =>
-    sumSP(s.events, ev => !ev.addedAfterStart && !ev.removedBeforeStart, 'initialPoints')
-  );
-  const plannedSP = plannedSPAll.slice(-displaySprints.length);
   const metricsArr = displaySprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
   const pulledInCount = metricsArr.map(m => m.pulledInCount || 0);
   const blockedDays = metricsArr.map(m => Math.ceil((m.blockedDays || 0) * 10) / 10);
@@ -694,7 +690,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const zonesBySprint = zonesBySprintAll.slice(-displaySprints.length);
   const avgBySprint = avgBySprintAll.slice(-displaySprints.length);
   const zoneMaxes = zonesBySprint.map(zs => zs ? zs[zs.length - 1].yMax : 0);
-  const maxY = Math.max(...completedSP, ...plannedSP, ...zoneMaxes, ...avgBySprint);
+  const maxY = Math.max(...completedSP, ...zoneMaxes, ...avgBySprint);
   zonesBySprint.forEach(zs => { if (zs) { zs[zs.length - 1].yMax = maxY; } });
 
   const ratingZonesPlugin = {
@@ -833,7 +829,6 @@ function renderBoardCharts(displaySprints, allSprints, container) {
     data: {
       labels: sprintLabels,
       datasets: [
-        { label: 'Initially Planned SP', data: plannedSP, borderColor: '#f97316', backgroundColor: 'rgba(249,115,22,0.3)', fill: false, tension: 0.1 },
         { label: 'Completed SP', data: completedSP, borderColor: '#6366f1', backgroundColor: 'rgba(99,102,241,0.3)', fill: false, tension: 0.1 },
         { label: 'Average Velocity', data: avgBySprint, borderColor: '#000000', borderDash: [5,5], fill: false, tension: 0 }
       ]

--- a/disruption.html
+++ b/disruption.html
@@ -495,8 +495,6 @@ function renderCharts(displaySprints, allSprints) {
   const sprintLabels = displaySprints.map(s => s.name);
   const completedSPAll = (allSprints || displaySprints).map(s => s.completed || 0);
   const completedSP = completedSPAll.slice(-displaySprints.length);
-  const plannedSPAll = (allSprints || displaySprints).map(s => s.initiallyPlanned || 0);
-  const plannedSP = plannedSPAll.slice(-displaySprints.length);
   const metricsArr = displaySprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
   const pulledInCount = metricsArr.map(m => m.pulledInCount || 0);
   const blockedDays = metricsArr.map(m => Math.ceil((m.blockedDays || 0) * 10) / 10);
@@ -562,7 +560,7 @@ function renderCharts(displaySprints, allSprints) {
   const zonesBySprint = zonesBySprintAll.slice(-displaySprints.length);
   const avgBySprint = avgBySprintAll.slice(-displaySprints.length);
   const zoneMaxes = zonesBySprint.map(zs => zs ? zs[zs.length - 1].yMax : 0);
-  const maxY = Math.max(...completedSP, ...plannedSP, ...zoneMaxes, ...avgBySprint);
+  const maxY = Math.max(...completedSP, ...zoneMaxes, ...avgBySprint);
   zonesBySprint.forEach(zs => { if (zs) { zs[zs.length - 1].yMax = maxY; } });
 
   const ratingZonesPlugin = {
@@ -672,7 +670,6 @@ function renderCharts(displaySprints, allSprints) {
     data: {
       labels: sprintLabels,
       datasets: [
-        { label: 'Initially Planned SP', data: plannedSP, borderColor: '#f97316', backgroundColor: 'rgba(249,115,22,0.3)', fill: false, tension: 0.1 },
         { label: 'Completed SP', data: completedSP, borderColor: '#6366f1', backgroundColor: 'rgba(99,102,241,0.3)', fill: false, tension: 0.1 },
         { label: 'Average Velocity', data: avgBySprint, borderColor: '#000000', borderDash: [5,5], fill: false, tension: 0 }
       ]

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -594,10 +594,6 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const sprintLabels = displaySprints.map(s => s.name);
   const completedSPAll = (allSprints || displaySprints).map(s => s.completed || 0);
   const completedSP = completedSPAll.slice(-displaySprints.length);
-  const plannedSPAll = (allSprints || displaySprints).map(s =>
-    sumSP(s.events, ev => !ev.addedAfterStart && !ev.removedBeforeStart, 'initialPoints')
-  );
-  const plannedSP = plannedSPAll.slice(-displaySprints.length);
   const metricsArr = displaySprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
   const pulledInCount = metricsArr.map(m => m.pulledInCount || 0);
   const blockedDays = metricsArr.map(m => Math.ceil((m.blockedDays || 0) * 10) / 10);
@@ -687,7 +683,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const zonesBySprint = zonesBySprintAll.slice(-displaySprints.length);
   const avgBySprint = avgBySprintAll.slice(-displaySprints.length);
   const zoneMaxes = zonesBySprint.map(zs => zs ? zs[zs.length - 1].yMax : 0);
-  const maxY = Math.max(...completedSP, ...plannedSP, ...zoneMaxes, ...avgBySprint);
+  const maxY = Math.max(...completedSP, ...zoneMaxes, ...avgBySprint);
   zonesBySprint.forEach(zs => { if (zs) { zs[zs.length - 1].yMax = maxY; } });
 
   const ratingZonesPlugin = {
@@ -816,7 +812,6 @@ function renderBoardCharts(displaySprints, allSprints, container) {
     data: {
       labels: sprintLabels,
       datasets: [
-        { label: 'Initially Planned SP', data: plannedSP, borderColor: '#f97316', backgroundColor: 'rgba(249,115,22,0.3)', fill: false, tension: 0.1 },
         { label: 'Completed SP', data: completedSP, borderColor: '#6366f1', backgroundColor: 'rgba(99,102,241,0.3)', fill: false, tension: 0.1 },
         { label: 'Average Velocity', data: avgBySprint, borderColor: '#000000', borderDash: [5,5], fill: false, tension: 0 }
       ]


### PR DESCRIPTION
## Summary
- Remove "Initially Planned SP" dataset from rating zone charts
- Clean up unused `plannedSP` calculations and max range logic

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b98afe42d483258df208b3880dfe45