### PR TITLE
Ensure re-added issues count as initially planned

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -425,6 +425,7 @@
 
                   let addedDate = null;
                   let inSprint = false;
+                  let wasInSprintAtStart = false;
                   const sprintHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
                   for (const h of sprintHist) {
                     const chDate = new Date(h.created);
@@ -452,6 +453,9 @@
                         }
                       }
                     }
+                    if (sprintStart && chDate <= sprintStart) {
+                      wasInSprintAtStart = inSprint;
+                    }
                   }
 
                   if (!addedDate && sprintStart && created) {
@@ -461,7 +465,7 @@
                     }
                   }
 
-                  if (addedDate && sprintStart && addedDate >= sprintStart) {
+                  if (addedDate && sprintStart && addedDate >= sprintStart && !wasInSprintAtStart) {
                     ev.addedAfterStart = true;
                   }
 

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -424,6 +424,7 @@
 
                   let addedDate = null;
                   let inSprint = false;
+                  let wasInSprintAtStart = false;
                   const sprintHist = histories.slice().sort((a, b) => new Date(a.created) - new Date(b.created));
                   for (const h of sprintHist) {
                     const chDate = new Date(h.created);
@@ -451,6 +452,9 @@
                         }
                       }
                     }
+                    if (sprintStart && chDate <= sprintStart) {
+                      wasInSprintAtStart = inSprint;
+                    }
                   }
 
                   if (!addedDate && sprintStart && created) {
@@ -460,7 +464,7 @@
                     }
                   }
 
-                  if (addedDate && sprintStart && addedDate >= sprintStart) {
+                  if (addedDate && sprintStart && addedDate >= sprintStart && !wasInSprintAtStart) {
                     ev.addedAfterStart = true;
                   }
 


### PR DESCRIPTION
## Summary
- Avoid marking issues as pulled in when they were in the sprint at start
- Track sprint membership at start to better classify `addedAfterStart`

## Testing
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/extractSprintKey.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b993c60a90832590249355c695129d