### PR TITLE
Align test report logic with KPI report

### DIFF
--- a/test.html
+++ b/test.html
@@ -80,26 +80,17 @@
       <tbody id="metricsBody"></tbody>
     </table>
     <div id="velocityStats"></div>
-    <div id="chartSection" class="chart-section">
-      <canvas id="piMixChart"></canvas>
-      <canvas id="completedChart"></canvas>
-      <div class="rating-zone-description">
-        <div id="ratingZoneToggle" style="cursor:pointer;"><strong>Rating zones (show)</strong></div>
-        <div id="ratingZoneDetails" style="display:none;">
-          <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Bloated: AV+2SD…∞.</strong> A significant share of this exceedingly high output probably comes from other effects than team performance alone. Analysis is advised because possibly there's something to be learned.</div>
-          <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Lively: AV+1SD…AV+2SD.</strong> The team's performance was outstanding, pushing the envelope on the brink of an unsustainable pace.</div>
-          <div><span style="background:rgba(21,128,61,0.5);"></span><strong>Spot-on: AV…AV+1SD.</strong> The team performed very well while also managing to increase the stability of their long-term output.</div>
-          <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Healthy: AV-1SD…AV.</strong> Things cannot always go up, so going down within the team's usual range of performance is perfectly normal.</div>
-          <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Concerning: AV-2SD…AV-1SD.</strong> Something went considerably wrong, but we're still seeing a robust core performance. Analysis is needed and also some learning that may result in adjustments.</div>
-          <div><span style="background:rgba(254,202,202,0.5);"></span><strong>Alarming: 0…AV-2SD.</strong> The major share of this plummeting output was probably caused by factors beyond the team‘s influence. Thorough analysis is needed which will lead to profound learning and change.</div>
-        </div>
+    <div id="chartSection" class="chart-section"></div>
+    <div class="rating-zone-description">
+      <div id="ratingZoneToggle" style="cursor:pointer;"><strong>Rating zones (show)</strong></div>
+      <div id="ratingZoneDetails" style="display:none;">
+        <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Bloated: AV+2SD…∞.</strong> A significant share of this exceedingly high output probably comes from other effects than team performance alone. Analysis is advised because possibly there's something to be learned.</div>
+        <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Lively: AV+1SD…AV+2SD.</strong> The team's performance was outstanding, pushing the envelope on the brink of an unsustainable pace.</div>
+        <div><span style="background:rgba(21,128,61,0.5);"></span><strong>Spot-on: AV…AV+1SD.</strong> The team performed very well while also managing to increase the stability of their long-term output.</div>
+        <div><span style="background:rgba(34,197,94,0.5);"></span><strong>Healthy: AV-1SD…AV.</strong> Things cannot always go up, so going down within the team's usual range of performance is perfectly normal.</div>
+        <div><span style="background:rgba(254,249,195,0.5);"></span><strong>Concerning: AV-2SD…AV-1SD.</strong> Something went considerably wrong, but we're still seeing a robust core performance. Analysis is needed and also some learning that may result in adjustments.</div>
+        <div><span style="background:rgba(254,202,202,0.5);"></span><strong>Alarming: 0…AV-2SD.</strong> The major share of this plummeting output was probably caused by factors beyond the team‘s influence. Thorough analysis is needed which will lead to profound learning and change.</div>
       </div>
-      <h2>Throughput per Sprint</h2>
-      <canvas id="throughputChart"></canvas>
-      <h2>Cycle Time (5-sprint median)</h2>
-      <canvas id="cycleTimeChart"></canvas>
-      <h2>Disruption Metrics</h2>
-      <canvas id="disruptionChart"></canvas>
     </div>
   </div>
 </div>
@@ -137,11 +128,8 @@
   // Keep references to existing Chart.js instances so they can be destroyed
   // when rendering charts multiple times. Without this, Chart.js will throw
   // an error about reusing a canvas that is already in use.
-  let completedChartInstance;
-  let disruptionChartInstance;
-  let piMixChartInstance;
-  let throughputChartInstance;
-  let cycleTimeChartInstance;
+  let chartInstances = [];
+  let boardLabels = {};
   const DISPLAY_SPRINT_COUNT = 10;
   const RATING_WINDOW = 4;
   const CYCLE_TIME_START = new Date('2025-06-09');
@@ -567,8 +555,8 @@ function renderVelocityStats(allSprints) {
     wrap.innerHTML = html;
   }
 
-function renderCharts(displaySprints, allSprints) {
-  const sprintLabels = displaySprints.map(s => `[${s.board}] ${s.name}`);
+function renderBoardCharts(displaySprints, allSprints, container) {
+  const sprintLabels = displaySprints.map(s => s.name);
   const completedSPAll = (allSprints || displaySprints).map(s => s.completed || 0);
   const completedSP = completedSPAll.slice(-displaySprints.length);
   const plannedSPAll = (allSprints || displaySprints).map(s => s.initiallyPlanned || 0);
@@ -608,41 +596,74 @@ function renderCharts(displaySprints, allSprints) {
       .reduce((sum, ev) => sum + ((ev.completedPoints ?? ev.points) || 0), 0)
   );
 
-    const throughputPerSprint = displaySprints.map(s =>
-      (s.events || []).filter(ev => ev.completedDate).length
-    );
-    const cycleTimePerSprint = displaySprints.map((s, idx) => {
-      const sprintStart = s.startDate ? new Date(s.startDate) : null;
-      if (!sprintStart || sprintStart <= CYCLE_TIME_START) return null;
-      const windowSprints = displaySprints
-        .slice(Math.max(0, idx - 4), idx + 1)
-        .filter(ws => ws.startDate && new Date(ws.startDate) > CYCLE_TIME_START);
-      const times = [];
-      windowSprints.forEach(ws => {
-        (ws.events || []).forEach(ev => {
-          if (typeof ev.cycleTime === 'number') times.push(ev.cycleTime);
-        });
+  const throughputPerSprint = displaySprints.map(s =>
+    (s.events || []).filter(ev => ev.completedDate).length
+  );
+
+  const cycleTimePerSprint = displaySprints.map((s, idx) => {
+    const sprintStart = s.startDate ? new Date(s.startDate) : null;
+    if (!sprintStart || sprintStart <= CYCLE_TIME_START) return null;
+    const windowSprints = displaySprints
+      .slice(Math.max(0, idx - 4), idx + 1)
+      .filter(ws => ws.startDate && new Date(ws.startDate) > CYCLE_TIME_START);
+    const times = [];
+    windowSprints.forEach(ws => {
+      (ws.events || []).forEach(ev => {
+        if (typeof ev.cycleTime === 'number') times.push(ev.cycleTime);
       });
-      if (!times.length) return null;
-      times.sort((a, b) => a - b);
-      const mid = Math.floor(times.length / 2);
-      const median = times.length % 2 ? times[mid] : (times[mid - 1] + times[mid]) / 2;
-      return Number(median.toFixed(1));
     });
-  const chartWidth = Math.max(sprintLabels.length * 120, 600);
-  const canvasTypes = {
-    piMixChart: 'pi',
-    completedChart: 'rating',
-    throughputChart: 'throughput',
-    cycleTimeChart: 'cycle',
-    disruptionChart: 'disruption'
-  };
-  Object.entries(canvasTypes).forEach(([id, type]) => {
-    const canvas = document.getElementById(id);
-    canvas.width = chartWidth;
-    canvas.height = 300;
-    canvas.dataset.type = type;
+    if (!times.length) return null;
+    times.sort((a, b) => a - b);
+    const mid = Math.floor(times.length / 2);
+    const median = times.length % 2 ? times[mid] : (times[mid - 1] + times[mid]) / 2;
+    return Number(median.toFixed(1));
   });
+
+  const chartWidth = Math.max(sprintLabels.length * 120, 600);
+  const piTitle = document.createElement('h2');
+  piTitle.textContent = 'Initially planned & completed';
+  container.appendChild(piTitle);
+  const piCanvas = document.createElement('canvas');
+  piCanvas.width = chartWidth;
+  piCanvas.height = 300;
+  piCanvas.dataset.type = 'pi';
+  container.appendChild(piCanvas);
+
+  const completedTitle = document.createElement('h2');
+  completedTitle.textContent = 'Rating Zone Chart';
+  container.appendChild(completedTitle);
+  const completedCanvas = document.createElement('canvas');
+  completedCanvas.width = chartWidth;
+  completedCanvas.height = 300;
+  completedCanvas.dataset.type = 'rating';
+  container.appendChild(completedCanvas);
+
+  const throughputTitle = document.createElement('h2');
+  throughputTitle.textContent = 'Throughput per Sprint';
+  container.appendChild(throughputTitle);
+  const throughputCanvas = document.createElement('canvas');
+  throughputCanvas.width = chartWidth;
+  throughputCanvas.height = 300;
+  throughputCanvas.dataset.type = 'throughput';
+  container.appendChild(throughputCanvas);
+
+  const cycleTitle = document.createElement('h2');
+  cycleTitle.textContent = 'Cycle Time (5-sprint median)';
+  container.appendChild(cycleTitle);
+  const cycleCanvas = document.createElement('canvas');
+  cycleCanvas.width = chartWidth;
+  cycleCanvas.height = 300;
+  cycleCanvas.dataset.type = 'cycle';
+  container.appendChild(cycleCanvas);
+
+  const disruptionTitle = document.createElement('h2');
+  disruptionTitle.textContent = 'Disruption Metrics';
+  container.appendChild(disruptionTitle);
+  const disruptionCanvas = document.createElement('canvas');
+  disruptionCanvas.width = chartWidth;
+  disruptionCanvas.height = 300;
+  disruptionCanvas.dataset.type = 'disruption';
+  container.appendChild(disruptionCanvas);
 
   const zonesBySprintAll = [];
   const avgBySprintAll = [];
@@ -695,24 +716,7 @@ function renderCharts(displaySprints, allSprints) {
     }
   };
 
-  // Destroy existing charts if they exist to allow re-rendering without errors
-  if (piMixChartInstance) {
-    piMixChartInstance.destroy();
-  }
-  if (completedChartInstance) {
-    completedChartInstance.destroy();
-  }
-  if (disruptionChartInstance) {
-    disruptionChartInstance.destroy();
-  }
-  if (throughputChartInstance) {
-    throughputChartInstance.destroy();
-  }
-  if (cycleTimeChartInstance) {
-    cycleTimeChartInstance.destroy();
-  }
-
-  const pctx = document.getElementById('piMixChart').getContext('2d');
+  const pctx = piCanvas.getContext('2d');
 
   function makeDiagonalPattern(ctx, color) {
     const size = 8;
@@ -738,7 +742,7 @@ function renderCharts(displaySprints, allSprints) {
   const plannedPIFill = makeDiagonalPattern(pctx, plannedPIColor);
   const plannedOtherFill = makeDiagonalPattern(pctx, plannedOtherColor);
 
-  piMixChartInstance = new Chart(pctx, {
+  const piMixChart = new Chart(pctx, {
     type: 'bar',
     data: {
       labels: sprintLabels,
@@ -785,7 +789,7 @@ function renderCharts(displaySprints, allSprints) {
               return completedTotal;
             }
           }
-        },
+        }
       ]
     },
     options: {
@@ -804,27 +808,23 @@ function renderCharts(displaySprints, allSprints) {
               const plannedTotal = (plannedPI[i] || 0) + (plannedOther[i] || 0);
               const initCompleted = initialCompleted[i] || 0;
               const completedTotal = (completedPI[i] || 0) + (completedOther[i] || 0);
-              return `Initially Planned total: ${plannedTotal}\nInitial Plan completed: ${initCompleted}\nCompleted total: ${completedTotal}`;
+              return `Initially Planned total: ${plannedTotal}
+Initial Plan completed: ${initCompleted}
+Completed total: ${completedTotal}`;
             }
           }
         },
-        datalabels: {
-          display: false,
-          color: '#000',
-          anchor: 'end',
-          align: 'top'
-        }
+        datalabels: { display: false }
       }
     }
   });
 
-  const vctx = document.getElementById('completedChart').getContext('2d');
-  completedChartInstance = new Chart(vctx, {
+  const vctx = completedCanvas.getContext('2d');
+  const completedChart = new Chart(vctx, {
     type: 'line',
     data: {
       labels: sprintLabels,
       datasets: [
-        { label: 'Initially Planned SP', data: plannedSP, borderColor: '#f97316', backgroundColor: 'rgba(249,115,22,0.3)', fill: false, tension: 0.1 },
         { label: 'Completed SP', data: completedSP, borderColor: '#6366f1', backgroundColor: 'rgba(99,102,241,0.3)', fill: false, tension: 0.1 },
         { label: 'Average Velocity', data: avgBySprint, borderColor: '#000000', borderDash: [5,5], fill: false, tension: 0 }
       ]
@@ -839,19 +839,14 @@ function renderCharts(displaySprints, allSprints) {
       plugins: {
         legend: { position: 'bottom' },
         ratingZones: { zonesBySprint },
-        datalabels: {
-          display: false,
-          color: '#000',
-          anchor: 'end',
-          align: 'top'
-        }
+        datalabels: { display: false }
       }
     },
     plugins: [ratingZonesPlugin]
   });
 
-  const tctx = document.getElementById('throughputChart').getContext('2d');
-  throughputChartInstance = new Chart(tctx, {
+  const tctx = throughputCanvas.getContext('2d');
+  const throughputChart = new Chart(tctx, {
     type: 'bar',
     data: {
       labels: sprintLabels,
@@ -878,8 +873,8 @@ function renderCharts(displaySprints, allSprints) {
     }
   });
 
-  const cctx = document.getElementById('cycleTimeChart').getContext('2d');
-  cycleTimeChartInstance = new Chart(cctx, {
+  const cctx = cycleCanvas.getContext('2d');
+  const cycleTimeChart = new Chart(cctx, {
     type: 'bar',
     data: {
       labels: sprintLabels,
@@ -906,36 +901,67 @@ function renderCharts(displaySprints, allSprints) {
     }
   });
 
-  const dctx = document.getElementById('disruptionChart').getContext('2d');
-  disruptionChartInstance = new Chart(dctx, {
+  const dctx = disruptionCanvas.getContext('2d');
+  const disruptionChart = new Chart(dctx, {
     type: 'bar',
-      data: {
-        labels: sprintLabels,
-        datasets: [
-          { label: 'Pulled In Issues', data: pulledInCount, backgroundColor: '#3b82f6', borderColor: '#3b82f6' },
-          { label: 'Blocked Days', data: blockedDays, backgroundColor: '#ef4444', borderColor: '#ef4444' },
-          { label: 'Moved Out Issues', data: movedOutCount, backgroundColor: '#10b981', borderColor: '#10b981' },
-        ]
+    data: {
+      labels: sprintLabels,
+      datasets: [
+        { label: 'Pulled In Issues', data: pulledInCount, backgroundColor: '#3b82f6', borderColor: '#3b82f6' },
+        { label: 'Blocked Days', data: blockedDays, backgroundColor: '#ef4444', borderColor: '#ef4444' },
+        { label: 'Moved Out Issues', data: movedOutCount, backgroundColor: '#10b981', borderColor: '#10b981' }
+      ]
+    },
+    options: {
+      responsive: false,
+      maintainAspectRatio: false,
+      scales: {
+        x: { offset: true },
+        y: { beginAtZero: true, title: { display: true, text: 'Issue Count / Days' } }
       },
-      options: {
-        responsive: false,
-        maintainAspectRatio: false,
-        scales: {
-          x: { offset: true },
-          y: { beginAtZero: true, title: { display: true, text: 'Issue Count / Days' } }
-        },
-        plugins: {
-          legend: { position: 'bottom' },
-          datalabels: {
-            display: true,
-            color: '#000',
-            anchor: 'end',
-            align: 'top'
-          }
+      plugins: {
+        legend: { position: 'bottom' },
+        datalabels: {
+          display: true,
+          color: '#000',
+          anchor: 'end',
+          align: 'top'
         }
       }
-    });
+    }
+  });
 
+  return [piMixChart, completedChart, throughputChart, cycleTimeChart, disruptionChart];
+}
+
+function renderCharts(displaySprints, allSprints) {
+  const section = document.getElementById('chartSection');
+  if (!section) return;
+  section.innerHTML = '';
+  chartInstances.forEach(ch => ch.destroy());
+  chartInstances = [];
+  const byBoardDisplay = {};
+  (displaySprints || []).forEach(s => {
+    const board = s.board;
+    if (!byBoardDisplay[board]) byBoardDisplay[board] = [];
+    byBoardDisplay[board].push(s);
+  });
+  const byBoardAll = {};
+  (allSprints || []).forEach(s => {
+    const board = s.board;
+    if (!byBoardAll[board]) byBoardAll[board] = [];
+    byBoardAll[board].push(s);
+  });
+  Object.keys(byBoardDisplay).forEach(boardId => {
+    const title = document.createElement('h2');
+    title.textContent = boardLabels[boardId] || `Board ${boardId}`;
+    section.appendChild(title);
+    const wrap = document.createElement('div');
+    wrap.className = 'board-chart-wrapper';
+    section.appendChild(wrap);
+    const charts = renderBoardCharts(byBoardDisplay[boardId], byBoardAll[boardId] || [], wrap);
+    chartInstances.push(...charts);
+  });
 }
 
   function toggleDetails(id, btn) {
@@ -951,6 +977,8 @@ function renderCharts(displaySprints, allSprints) {
     const jiraDomain = document.getElementById('jiraDomain').value.trim();
     const selected = boardChoices ? boardChoices.getValue() : [];
     const boards = selected.map(b => b.value);
+    boardLabels = {};
+    selected.forEach(b => { boardLabels[b.value] = b.label; });
     if (!jiraDomain || !boards.length) {
       alert('Enter Jira domain and select boards.');
       return;
@@ -958,7 +986,13 @@ function renderCharts(displaySprints, allSprints) {
     Logger.info('Loading disruption report for boards', boards.join(','));
     const { sprints: fetchedSprints } = await fetchDisruptionData(jiraDomain, boards);
     allSprints = fetchedSprints;
-    sprints = filterRecentSprints(allSprints, [], DISPLAY_SPRINT_COUNT);
+    const byBoard = {};
+    fetchedSprints.forEach(s => {
+      if (!byBoard[s.board]) byBoard[s.board] = [];
+      byBoard[s.board].push(s);
+    });
+    Object.values(byBoard).forEach(arr => arr.sort((a, b) => new Date(a.startDate) - new Date(b.startDate)));
+    sprints = Object.values(byBoard).flatMap(arr => arr.slice(-DISPLAY_SPRINT_COUNT));
     renderTable(sprints);
     renderSprintList();
     document.getElementById('sprintRow').style.display = sprints.length ? '' : 'none';
@@ -982,52 +1016,67 @@ function renderCharts(displaySprints, allSprints) {
   function exportPDF() {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({ unit: 'pt', format: 'a4' });
-    const charts = [piMixChartInstance, completedChartInstance, throughputChartInstance, cycleTimeChartInstance, disruptionChartInstance];
+    const charts = [...chartInstances];
     charts.forEach(ch => {
-      if (ch && ch.options.plugins?.datalabels) {
-        const plugin = ch.options.plugins.datalabels;
-        plugin._origDisplay = plugin.display;
-        plugin.display = true;
-        ch.update();
+      if (!ch) return;
+      const legend = ch.options.plugins?.legend || (ch.options.plugins.legend = {});
+      const labels = legend.labels || (legend.labels = {});
+      ch._origLegendFilter = labels.filter;
+      labels.filter = item => item.text && !item.hidden;
+      if (ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = true;
       }
+      ch.update();
     });
     const includePi = document.getElementById('includePi')?.checked;
     const includeRating = document.getElementById('includeRating')?.checked;
     const includeThroughput = document.getElementById('includeThroughput')?.checked;
     const includeCycle = document.getElementById('includeCycle')?.checked;
     const includeDisruption = document.getElementById('includeDisruption')?.checked;
-    const canvases = document.querySelectorAll('#chartSection canvas');
     const pageWidth = pdf.internal.pageSize.getWidth();
     const pageHeight = pdf.internal.pageSize.getHeight();
     const margin = 20;
     let y = margin;
-    canvases.forEach(cv => {
-      const type = cv.dataset.type;
-      if ((type === 'pi' && !includePi) ||
-          (type === 'rating' && !includeRating) ||
-          (type === 'throughput' && !includeThroughput) ||
-          (type === 'cycle' && !includeCycle) ||
-          (type === 'disruption' && !includeDisruption)) {
-        return;
+    const section = document.getElementById('chartSection');
+    const children = section ? Array.from(section.children) : [];
+    for (let i = 0; i < children.length; i += 2) {
+      const boardTitleEl = children[i];
+      const wrapper = children[i + 1];
+      const boardTitle = boardTitleEl?.textContent?.trim() || '';
+      const elems = Array.from(wrapper.children);
+      for (let j = 0; j < elems.length; j += 2) {
+        const chartTitleEl = elems[j];
+        const canvas = elems[j + 1];
+        const type = canvas.dataset.type;
+        if ((type === 'pi' && !includePi) || (type === 'rating' && !includeRating) || (type === 'throughput' && !includeThroughput) || (type === 'cycle' && !includeCycle) || (type === 'disruption' && !includeDisruption)) {
+          continue;
+        }
+        const width = pageWidth - margin * 2;
+        const height = canvas.height * width / canvas.width;
+        if (y + 14 + height > pageHeight - margin) {
+          pdf.addPage();
+          y = margin;
+        }
+        pdf.setFontSize(12);
+        pdf.text(`${boardTitle} - ${chartTitleEl.textContent.trim()}`, margin, y);
+        y += 14;
+        pdf.addImage(canvasToHighResDataURL(canvas), 'PNG', margin, y, width, height);
+        y += height + 10;
       }
-      const img = canvasToHighResDataURL(cv);
-      const width = pageWidth - margin * 2;
-      const height = cv.height * width / cv.width;
-      if (y + height > pageHeight - margin) {
-        pdf.addPage();
-        y = margin;
-      }
-      pdf.addImage(img, 'PNG', margin, y, width, height);
-      y += height + 10;
-    });
+    }
     const dateStr = new Date().toISOString().split('T')[0];
     pdf.save(`Disruption_Report_${dateStr}.pdf`);
     charts.forEach(ch => {
-      if (ch && ch.options.plugins?.datalabels) {
-        const plugin = ch.options.plugins.datalabels;
-        plugin.display = plugin._origDisplay;
-        ch.update();
+      if (!ch) return;
+      const legendLabels = ch.options.plugins?.legend?.labels;
+      if (legendLabels) {
+        legendLabels.filter = ch._origLegendFilter;
+        delete ch._origLegendFilter;
       }
+      if (ch.options.plugins?.datalabels) {
+        ch.options.plugins.datalabels.display = false;
+      }
+      ch.update();
     });
   }
 


### PR DESCRIPTION
## Summary
- Synchronize test.html fetching and visualization with KPI report
- Render board-specific charts dynamically and update PDF export

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68bad1201ea48325b9680bfe8298d73d