### PR TITLE
Add board group selection to KPI reports

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -135,6 +135,12 @@
   // an error about reusing a canvas that is already in use.
   let chartInstances = [];
   let boardLabels = {};
+  const BOARD_GROUPS = {
+    'SCO': ['4133', '4132', '4131'],
+    'MCO': ['2796', '2526', '6346'],
+    'Butterfly': ['6347', '6390'],
+    'ACOSS': ['2796', '2526', '6346', '4133', '4132', '4131', '6347', '6390', '4894']
+  };
   const DISPLAY_SPRINT_COUNT = 6;
   const RATING_WINDOW = 4;
   let sprints = [];
@@ -168,7 +174,11 @@
     try {
       const boards = await Jira.fetchBoardsByJql(domain);
       boardChoices.clearChoices();
-      boardChoices.setChoices(boards.map(b => ({ value: b.id, label: b.name })), 'value', 'label', true);
+      const groupChoices = Object.keys(BOARD_GROUPS).map(g => ({ value: g, label: g }));
+      boardChoices.setChoices([
+        ...boards.map(b => ({ value: String(b.id), label: b.name })),
+        ...groupChoices
+      ], 'value', 'label', true);
       boardChoices.removeActiveItems();
       boards.forEach(b => boardChoices.setChoiceByValue(String(b.id)));
       const show = boards.length ? '' : 'none';
@@ -204,9 +214,18 @@
       const combined = {};
       const issueCache = new Map();
       try {
-        await Promise.all(boardNums.map(async boardNum => {
+        const expandedBoards = [];
+        boardNums.forEach(b => {
+          if (BOARD_GROUPS[b]) {
+            BOARD_GROUPS[b].forEach(id => expandedBoards.push({ id, group: b }));
+          } else {
+            expandedBoards.push({ id: b, group: null });
+          }
+        });
+        await Promise.all(expandedBoards.map(async ({ id: boardNum, group }) => {
+          const boardKey = group || boardNum;
           const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
-          const isBfBoard = ['6390'].includes(String(boardNum));
+          const isBfBoard = ['6347', '6390'].includes(String(boardNum));
           const resp = await fetch(url, { credentials: 'include' });
           let data = {};
           if (resp.ok) {
@@ -486,10 +505,10 @@
               const initiallyPlannedSource = 'sum of events not added after start';
 
 
-              const key = `${boardNum}-${s.id}`;
-              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
+              const key = `${boardKey}-${boardNum}-${s.id}`;
+              const existing = combined[key] || { board: boardKey, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
               existing.id = existing.id || s.id;
-              existing.board = boardNum;
+              existing.board = boardKey;
               existing.startDate = existing.startDate || s.startDate;
               existing.events = existing.events.concat(events);
               existing.initiallyPlanned += initiallyPlanned || 0;

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -135,6 +135,12 @@
   // an error about reusing a canvas that is already in use.
   let chartInstances = [];
   let boardLabels = {};
+  const BOARD_GROUPS = {
+    'SCO': ['4133', '4132', '4131'],
+    'MCO': ['2796', '2526', '6346'],
+    'Butterfly': ['6347', '6390'],
+    'ACOSS': ['2796', '2526', '6346', '4133', '4132', '4131', '6347', '6390', '4894']
+  };
   const DISPLAY_SPRINT_COUNT = 6;
   const RATING_WINDOW = 4;
   let sprints = [];
@@ -168,7 +174,11 @@
     try {
       const boards = await Jira.fetchBoardsByJql(domain);
       boardChoices.clearChoices();
-      boardChoices.setChoices(boards.map(b => ({ value: b.id, label: b.name })), 'value', 'label', true);
+      const groupChoices = Object.keys(BOARD_GROUPS).map(g => ({ value: g, label: g }));
+      boardChoices.setChoices([
+        ...boards.map(b => ({ value: String(b.id), label: b.name })),
+        ...groupChoices
+      ], 'value', 'label', true);
       boardChoices.removeActiveItems();
       boards.forEach(b => boardChoices.setChoiceByValue(String(b.id)));
       const show = boards.length ? '' : 'none';
@@ -204,9 +214,18 @@
       const combined = {};
       const issueCache = new Map();
       try {
-        await Promise.all(boardNums.map(async boardNum => {
+        const expandedBoards = [];
+        boardNums.forEach(b => {
+          if (BOARD_GROUPS[b]) {
+            BOARD_GROUPS[b].forEach(id => expandedBoards.push({ id, group: b }));
+          } else {
+            expandedBoards.push({ id: b, group: null });
+          }
+        });
+        await Promise.all(expandedBoards.map(async ({ id: boardNum, group }) => {
+          const boardKey = group || boardNum;
           const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
-          const isBfBoard = ['6390'].includes(String(boardNum));
+          const isBfBoard = ['6347', '6390'].includes(String(boardNum));
           const resp = await fetch(url, { credentials: 'include' });
           let data = {};
           if (resp.ok) {
@@ -485,10 +504,10 @@
               const initiallyPlannedSource = 'sum of events not added after start';
 
 
-              const key = `${boardNum}-${s.id}`;
-              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
+              const key = `${boardKey}-${boardNum}-${s.id}`;
+              const existing = combined[key] || { board: boardKey, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
               existing.id = existing.id || s.id;
-              existing.board = boardNum;
+              existing.board = boardKey;
               existing.startDate = existing.startDate || s.startDate;
               existing.events = existing.events.concat(events);
               existing.initiallyPlanned += initiallyPlanned || 0;

--- a/test.html
+++ b/test.html
@@ -130,6 +130,12 @@
   // an error about reusing a canvas that is already in use.
   let chartInstances = [];
   let boardLabels = {};
+  const BOARD_GROUPS = {
+    'SCO': ['4133', '4132', '4131'],
+    'MCO': ['2796', '2526', '6346'],
+    'Butterfly': ['6347', '6390'],
+    'ACOSS': ['2796', '2526', '6346', '4133', '4132', '4131', '6347', '6390', '4894']
+  };
   const DISPLAY_SPRINT_COUNT = 10;
   const RATING_WINDOW = 4;
   const CYCLE_TIME_START = new Date('2025-06-09');
@@ -164,7 +170,11 @@
     try {
       const boards = await Jira.fetchBoardsByJql(domain);
       boardChoices.clearChoices();
-      boardChoices.setChoices(boards.map(b => ({ value: b.id, label: b.name })), 'value', 'label', true);
+      const groupChoices = Object.keys(BOARD_GROUPS).map(g => ({ value: g, label: g }));
+      boardChoices.setChoices([
+        ...boards.map(b => ({ value: String(b.id), label: b.name })),
+        ...groupChoices
+      ], 'value', 'label', true);
       boardChoices.removeActiveItems();
       boards.forEach(b => boardChoices.setChoiceByValue(String(b.id)));
       const show = boards.length ? '' : 'none';
@@ -200,7 +210,16 @@
       const combined = {};
       const issueCache = new Map();
       try {
-        await Promise.all(boardNums.map(async boardNum => {
+        const expandedBoards = [];
+        boardNums.forEach(b => {
+          if (BOARD_GROUPS[b]) {
+            BOARD_GROUPS[b].forEach(id => expandedBoards.push({ id, group: b }));
+          } else {
+            expandedBoards.push({ id: b, group: null });
+          }
+        });
+        await Promise.all(expandedBoards.map(async ({ id: boardNum, group }) => {
+          const boardKey = group || boardNum;
           const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
           const isBfBoard = ['6347', '6390'].includes(String(boardNum));
           const resp = await fetch(url, { credentials: 'include' });
@@ -461,10 +480,10 @@
                 .filter(ev => !ev.addedAfterStart && !ev.removedBeforeStart)
                 .reduce((sum, ev) => sum + (ev.initialPoints ?? ev.points ?? 0), 0);
               const initiallyPlannedSource = 'sum of events not added after start';
-              const key = `${boardNum}-${s.id}`;
-              const existing = combined[key] || { board: boardNum, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
+              const key = `${boardKey}-${boardNum}-${s.id}`;
+              const existing = combined[key] || { board: boardKey, id: s.id, name: s.name, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
               existing.id = existing.id || s.id;
-              existing.board = boardNum;
+              existing.board = boardKey;
               existing.startDate = existing.startDate || s.startDate;
               existing.events = existing.events.concat(events);
               existing.initiallyPlanned += initiallyPlanned || 0;


### PR DESCRIPTION
## Summary
- allow selecting predefined board groups (SCO, MCO, Butterfly, ACOSS) in KPI reports and test page
- expand data fetch logic to aggregate selected group boards as a single board

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68bea7194fac8325b35736704e4e3d3c