### PR TITLE
Avoid auto-loading and preselection for board groups

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -180,13 +180,9 @@
         ...groupChoices
       ], 'value', 'label', true);
       boardChoices.removeActiveItems();
-      boards.forEach(b => boardChoices.setChoiceByValue(String(b.id)));
       const show = boards.length ? '' : 'none';
       document.getElementById('boardLabel').style.display = show;
       document.getElementById('loadBtn').style.display = show;
-      if (boards.length) {
-        loadDisruption();
-      }
     } catch (e) {
       Logger.error('Failed to load boards', e);
     }

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -180,13 +180,9 @@
         ...groupChoices
       ], 'value', 'label', true);
       boardChoices.removeActiveItems();
-      boards.forEach(b => boardChoices.setChoiceByValue(String(b.id)));
       const show = boards.length ? '' : 'none';
       document.getElementById('boardLabel').style.display = show;
       document.getElementById('loadBtn').style.display = show;
-      if (boards.length) {
-        loadDisruption();
-      }
     } catch (e) {
       Logger.error('Failed to load boards', e);
     }

--- a/test.html
+++ b/test.html
@@ -176,13 +176,9 @@
         ...groupChoices
       ], 'value', 'label', true);
       boardChoices.removeActiveItems();
-      boards.forEach(b => boardChoices.setChoiceByValue(String(b.id)));
       const show = boards.length ? '' : 'none';
       document.getElementById('boardLabel').style.display = show;
       document.getElementById('loadBtn').style.display = show;
-      if (boards.length) {
-        loadDisruption();
-      }
     } catch (e) {
       Logger.error('Failed to load boards', e);
     }


### PR DESCRIPTION
## Summary
- Leave board selections empty when loading KPI report pages
- Load reports only after clicking **Load Data**

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bea98b8ea883259f18e456b0921182