### PR TITLE
Fix group sprint aggregation using start date key

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -536,7 +536,11 @@
 
               groups.forEach(group => {
                 const sprintName = extractSprintKey(s.name) || s.name;
-                const key = `${group}-${sprintName}`;
+                // Use the sprint start date as the aggregation key to ensure that
+                // all boards for the same time period are combined even if their
+                // sprint names differ.
+                const groupKey = s.startDate ? new Date(s.startDate).toISOString().split('T')[0] : sprintName;
+                const key = `${group}-${groupKey}`;
                 const existing = combined[key] || { board: group, id: sprintName, name: sprintName, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
                 existing.startDate = !existing.startDate || new Date(existing.startDate) > new Date(s.startDate) ? s.startDate : existing.startDate;
                 existing.events = existing.events.concat(events);

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -535,7 +535,10 @@
 
               groups.forEach(group => {
                 const sprintName = extractSprintKey(s.name) || s.name;
-                const key = `${group}-${sprintName}`;
+                // Aggregate group data using the sprint start date to avoid
+                // discrepancies when sprint names differ between boards.
+                const groupKey = s.startDate ? new Date(s.startDate).toISOString().split('T')[0] : sprintName;
+                const key = `${group}-${groupKey}`;
                 const existing = combined[key] || { board: group, id: sprintName, name: sprintName, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
                 existing.startDate = !existing.startDate || new Date(existing.startDate) > new Date(s.startDate) ? s.startDate : existing.startDate;
                 existing.events = existing.events.concat(events);


### PR DESCRIPTION
## Summary
- ensure KPI group metrics sum board values by aggregating on sprint start date when names differ

## Testing
- `node test/disruption.test.js && node test/epicLabelsConsole.test.js && node test/extractSprintKey.test.js && node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bed5c501088325b1ce8b309fbd27cd