### PR TITLE
Aggregate board metrics to compute group totals

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -243,7 +243,6 @@
         });
         const fetchBoards = Array.from(new Set(uniqueBoards));
         await Promise.all(fetchBoards.map(async boardNum => {
-          const groups = boardToGroups[boardNum] || [];
           const boardKey = boardNum;
           const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
           const isBfBoard = ['6347', '6390'].includes(String(boardNum));
@@ -533,21 +532,6 @@
               existingBoard.initiallyPlanned += initiallyPlanned || 0;
               existingBoard.completed += completed || 0;
               combined[boardEntryKey] = existingBoard;
-
-              groups.forEach(group => {
-                const sprintName = extractSprintKey(s.name) || s.name;
-                // Use the sprint start date as the aggregation key to ensure that
-                // all boards for the same time period are combined even if their
-                // sprint names differ.
-                const groupKey = s.startDate ? new Date(s.startDate).toISOString().split('T')[0] : sprintName;
-                const key = `${group}-${groupKey}`;
-                const existing = combined[key] || { board: group, id: sprintName, name: sprintName, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
-                existing.startDate = !existing.startDate || new Date(existing.startDate) > new Date(s.startDate) ? s.startDate : existing.startDate;
-                existing.events = existing.events.concat(events);
-                existing.initiallyPlanned += initiallyPlanned || 0;
-                existing.completed += completed || 0;
-                combined[key] = existing;
-              });
             } catch (e) {
               Logger.error('sprint fetch failed', e);
             }
@@ -555,7 +539,7 @@
         }));
         Logger.info('Disruption data fetched for', Object.keys(combined).length, 'sprints');
         const sprintsArr = Object.values(combined).sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
-        return { sprints: sprintsArr };
+        return { sprints: sprintsArr, boardToGroups };
       } catch (e) {
         Logger.error('Failed to fetch disruption data', e);
         alert('Failed to fetch disruption data.');
@@ -568,7 +552,7 @@
     let html = '';
     const sorted = data.slice().sort((a, b) => new Date(b.startDate || 0) - new Date(a.startDate || 0));
     sorted.forEach((sprint, idx) => {
-      const metrics = Disruption.calculateDisruptionMetrics(sprint.events);
+      const metrics = sprint.metrics || Disruption.calculateDisruptionMetrics(sprint.events);
       const detailsId = `details-${idx}`;
       const events = sprint.events || [];
       const piCompleted = events.filter(ev => ev.piRelevant && ev.completed).map(ev => ev.key);
@@ -655,7 +639,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const sprintLabels = displaySprints.map(s => s.name);
   const completedSPAll = (allSprints || displaySprints).map(s => s.completed || 0);
   const completedSP = completedSPAll.slice(-displaySprints.length);
-  const metricsArr = displaySprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
+  const metricsArr = displaySprints.map(s => s.metrics || Disruption.calculateDisruptionMetrics(s.events));
   const pulledInCount = metricsArr.map(m => m.pulledInCount || 0);
   const blockedDays = metricsArr.map(m => Math.ceil((m.blockedDays || 0) * 10) / 10);
   const blockedCount = metricsArr.map(m => m.blockedCount || 0);
@@ -1087,13 +1071,67 @@ function renderCharts(displaySprints, allSprints) {
       return;
     }
     Logger.info('Loading disruption report for boards', boards.join(','));
-    const { sprints: fetchedSprints } = await fetchDisruptionData(jiraDomain, boards);
+    const { sprints: fetchedSprints, boardToGroups } = await fetchDisruptionData(jiraDomain, boards);
     allSprints = fetchedSprints;
+    fetchedSprints.forEach(s => { s.metrics = Disruption.calculateDisruptionMetrics(s.events); });
     const byBoard = {};
     fetchedSprints.forEach(s => {
       if (!byBoard[s.board]) byBoard[s.board] = [];
       byBoard[s.board].push(s);
     });
+
+    const groupMap = {};
+    Object.entries(boardToGroups || {}).forEach(([boardId, groups]) => {
+      groups.forEach(g => {
+        if (!groupMap[g]) groupMap[g] = [];
+        groupMap[g].push(boardId);
+      });
+    });
+
+    const groupSprints = {};
+    Object.entries(groupMap).forEach(([group, boardIds]) => {
+      boardIds.forEach(id => {
+        (byBoard[id] || []).forEach(s => {
+          const sprintName = extractSprintKey(s.name) || s.name;
+          const groupKey = s.startDate ? new Date(s.startDate).toISOString().split('T')[0] : sprintName;
+          const key = `${group}-${groupKey}`;
+          const existing = groupSprints[key] || { board: group, id: sprintName, name: sprintName, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, metrics: { pulledIn: 0, blockedDays: 0, movedOut: 0, spillover: 0, pulledInIssues: new Set(), blockedIssues: new Set(), movedOutIssues: new Set(), spilloverIssues: new Set() } };
+          existing.startDate = !existing.startDate || new Date(existing.startDate) > new Date(s.startDate) ? s.startDate : existing.startDate;
+          existing.events = existing.events.concat(s.events || []);
+          existing.initiallyPlanned += s.initiallyPlanned || 0;
+          existing.completed += s.completed || 0;
+          const m = s.metrics || {};
+          existing.metrics.pulledIn += m.pulledIn || 0;
+          existing.metrics.blockedDays += m.blockedDays || 0;
+          existing.metrics.movedOut += m.movedOut || 0;
+          existing.metrics.spillover += m.spillover || 0;
+          (m.pulledInIssues || []).forEach(k => existing.metrics.pulledInIssues.add(k));
+          (m.blockedIssues || []).forEach(k => existing.metrics.blockedIssues.add(k));
+          (m.movedOutIssues || []).forEach(k => existing.metrics.movedOutIssues.add(k));
+          (m.spilloverIssues || []).forEach(k => existing.metrics.spilloverIssues.add(k));
+          groupSprints[key] = existing;
+        });
+      });
+    });
+
+    const groupArr = Object.values(groupSprints).map(s => {
+      const m = s.metrics;
+      m.pulledInCount = m.pulledInIssues.size;
+      m.blockedCount = m.blockedIssues.size;
+      m.movedOutCount = m.movedOutIssues.size;
+      m.spilloverCount = m.spilloverIssues.size;
+      m.pulledInIssues = Array.from(m.pulledInIssues);
+      m.blockedIssues = Array.from(m.blockedIssues);
+      m.movedOutIssues = Array.from(m.movedOutIssues);
+      m.spilloverIssues = Array.from(m.spilloverIssues);
+      return s;
+    });
+
+    groupArr.forEach(s => {
+      if (!byBoard[s.board]) byBoard[s.board] = [];
+      byBoard[s.board].push(s);
+    });
+
     Object.values(byBoard).forEach(arr => arr.sort((a, b) => new Date(a.startDate) - new Date(b.startDate)));
     sprints = Object.values(byBoard).flatMap(arr => arr.slice(-DISPLAY_SPRINT_COUNT));
     renderTable(sprints);

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -243,7 +243,6 @@
         });
         const fetchBoards = Array.from(new Set(uniqueBoards));
         await Promise.all(fetchBoards.map(async boardNum => {
-          const groups = boardToGroups[boardNum] || [];
           const boardKey = boardNum;
           const url = `https://${jiraDomain}/rest/greenhopper/1.0/rapid/charts/velocity?rapidViewId=${boardNum}`;
           const isBfBoard = ['6347', '6390'].includes(String(boardNum));
@@ -532,20 +531,6 @@
               existingBoard.initiallyPlanned += initiallyPlanned || 0;
               existingBoard.completed += completed || 0;
               combined[boardEntryKey] = existingBoard;
-
-              groups.forEach(group => {
-                const sprintName = extractSprintKey(s.name) || s.name;
-                // Aggregate group data using the sprint start date to avoid
-                // discrepancies when sprint names differ between boards.
-                const groupKey = s.startDate ? new Date(s.startDate).toISOString().split('T')[0] : sprintName;
-                const key = `${group}-${groupKey}`;
-                const existing = combined[key] || { board: group, id: sprintName, name: sprintName, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, initiallyPlannedSource, completedSource };
-                existing.startDate = !existing.startDate || new Date(existing.startDate) > new Date(s.startDate) ? s.startDate : existing.startDate;
-                existing.events = existing.events.concat(events);
-                existing.initiallyPlanned += initiallyPlanned || 0;
-                existing.completed += completed || 0;
-                combined[key] = existing;
-              });
             } catch (e) {
               Logger.error('sprint fetch failed', e);
             }
@@ -553,7 +538,7 @@
         }));
         Logger.info('Disruption data fetched for', Object.keys(combined).length, 'sprints');
         const sprintsArr = Object.values(combined).sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
-        return { sprints: sprintsArr };
+        return { sprints: sprintsArr, boardToGroups };
       } catch (e) {
         Logger.error('Failed to fetch disruption data', e);
         alert('Failed to fetch disruption data.');
@@ -566,7 +551,7 @@
     let html = '';
     const sorted = data.slice().sort((a, b) => new Date(b.startDate || 0) - new Date(a.startDate || 0));
     sorted.forEach((sprint, idx) => {
-      const metrics = Disruption.calculateDisruptionMetrics(sprint.events);
+      const metrics = sprint.metrics || Disruption.calculateDisruptionMetrics(sprint.events);
       const detailsId = `details-${idx}`;
       const events = sprint.events || [];
       const piCompleted = events.filter(ev => ev.piRelevant && ev.completed).map(ev => ev.key);
@@ -653,7 +638,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const sprintLabels = displaySprints.map(s => s.name);
   const completedSPAll = (allSprints || displaySprints).map(s => s.completed || 0);
   const completedSP = completedSPAll.slice(-displaySprints.length);
-  const metricsArr = displaySprints.map(s => Disruption.calculateDisruptionMetrics(s.events));
+  const metricsArr = displaySprints.map(s => s.metrics || Disruption.calculateDisruptionMetrics(s.events));
   const pulledInCount = metricsArr.map(m => m.pulledInCount || 0);
   const blockedDays = metricsArr.map(m => Math.ceil((m.blockedDays || 0) * 10) / 10);
   const blockedCount = metricsArr.map(m => m.blockedCount || 0);
@@ -1069,13 +1054,67 @@ function renderCharts(displaySprints, allSprints) {
       return;
     }
     Logger.info('Loading disruption report for boards', boards.join(','));
-    const { sprints: fetchedSprints } = await fetchDisruptionData(jiraDomain, boards);
+    const { sprints: fetchedSprints, boardToGroups } = await fetchDisruptionData(jiraDomain, boards);
     allSprints = fetchedSprints;
+    fetchedSprints.forEach(s => { s.metrics = Disruption.calculateDisruptionMetrics(s.events); });
     const byBoard = {};
     fetchedSprints.forEach(s => {
       if (!byBoard[s.board]) byBoard[s.board] = [];
       byBoard[s.board].push(s);
     });
+
+    const groupMap = {};
+    Object.entries(boardToGroups || {}).forEach(([boardId, groups]) => {
+      groups.forEach(g => {
+        if (!groupMap[g]) groupMap[g] = [];
+        groupMap[g].push(boardId);
+      });
+    });
+
+    const groupSprints = {};
+    Object.entries(groupMap).forEach(([group, boardIds]) => {
+      boardIds.forEach(id => {
+        (byBoard[id] || []).forEach(s => {
+          const sprintName = extractSprintKey(s.name) || s.name;
+          const groupKey = s.startDate ? new Date(s.startDate).toISOString().split('T')[0] : sprintName;
+          const key = `${group}-${groupKey}`;
+          const existing = groupSprints[key] || { board: group, id: sprintName, name: sprintName, startDate: s.startDate, events: [], initiallyPlanned: 0, completed: 0, metrics: { pulledIn: 0, blockedDays: 0, movedOut: 0, spillover: 0, pulledInIssues: new Set(), blockedIssues: new Set(), movedOutIssues: new Set(), spilloverIssues: new Set() } };
+          existing.startDate = !existing.startDate || new Date(existing.startDate) > new Date(s.startDate) ? s.startDate : existing.startDate;
+          existing.events = existing.events.concat(s.events || []);
+          existing.initiallyPlanned += s.initiallyPlanned || 0;
+          existing.completed += s.completed || 0;
+          const m = s.metrics || {};
+          existing.metrics.pulledIn += m.pulledIn || 0;
+          existing.metrics.blockedDays += m.blockedDays || 0;
+          existing.metrics.movedOut += m.movedOut || 0;
+          existing.metrics.spillover += m.spillover || 0;
+          (m.pulledInIssues || []).forEach(k => existing.metrics.pulledInIssues.add(k));
+          (m.blockedIssues || []).forEach(k => existing.metrics.blockedIssues.add(k));
+          (m.movedOutIssues || []).forEach(k => existing.metrics.movedOutIssues.add(k));
+          (m.spilloverIssues || []).forEach(k => existing.metrics.spilloverIssues.add(k));
+          groupSprints[key] = existing;
+        });
+      });
+    });
+
+    const groupArr = Object.values(groupSprints).map(s => {
+      const m = s.metrics;
+      m.pulledInCount = m.pulledInIssues.size;
+      m.blockedCount = m.blockedIssues.size;
+      m.movedOutCount = m.movedOutIssues.size;
+      m.spilloverCount = m.spilloverIssues.size;
+      m.pulledInIssues = Array.from(m.pulledInIssues);
+      m.blockedIssues = Array.from(m.blockedIssues);
+      m.movedOutIssues = Array.from(m.movedOutIssues);
+      m.spilloverIssues = Array.from(m.spilloverIssues);
+      return s;
+    });
+
+    groupArr.forEach(s => {
+      if (!byBoard[s.board]) byBoard[s.board] = [];
+      byBoard[s.board].push(s);
+    });
+
     Object.values(byBoard).forEach(arr => arr.sort((a, b) => new Date(a.startDate) - new Date(b.startDate)));
     sprints = Object.values(byBoard).flatMap(arr => arr.slice(-DISPLAY_SPRINT_COUNT));
     renderTable(sprints);


### PR DESCRIPTION
## Summary
- Sum board sprint metrics to derive group data instead of recalculating from additional fetches
- Return selected board-to-group mapping for later aggregation
- Use precomputed metrics when rendering tables and charts

## Testing
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/extractSprintKey.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68beda4bf9f08325a5ec5efaeb15aa2c