### PR TITLE
Remove Topic Mix report option from selectors

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -42,7 +42,6 @@
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
         <option value="KPI_Report.html">KPI Report</option>
-        <option value="index_topicmix.html">Topic Mix</option>
       </select>
     </label>
   </div>

--- a/disruption.html
+++ b/disruption.html
@@ -41,7 +41,6 @@
         <option value="index_throughput.html">Throughput</option>
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
-        <option value="index_topicmix.html">Topic Mix</option>
       </select>
     </label>
   </div>

--- a/index.html
+++ b/index.html
@@ -119,7 +119,6 @@
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
           <option value="index_disruption.html">Disruption</option>
-          <option value="index_topicmix.html">Topic Mix</option>
         </select>
       </label>
     </div>

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -41,7 +41,6 @@
         <option value="index_throughput.html">Throughput</option>
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
-        <option value="index_topicmix.html">Topic Mix</option>
       </select>
     </label>
   </div>

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -119,7 +119,6 @@
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
           <option value="index_disruption.html">Disruption</option>
-          <option value="index_topicmix.html">Topic Mix</option>
         </select>
       </label>
     </div>

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -119,7 +119,6 @@
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
           <option value="index_disruption.html">Disruption</option>
-          <option value="index_topicmix.html">Topic Mix</option>
         </select>
       </label>
     </div>

--- a/index_topicmix.html
+++ b/index_topicmix.html
@@ -23,7 +23,6 @@
         <option value="index_throughput.html">Throughput</option>
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
-        <option value="index_topicmix.html">Topic Mix</option>
       </select>
     </label>
   </div>
@@ -267,7 +266,6 @@ async function loadTopicMix() {
   }
 }
 
-document.getElementById('versionSelect').value = 'index_topicmix.html';
 </script>
 </body>
 </html>

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -42,7 +42,6 @@
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
         <option value="KPI_Report.html">KPI Report</option>
-        <option value="index_topicmix.html">Topic Mix</option>
       </select>
     </label>
   </div>


### PR DESCRIPTION
## Summary
- remove Topic Mix from version dropdown across all report pages
- tidy up Topic Mix page by dropping self-selection reference

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68bff24cd6bc8325be603efa6a076d0d