### PR TITLE
Fix throughput calculation to exclude spillovers

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -614,7 +614,7 @@ function renderVelocityStats(allSprints) {
 
     (allSprints || []).forEach(s => {
       (s.events || []).forEach(ev => {
-        if (ev.completedDate) {
+        if (ev.completed) {
           totalCompleted++;
           const sprintStart = s.startDate ? new Date(s.startDate) : null;
           if (sprintStart && sprintStart > CYCLE_TIME_START && typeof ev.cycleTime === 'number') {
@@ -677,7 +677,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   );
 
   const throughputPerSprint = displaySprints.map(s =>
-    (s.events || []).filter(ev => ev.completedDate).length
+    (s.events || []).filter(ev => ev.completed).length
   );
 
   const cycleTimePerSprint = displaySprints.map((s, idx) => {

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -613,7 +613,7 @@ function renderVelocityStats(allSprints) {
 
     (allSprints || []).forEach(s => {
       (s.events || []).forEach(ev => {
-        if (ev.completedDate) {
+        if (ev.completed) {
           totalCompleted++;
           const sprintStart = s.startDate ? new Date(s.startDate) : null;
           if (sprintStart && sprintStart > CYCLE_TIME_START && typeof ev.cycleTime === 'number') {
@@ -670,7 +670,7 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   );
 
   const throughputPerSprint = displaySprints.map(s =>
-    (s.events || []).filter(ev => ev.completedDate).length
+    (s.events || []).filter(ev => ev.completed).length
   );
 
   const cycleTimePerSprint = displaySprints.map((s, idx) => {


### PR DESCRIPTION
## Summary
- ensure KPI report pages count throughput based on completed issues only
- adjust overall throughput stats to ignore spillovers

## Testing
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/extractSprintKey.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bff6ace38c83258b812effc6dbe1dc