### PR TITLE
Aggregate group sprints by recency

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -1116,8 +1116,12 @@ function renderCharts(displaySprints, allSprints) {
           const s = arr[arr.length - 1 - i];
           if (!s) return;
           found = true;
-          const sprintName = extractSprintKey(s.name) || s.name;
-          if (!agg.name) { agg.name = sprintName; agg.id = sprintName; }
+          if (!agg.name) {
+            const sprintNum = i + 1;
+            const sprintName = `${group} ${sprintNum}`;
+            agg.name = sprintName;
+            agg.id = sprintName;
+          }
           if (!agg.startDate || new Date(agg.startDate) > new Date(s.startDate)) {
             agg.startDate = s.startDate;
           }
@@ -1152,7 +1156,17 @@ function renderCharts(displaySprints, allSprints) {
       byBoard[group] = aggregated;
     });
 
-    sprints = Object.values(byBoard).flatMap(arr => arr.slice(-DISPLAY_SPRINT_COUNT));
+    const selectedDisplay = [];
+    const selectedAll = [];
+    boards.forEach(b => {
+      const arr = byBoard[b];
+      if (arr) {
+        selectedAll.push(...arr);
+        selectedDisplay.push(...arr.slice(-DISPLAY_SPRINT_COUNT));
+      }
+    });
+    sprints = selectedDisplay;
+    allSprints = selectedAll;
     renderTable(sprints);
     renderSprintList();
     document.getElementById('sprintRow').style.display = sprints.length ? '' : 'none';

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -1099,8 +1099,12 @@ function renderCharts(displaySprints, allSprints) {
           const s = arr[arr.length - 1 - i];
           if (!s) return;
           found = true;
-          const sprintName = extractSprintKey(s.name) || s.name;
-          if (!agg.name) { agg.name = sprintName; agg.id = sprintName; }
+          if (!agg.name) {
+            const sprintNum = i + 1;
+            const sprintName = `${group} ${sprintNum}`;
+            agg.name = sprintName;
+            agg.id = sprintName;
+          }
           if (!agg.startDate || new Date(agg.startDate) > new Date(s.startDate)) {
             agg.startDate = s.startDate;
           }
@@ -1135,7 +1139,17 @@ function renderCharts(displaySprints, allSprints) {
       byBoard[group] = aggregated;
     });
 
-    sprints = Object.values(byBoard).flatMap(arr => arr.slice(-DISPLAY_SPRINT_COUNT));
+    const selectedDisplay = [];
+    const selectedAll = [];
+    boards.forEach(b => {
+      const arr = byBoard[b];
+      if (arr) {
+        selectedAll.push(...arr);
+        selectedDisplay.push(...arr.slice(-DISPLAY_SPRINT_COUNT));
+      }
+    });
+    sprints = selectedDisplay;
+    allSprints = selectedAll;
     renderTable(sprints);
     renderSprintList();
     document.getElementById('sprintRow').style.display = sprints.length ? '' : 'none';


### PR DESCRIPTION
## Summary
- Group selections now aggregate data from their member boards rather than fetching separately.
- Group sprint names follow a simple "group N" scheme ordered by most recent closures.
- Only the selected boards or groups contribute to charts and tables.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c138ab88b08325a073d8257b94f879