### PR TITLE
Visualize pulled-in spillovers with hatched bars

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -644,6 +644,8 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const blockedCount = metricsArr.map(m => m.blockedCount || 0);
   const movedOutCount = metricsArr.map(m => m.movedOutCount || 0);
   const spilloverCount = metricsArr.map(m => m.spilloverCount || 0);
+  const spilloverPulledInCount = metricsArr.map(m => m.spilloverPulledInCount || 0);
+  const spilloverOnlyCount = spilloverCount.map((n, i) => n - spilloverPulledInCount[i]);
 
 
   function sumSP(events, pred, field = 'points') {
@@ -987,23 +989,36 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   });
 
   const dctx = disruptionCanvas.getContext('2d');
+  const patternCanvas = document.createElement('canvas');
+  patternCanvas.width = 6;
+  patternCanvas.height = 6;
+  const pctx = patternCanvas.getContext('2d');
+  pctx.fillStyle = '#f59e0b';
+  pctx.fillRect(0, 0, 6, 6);
+  pctx.strokeStyle = '#ffffff';
+  pctx.beginPath();
+  pctx.moveTo(0, 6);
+  pctx.lineTo(6, 0);
+  pctx.stroke();
+  const hatchPattern = dctx.createPattern(patternCanvas, 'repeat');
   const disruptionChart = new Chart(dctx, {
     type: 'bar',
     data: {
       labels: sprintLabels,
       datasets: [
-        { label: 'Pulled In Issues', data: pulledInCount, backgroundColor: '#3b82f6', borderColor: '#3b82f6' },
-        { label: 'Blocked Days', data: blockedDays, backgroundColor: '#ef4444', borderColor: '#ef4444' },
-        { label: 'Moved Out Issues', data: movedOutCount, backgroundColor: '#10b981', borderColor: '#10b981' },
-        { label: 'Spillover Issues', data: spilloverCount, backgroundColor: '#f59e0b', borderColor: '#f59e0b' }
+        { label: 'Pulled In Issues', data: pulledInCount, backgroundColor: '#3b82f6', borderColor: '#3b82f6', stack: 'pulledIn' },
+        { label: 'Blocked Days', data: blockedDays, backgroundColor: '#ef4444', borderColor: '#ef4444', stack: 'blocked' },
+        { label: 'Moved Out Issues', data: movedOutCount, backgroundColor: '#10b981', borderColor: '#10b981', stack: 'movedOut' },
+        { label: 'Spillover Issues', data: spilloverOnlyCount, backgroundColor: '#f59e0b', borderColor: '#f59e0b', stack: 'spillover' },
+        { label: 'Spillover & Pulled In Issues', data: spilloverPulledInCount, backgroundColor: hatchPattern, borderColor: '#f59e0b', stack: 'spillover' }
       ]
     },
     options: {
       responsive: false,
       maintainAspectRatio: false,
       scales: {
-        x: { offset: true },
-        y: { beginAtZero: true, title: { display: true, text: 'Issue Count / Blocked Days' } }
+        x: { offset: true, stacked: true },
+        y: { beginAtZero: true, stacked: true, title: { display: true, text: 'Issue Count / Blocked Days' } }
       },
       plugins: {
         legend: { position: 'bottom' },

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -643,6 +643,8 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const blockedCount = metricsArr.map(m => m.blockedCount || 0);
   const movedOutCount = metricsArr.map(m => m.movedOutCount || 0);
   const spilloverCount = metricsArr.map(m => m.spilloverCount || 0);
+  const spilloverPulledInCount = metricsArr.map(m => m.spilloverPulledInCount || 0);
+  const spilloverOnlyCount = spilloverCount.map((n, i) => n - spilloverPulledInCount[i]);
 
 
   function sumSP(events, pred, field = 'points') {
@@ -970,23 +972,36 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   });
 
   const dctx = disruptionCanvas.getContext('2d');
+  const patternCanvas = document.createElement('canvas');
+  patternCanvas.width = 6;
+  patternCanvas.height = 6;
+  const pctx = patternCanvas.getContext('2d');
+  pctx.fillStyle = '#f59e0b';
+  pctx.fillRect(0, 0, 6, 6);
+  pctx.strokeStyle = '#ffffff';
+  pctx.beginPath();
+  pctx.moveTo(0, 6);
+  pctx.lineTo(6, 0);
+  pctx.stroke();
+  const hatchPattern = dctx.createPattern(patternCanvas, 'repeat');
   const disruptionChart = new Chart(dctx, {
     type: 'bar',
     data: {
       labels: sprintLabels,
       datasets: [
-        { label: 'Pulled In Issues', data: pulledInCount, backgroundColor: '#3b82f6', borderColor: '#3b82f6' },
-        { label: 'Blocked Days', data: blockedDays, backgroundColor: '#ef4444', borderColor: '#ef4444' },
-        { label: 'Moved Out Issues', data: movedOutCount, backgroundColor: '#10b981', borderColor: '#10b981' },
-        { label: 'Spillover Issues', data: spilloverCount, backgroundColor: '#f59e0b', borderColor: '#f59e0b' }
+        { label: 'Pulled In Issues', data: pulledInCount, backgroundColor: '#3b82f6', borderColor: '#3b82f6', stack: 'pulledIn' },
+        { label: 'Blocked Days', data: blockedDays, backgroundColor: '#ef4444', borderColor: '#ef4444', stack: 'blocked' },
+        { label: 'Moved Out Issues', data: movedOutCount, backgroundColor: '#10b981', borderColor: '#10b981', stack: 'movedOut' },
+        { label: 'Spillover Issues', data: spilloverOnlyCount, backgroundColor: '#f59e0b', borderColor: '#f59e0b', stack: 'spillover' },
+        { label: 'Spillover & Pulled In Issues', data: spilloverPulledInCount, backgroundColor: hatchPattern, borderColor: '#f59e0b', stack: 'spillover' }
       ]
     },
     options: {
       responsive: false,
       maintainAspectRatio: false,
       scales: {
-        x: { offset: true },
-        y: { beginAtZero: true, title: { display: true, text: 'Issue Count / Blocked Days' } }
+        x: { offset: true, stacked: true },
+        y: { beginAtZero: true, stacked: true, title: { display: true, text: 'Issue Count / Blocked Days' } }
       },
       plugins: {
         legend: { position: 'bottom' },

--- a/src/disruption.js
+++ b/src/disruption.js
@@ -27,10 +27,12 @@
       blockedIssues: new Set(),
       movedOutIssues: new Set(),
       spilloverIssues: new Set(),
+      spilloverPulledInIssues: new Set(),
       pulledInCount: 0,
       blockedCount: 0,
       movedOutCount: 0,
-      spilloverCount: 0
+      spilloverCount: 0,
+      spilloverPulledInCount: 0
     };
 
     // Track which categories each issue has already contributed to so the same
@@ -82,16 +84,25 @@
       }
     });
 
+    // Determine issues that were both pulled in and ended up as spillovers
+    metrics.spilloverIssues.forEach(key => {
+      if (metrics.pulledInIssues.has(key)) {
+        metrics.spilloverPulledInIssues.add(key);
+      }
+    });
+
     metrics.pulledInCount = metrics.pulledInIssues.size;
     metrics.blockedCount = metrics.blockedIssues.size;
     metrics.movedOutCount = metrics.movedOutIssues.size;
     metrics.spilloverCount = metrics.spilloverIssues.size;
+    metrics.spilloverPulledInCount = metrics.spilloverPulledInIssues.size;
 
     // Convert sets back to arrays for downstream consumers
     metrics.pulledInIssues = Array.from(metrics.pulledInIssues);
     metrics.blockedIssues = Array.from(metrics.blockedIssues);
     metrics.movedOutIssues = Array.from(metrics.movedOutIssues);
     metrics.spilloverIssues = Array.from(metrics.spilloverIssues);
+    metrics.spilloverPulledInIssues = Array.from(metrics.spilloverPulledInIssues);
 
     logger.debug('Calculated metrics', metrics);
     return metrics;

--- a/test/disruption.test.js
+++ b/test/disruption.test.js
@@ -51,4 +51,16 @@ const { calculateDisruptionMetrics } = require('../src/disruption');
   assert.deepStrictEqual(metrics.spilloverIssues, ['ST-5']);
 })();
 
+// Test spillover items that were pulled in after sprint start
+(() => {
+  const events = [
+    { key: 'ST-7', points: 2, addedAfterStart: true }
+  ];
+  const metrics = calculateDisruptionMetrics(events);
+  assert.strictEqual(metrics.pulledInCount, 1);
+  assert.strictEqual(metrics.spilloverCount, 1);
+  assert.strictEqual(metrics.spilloverPulledInCount, 1);
+  assert.deepStrictEqual(metrics.spilloverPulledInIssues, ['ST-7']);
+})();
+
 console.log('disruption tests passed');


### PR DESCRIPTION
## Summary
- track issues that were both pulled into a sprint after start and later spilled over
- split spillover metrics and draw hatched bar segment for pulled-in spillovers
- cover new metric with unit test

## Testing
- `node test/disruption.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2bc3ea5e88325b88188ea000c1e24