### PR TITLE
fix: rename pattern context to avoid redeclaration

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -992,14 +992,14 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const patternCanvas = document.createElement('canvas');
   patternCanvas.width = 6;
   patternCanvas.height = 6;
-  const pctx = patternCanvas.getContext('2d');
-  pctx.fillStyle = '#f59e0b';
-  pctx.fillRect(0, 0, 6, 6);
-  pctx.strokeStyle = '#ffffff';
-  pctx.beginPath();
-  pctx.moveTo(0, 6);
-  pctx.lineTo(6, 0);
-  pctx.stroke();
+  const patternCtx = patternCanvas.getContext('2d');
+  patternCtx.fillStyle = '#f59e0b';
+  patternCtx.fillRect(0, 0, 6, 6);
+  patternCtx.strokeStyle = '#ffffff';
+  patternCtx.beginPath();
+  patternCtx.moveTo(0, 6);
+  patternCtx.lineTo(6, 0);
+  patternCtx.stroke();
   const hatchPattern = dctx.createPattern(patternCanvas, 'repeat');
   const disruptionChart = new Chart(dctx, {
     type: 'bar',


### PR DESCRIPTION
## Summary
- prevent duplicate variable declarations in disruption pattern code

## Testing
- `node test/disruption.test.js` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bef803708325ba0a6406fa0bf29a