### PR TITLE
Make KPI tables responsive

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -13,7 +13,8 @@
   <style>
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
-    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+    .table-wrap { overflow-x: auto; }
+    table { border-collapse: collapse; min-width: 100%; margin-top: 20px; }
     th, td { border: 1px solid #e5e7eb; padding: 6px 10px; text-align:left; font-size:0.95em; }
     th { background:#e0e7ef; }
     .btn { background:#6366f1; color:#fff; border:none; border-radius:6px; padding:7px 18px; cursor:pointer; font-size:1em; }
@@ -67,7 +68,8 @@
   </div>
   <div id="logPanel" style="display:none; white-space:pre-wrap; font-size:0.85em; background:#f3f4f6; border:1px solid #e5e7eb; padding:6px; margin:10px 0; max-height:150px; overflow:auto;"></div>
   <div id="pdfContent">
-    <table>
+    <div class="table-wrap">
+      <table>
       <thead>
         <tr>
           <th>Sprint</th>
@@ -85,7 +87,8 @@
         </tr>
       </thead>
       <tbody id="metricsBody"></tbody>
-    </table>
+      </table>
+    </div>
     <div id="velocityStats"></div>
     <div id="chartSection" class="chart-section"></div>
     <div class="rating-zone-description">

--- a/disruption.html
+++ b/disruption.html
@@ -13,7 +13,8 @@
   <style>
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
-    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+    .table-wrap { overflow-x: auto; }
+    table { border-collapse: collapse; min-width: 100%; margin-top: 20px; }
     th, td { border: 1px solid #e5e7eb; padding: 6px 10px; text-align:left; font-size:0.95em; }
     th { background:#e0e7ef; }
     .btn { background:#6366f1; color:#fff; border:none; border-radius:6px; padding:7px 18px; cursor:pointer; font-size:1em; }
@@ -58,7 +59,8 @@
   </div>
   <div id="logPanel" style="display:none; white-space:pre-wrap; font-size:0.85em; background:#f3f4f6; border:1px solid #e5e7eb; padding:6px; margin:10px 0; max-height:150px; overflow:auto;"></div>
   <div id="pdfContent">
-    <table>
+    <div class="table-wrap">
+      <table>
       <thead>
         <tr>
           <th>Sprint</th>
@@ -71,7 +73,8 @@
         </tr>
       </thead>
       <tbody id="metricsBody"></tbody>
-    </table>
+      </table>
+    </div>
     <div id="velocityStats"></div>
     <div id="chartSection" class="chart-section">
       <h2>Initially planned &amp; completed</h2>

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -13,7 +13,8 @@
   <style>
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
-    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+    .table-wrap { overflow-x: auto; }
+    table { border-collapse: collapse; min-width: 100%; margin-top: 20px; }
     th, td { border: 1px solid #e5e7eb; padding: 6px 10px; text-align:left; font-size:0.95em; }
     th { background:#e0e7ef; }
     .btn { background:#6366f1; color:#fff; border:none; border-radius:6px; padding:7px 18px; cursor:pointer; font-size:1em; }
@@ -58,7 +59,8 @@
   </div>
   <div id="logPanel" style="display:none; white-space:pre-wrap; font-size:0.85em; background:#f3f4f6; border:1px solid #e5e7eb; padding:6px; margin:10px 0; max-height:150px; overflow:auto;"></div>
   <div id="pdfContent">
-    <table>
+    <div class="table-wrap">
+      <table>
       <thead>
         <tr>
           <th>Sprint</th>
@@ -71,7 +73,8 @@
         </tr>
       </thead>
       <tbody id="metricsBody"></tbody>
-    </table>
+      </table>
+    </div>
     <div id="velocityStats"></div>
     <div id="chartSection" class="chart-section">
       <h2>Initially planned &amp; completed</h2>

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -13,7 +13,8 @@
   <style>
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
-    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+    .table-wrap { overflow-x: auto; }
+    table { border-collapse: collapse; min-width: 100%; margin-top: 20px; }
     th, td { border: 1px solid #e5e7eb; padding: 6px 10px; text-align:left; font-size:0.95em; }
     th { background:#e0e7ef; }
     .btn { background:#6366f1; color:#fff; border:none; border-radius:6px; padding:7px 18px; cursor:pointer; font-size:1em; }
@@ -67,7 +68,8 @@
   </div>
   <div id="logPanel" style="display:none; white-space:pre-wrap; font-size:0.85em; background:#f3f4f6; border:1px solid #e5e7eb; padding:6px; margin:10px 0; max-height:150px; overflow:auto;"></div>
   <div id="pdfContent">
-    <table>
+    <div class="table-wrap">
+      <table>
       <thead>
         <tr>
           <th>Sprint</th>
@@ -85,7 +87,8 @@
         </tr>
       </thead>
       <tbody id="metricsBody"></tbody>
-    </table>
+      </table>
+    </div>
     <div id="velocityStats"></div>
     <div id="chartSection" class="chart-section"></div>
     <div class="rating-zone-description">

--- a/test.html
+++ b/test.html
@@ -13,7 +13,8 @@
   <style>
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
-    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+    .table-wrap { overflow-x: auto; }
+    table { border-collapse: collapse; min-width: 100%; margin-top: 20px; }
     th, td { border: 1px solid #e5e7eb; padding: 6px 10px; text-align:left; font-size:0.95em; }
     th { background:#e0e7ef; }
     .btn { background:#6366f1; color:#fff; border:none; border-radius:6px; padding:7px 18px; cursor:pointer; font-size:1em; }
@@ -65,7 +66,8 @@
   </div>
   <div id="logPanel" style="display:none; white-space:pre-wrap; font-size:0.85em; background:#f3f4f6; border:1px solid #e5e7eb; padding:6px; margin:10px 0; max-height:150px; overflow:auto;"></div>
   <div id="pdfContent">
-    <table>
+    <div class="table-wrap">
+      <table>
       <thead>
         <tr>
           <th>Sprint</th>
@@ -78,7 +80,8 @@
         </tr>
       </thead>
       <tbody id="metricsBody"></tbody>
-    </table>
+      </table>
+    </div>
     <div id="velocityStats"></div>
     <div id="chartSection" class="chart-section"></div>
     <div class="rating-zone-description">


### PR DESCRIPTION
## Summary
- Wrap KPI data tables in a scrollable container so wide datasets no longer overflow the page
- Add shared `.table-wrap` style for horizontal scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68c2beddd9208325b57a28424f312adf