### PR TITLE
Fix spillover & pulled-in metrics for grouped boards

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -1161,14 +1161,21 @@ function renderCharts(displaySprints, allSprints) {
       }
       aggregated.forEach(s => {
         const m = s.metrics;
-        m.pulledInCount = m.pulledInIssues.size;
-        m.blockedCount = m.blockedIssues.size;
-        m.movedOutCount = m.movedOutIssues.size;
-        m.spilloverCount = m.spilloverIssues.size;
-        m.pulledInIssues = Array.from(m.pulledInIssues);
-        m.blockedIssues = Array.from(m.blockedIssues);
-        m.movedOutIssues = Array.from(m.movedOutIssues);
-        m.spilloverIssues = Array.from(m.spilloverIssues);
+        const pulledSet = m.pulledInIssues;
+        const blockedSet = m.blockedIssues;
+        const movedOutSet = m.movedOutIssues;
+        const spillSet = m.spilloverIssues;
+        const spillPullSet = new Set([...pulledSet].filter(k => spillSet.has(k)));
+        m.pulledInCount = pulledSet.size;
+        m.blockedCount = blockedSet.size;
+        m.movedOutCount = movedOutSet.size;
+        m.spilloverCount = spillSet.size;
+        m.spilloverPulledInCount = spillPullSet.size;
+        m.pulledInIssues = Array.from(pulledSet);
+        m.blockedIssues = Array.from(blockedSet);
+        m.movedOutIssues = Array.from(movedOutSet);
+        m.spilloverIssues = Array.from(spillSet);
+        m.spilloverPulledInIssues = Array.from(spillPullSet);
       });
       aggregated.sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
       byBoard[group] = aggregated;

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -1144,14 +1144,21 @@ function renderCharts(displaySprints, allSprints) {
       }
       aggregated.forEach(s => {
         const m = s.metrics;
-        m.pulledInCount = m.pulledInIssues.size;
-        m.blockedCount = m.blockedIssues.size;
-        m.movedOutCount = m.movedOutIssues.size;
-        m.spilloverCount = m.spilloverIssues.size;
-        m.pulledInIssues = Array.from(m.pulledInIssues);
-        m.blockedIssues = Array.from(m.blockedIssues);
-        m.movedOutIssues = Array.from(m.movedOutIssues);
-        m.spilloverIssues = Array.from(m.spilloverIssues);
+        const pulledSet = m.pulledInIssues;
+        const blockedSet = m.blockedIssues;
+        const movedOutSet = m.movedOutIssues;
+        const spillSet = m.spilloverIssues;
+        const spillPullSet = new Set([...pulledSet].filter(k => spillSet.has(k)));
+        m.pulledInCount = pulledSet.size;
+        m.blockedCount = blockedSet.size;
+        m.movedOutCount = movedOutSet.size;
+        m.spilloverCount = spillSet.size;
+        m.spilloverPulledInCount = spillPullSet.size;
+        m.pulledInIssues = Array.from(pulledSet);
+        m.blockedIssues = Array.from(blockedSet);
+        m.movedOutIssues = Array.from(movedOutSet);
+        m.spilloverIssues = Array.from(spillSet);
+        m.spilloverPulledInIssues = Array.from(spillPullSet);
       });
       aggregated.sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
       byBoard[group] = aggregated;


### PR DESCRIPTION
## Summary
- correctly compute spillover & pulled-in intersection for aggregated board groups
- expose spilloverPulledIn counts for charts in grouped KPI reports

## Testing
- `node test/disruption.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/extractSprintKey.test.js`
- `node test/piPlanVsCompleteChart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2e0030b0483259f0905df050981f6