### PR TITLE
Exclude current week from weekly throughput

### DIFF
--- a/src/sim.js
+++ b/src/sim.js
@@ -14,12 +14,13 @@ function weekStart(dt) {
 function calculateWeeklyThroughput(issues, current=new Date()) {
   logger.debug('calculateWeeklyThroughput start', { count: issues.length, current });
   const counts = new Array(12).fill(0);
-  const currentWeek = weekStart(current);
+  const lastCompletedWeekStart = weekStart(current); // start of current week
+  lastCompletedWeekStart.setDate(lastCompletedWeekStart.getDate() - 7); // shift to last full week
   issues.forEach(it => {
     const dateStr = it.resolutiondate;
     if (!dateStr) return;
     const w = weekStart(dateStr);
-    const diff = Math.floor((currentWeek - w) / (7*24*60*60*1000));
+    const diff = Math.floor((lastCompletedWeekStart - w) / (7*24*60*60*1000));
     if (diff >= 0 && diff < 12) counts[11 - diff]++;
   });
   logger.debug('calculateWeeklyThroughput result', counts);


### PR DESCRIPTION
## Summary
- anchor weekly throughput calculations on the last completed week so the 12-week window omits the current in-progress week
- clarify variable naming around last completed week start

## Testing
- `node test/disruption.test.js`
- `node test/extractSprintKey.test.js`
- `node test/fetchIssuesBatch.test.js`
- `node test/fetchBoardsByJql.test.js`
- `node test/piPlanVsCompleteChart.test.js`
- `node test/epicLabelsConsole.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7d155105883258f05d03866ad9984