### PR TITLE
Revert exclusion of current week from throughput calculations

### DIFF
--- a/src/sim.js
+++ b/src/sim.js
@@ -14,13 +14,12 @@ function weekStart(dt) {
 function calculateWeeklyThroughput(issues, current=new Date()) {
   logger.debug('calculateWeeklyThroughput start', { count: issues.length, current });
   const counts = new Array(12).fill(0);
-  const lastCompletedWeekStart = weekStart(current); // start of current week
-  lastCompletedWeekStart.setDate(lastCompletedWeekStart.getDate() - 7); // shift to last full week
+  const currentWeek = weekStart(current);
   issues.forEach(it => {
     const dateStr = it.resolutiondate;
     if (!dateStr) return;
     const w = weekStart(dateStr);
-    const diff = Math.floor((lastCompletedWeekStart - w) / (7*24*60*60*1000));
+    const diff = Math.floor((currentWeek - w) / (7*24*60*60*1000));
     if (diff >= 0 && diff < 12) counts[11 - diff]++;
   });
   logger.debug('calculateWeeklyThroughput result', counts);


### PR DESCRIPTION
## Summary
- restore weekly throughput computation to include the current week

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68c7df23c5d88325b8027ec4566b32b3