### PR TITLE
Fix 410 error in weekly throughput fetches

### DIFF
--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -233,7 +233,7 @@ function addTooltipListeners() {
         return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
       }
       try {
-        const cfgUrl = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/configuration`;
+        const cfgUrl = `https://${jiraDomain}/rest/agile/latest/board/${boardNum}/configuration`;
         const cfgResp = await fetch(cfgUrl, { credentials: "include" });
         if (!cfgResp.ok) throw new Error('cfg');
         const cfg = await cfgResp.json();
@@ -290,7 +290,7 @@ function addTooltipListeners() {
     async function fetchBoardTeam() {
       boardTeams = [];
       try {
-        const cfgUrl = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/configuration`;
+        const cfgUrl = `https://${jiraDomain}/rest/agile/latest/board/${boardNum}/configuration`;
         const cfgResp = await fetch(cfgUrl, { credentials: "include" });
         if (!cfgResp.ok) return;
         const cfg = await cfgResp.json();
@@ -332,7 +332,7 @@ function addTooltipListeners() {
       let total = null;
 
       while (true) {
-        const url = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/sprint?maxResults=${maxResults}&startAt=${startAt}`;
+        const url = `https://${jiraDomain}/rest/agile/latest/board/${boardNum}/sprint?maxResults=${maxResults}&startAt=${startAt}`;
         console.log("Fetching sprints:", url);
         try {
           const resp = await fetch(url, { credentials: "include" });


### PR DESCRIPTION
## Summary
- revert velocity and sprint report calls in most reports back to `/rest/greenhopper/1.0`
- switch weekly throughput report to `/rest/agile/latest` configuration and sprint endpoints to resolve HTTP 410

## Testing
- `node test/disruption.test.js`
- `node test/extractSprintKey.test.js`
- `node test/fetchIssuesBatch.test.js`
- `node test/epicLabelsConsole.test.js`
- `node test/fetchBoardsByJql.test.js`
- `node test/piPlanVsCompleteChart.test.js`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68c7ff2447f4832594b911201a38dac5