### PR TITLE
Fix weekly throughput week selection

### DIFF
--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -261,6 +261,7 @@ function addTooltipListeners() {
         }
         const weeks = new Array(12).fill(0).map(()=>[]);
         const current = weekStart(new Date());
+        const WEEK_MS = 7*24*60*60*1000;
         throughputWeekNums = [];
         for (let i=0;i<12;i++) {
           const d = new Date(current);
@@ -273,7 +274,7 @@ function addTooltipListeners() {
           const dateStr = it.fields && it.fields.resolutiondate;
           if (!dateStr) continue;
           const w = weekStart(dateStr);
-          const diff = Math.floor((current - w) / (7*24*60*60*1000));
+          const diff = Math.round((current - w) / WEEK_MS);
           if (diff >=0 && diff < 12) weeks[11-diff].push(it.key);
         }
         throughputIssues = weeks;


### PR DESCRIPTION
## Summary
- ensure the weekly throughput calculation uses a rounded week difference
- add a shared week-length constant so the current week is retained when DST shifts occur

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c90749f9f48325be797164b5443aba