### PR TITLE
Fix weekly throughput fetch to include board issue types

### DIFF
--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -246,14 +246,17 @@ function addTooltipListeners() {
             boardJql = (fd.jql || '').replace(/ORDER BY[\s\S]*$/i, '').trim();
           }
         }
-        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}issuetype in (Story,Bug,Task) AND statusCategory = Done AND resolutiondate >= startOfWeek(-11)`;
+        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}statusCategory = Done AND resolutiondate >= startOfWeek(-11)`;
         const enc = encodeURIComponent(jql);
         let startAt = 0;
         let issues = [];
         while (true) {
-          const url = `https://${jiraDomain}/rest/api/3/search?jql=${enc}&fields=key,resolution,resolutiondate&startAt=${startAt}&maxResults=100`;
+          const url = `https://${jiraDomain}/rest/api/3/search?jql=${enc}&fields=key,resolution,resolutiondate,issuetype&startAt=${startAt}&maxResults=100`;
           const resp = await fetch(url, { credentials: "include" });
-          if (!resp.ok) break;
+          if (!resp.ok) {
+            const message = await resp.text();
+            throw new Error(`search_failed:${resp.status}:${message}`);
+          }
           const data = await resp.json();
           issues = issues.concat(data.issues || []);
           startAt += 100;
@@ -269,6 +272,12 @@ function addTooltipListeners() {
           throughputWeekNums.push(isoWeekNumber(d));
         }
         for (const it of issues) {
+          const issueType = it.fields && it.fields.issuetype;
+          if (issueType) {
+            const typeName = (issueType.name || '').toLowerCase();
+            if (typeName === 'epic') continue;
+            if (issueType.subtask) continue;
+          }
           const resName = it.fields && it.fields.resolution && it.fields.resolution.name;
           if (!validResolution(resName)) continue;
           const dateStr = it.fields && it.fields.resolutiondate;


### PR DESCRIPTION
## Summary
- remove the Story/Bug/Task restriction from the weekly throughput search so board-specific issue types are counted
- request issuetype details and skip epics/subtasks client-side instead of depending on the old filter
- bubble up Jira search errors instead of silently returning zero throughput when the request fails

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca839923588325bc057a4eac1bd11b