### PR TITLE
Align weekly throughput calculations with completed weeks

### DIFF
--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -246,7 +246,7 @@ function addTooltipListeners() {
             boardJql = (fd.jql || '').replace(/ORDER BY[\s\S]*$/i, '').trim();
           }
         }
-        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}statusCategory = Done AND resolutiondate >= startOfWeek(-11)`;
+        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}statusCategory = Done AND resolutiondate >= startOfWeek(-12) AND resolutiondate < startOfWeek()`;
         const enc = encodeURIComponent(jql);
         let startAt = 0;
         let issues = [];
@@ -264,10 +264,12 @@ function addTooltipListeners() {
         }
         const weeks = new Array(12).fill(0).map(()=>[]);
         const current = weekStart(new Date());
+        const lastCompletedWeekStart = new Date(current);
+        lastCompletedWeekStart.setDate(lastCompletedWeekStart.getDate() - 7);
         const WEEK_MS = 7*24*60*60*1000;
         throughputWeekNums = [];
         for (let i=0;i<12;i++) {
-          const d = new Date(current);
+          const d = new Date(lastCompletedWeekStart);
           d.setDate(d.getDate() - (11-i)*7);
           throughputWeekNums.push(isoWeekNumber(d));
         }
@@ -283,7 +285,7 @@ function addTooltipListeners() {
           const dateStr = it.fields && it.fields.resolutiondate;
           if (!dateStr) continue;
           const w = weekStart(dateStr);
-          const diff = Math.round((current - w) / WEEK_MS);
+          const diff = Math.round((lastCompletedWeekStart - w) / WEEK_MS);
           if (diff >=0 && diff < 12) weeks[11-diff].push(it.key);
         }
         throughputIssues = weeks;

--- a/src/sim.js
+++ b/src/sim.js
@@ -14,12 +14,19 @@ function weekStart(dt) {
 function calculateWeeklyThroughput(issues, current=new Date()) {
   logger.debug('calculateWeeklyThroughput start', { count: issues.length, current });
   const counts = new Array(12).fill(0);
-  const currentWeek = weekStart(current);
+  const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+  const currentWeekStart = weekStart(current);
+  const lastCompletedWeekStart = new Date(currentWeekStart);
+  lastCompletedWeekStart.setDate(lastCompletedWeekStart.getDate() - 7);
+  logger.debug('calculateWeeklyThroughput reference week', {
+    currentWeekStart,
+    lastCompletedWeekStart
+  });
   issues.forEach(it => {
     const dateStr = it.resolutiondate;
     if (!dateStr) return;
     const w = weekStart(dateStr);
-    const diff = Math.floor((currentWeek - w) / (7*24*60*60*1000));
+    const diff = Math.round((lastCompletedWeekStart - w) / WEEK_MS);
     if (diff >= 0 && diff < 12) counts[11 - diff]++;
   });
   logger.debug('calculateWeeklyThroughput result', counts);


### PR DESCRIPTION
## Summary
- update the Monte Carlo helper to measure weekly throughput from the last fully completed week and avoid double declarations
- align the weekly throughput dashboard with the same window by adjusting the JQL range, bucket labels, and week-to-week comparison logic

## Testing
- node <<'NODE'
const { calculateWeeklyThroughput } = require('./src/sim');
const issues = [
  { resolutiondate: '2024-05-06T12:00:00.000Z' },
  { resolutiondate: '2024-04-29T12:00:00.000Z' },
  { resolutiondate: '2024-05-13T12:00:00.000Z' }
];
const result = calculateWeeklyThroughput(issues, new Date('2024-05-15T10:00:00.000Z'));
console.log(result);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68ca97a94f0c8325afdb69f593767f99