### PR TITLE
Revert repository to pre-6bf57d4 state

### DIFF
--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -233,7 +233,7 @@ function addTooltipListeners() {
         return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
       }
       try {
-        const cfgUrl = `https://${jiraDomain}/rest/agile/latest/board/${boardNum}/configuration`;
+        const cfgUrl = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/configuration`;
         const cfgResp = await fetch(cfgUrl, { credentials: "include" });
         if (!cfgResp.ok) throw new Error('cfg');
         const cfg = await cfgResp.json();
@@ -246,17 +246,14 @@ function addTooltipListeners() {
             boardJql = (fd.jql || '').replace(/ORDER BY[\s\S]*$/i, '').trim();
           }
         }
-        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}statusCategory = Done AND resolutiondate >= startOfWeek(-12) AND resolutiondate < startOfWeek()`;
+        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}issuetype in (Story,Bug,Task) AND statusCategory = Done AND resolutiondate >= startOfWeek(-11)`;
         const enc = encodeURIComponent(jql);
         let startAt = 0;
         let issues = [];
         while (true) {
-          const url = `https://${jiraDomain}/rest/api/3/search?jql=${enc}&fields=key,resolution,resolutiondate,issuetype&startAt=${startAt}&maxResults=100`;
+          const url = `https://${jiraDomain}/rest/api/3/search?jql=${enc}&fields=key,resolution,resolutiondate&startAt=${startAt}&maxResults=100`;
           const resp = await fetch(url, { credentials: "include" });
-          if (!resp.ok) {
-            const message = await resp.text();
-            throw new Error(`search_failed:${resp.status}:${message}`);
-          }
+          if (!resp.ok) break;
           const data = await resp.json();
           issues = issues.concat(data.issues || []);
           startAt += 100;
@@ -264,28 +261,19 @@ function addTooltipListeners() {
         }
         const weeks = new Array(12).fill(0).map(()=>[]);
         const current = weekStart(new Date());
-        const lastCompletedWeekStart = new Date(current);
-        lastCompletedWeekStart.setDate(lastCompletedWeekStart.getDate() - 7);
-        const WEEK_MS = 7*24*60*60*1000;
         throughputWeekNums = [];
         for (let i=0;i<12;i++) {
-          const d = new Date(lastCompletedWeekStart);
+          const d = new Date(current);
           d.setDate(d.getDate() - (11-i)*7);
           throughputWeekNums.push(isoWeekNumber(d));
         }
         for (const it of issues) {
-          const issueType = it.fields && it.fields.issuetype;
-          if (issueType) {
-            const typeName = (issueType.name || '').toLowerCase();
-            if (typeName === 'epic') continue;
-            if (issueType.subtask) continue;
-          }
           const resName = it.fields && it.fields.resolution && it.fields.resolution.name;
           if (!validResolution(resName)) continue;
           const dateStr = it.fields && it.fields.resolutiondate;
           if (!dateStr) continue;
           const w = weekStart(dateStr);
-          const diff = Math.round((lastCompletedWeekStart - w) / WEEK_MS);
+          const diff = Math.floor((current - w) / (7*24*60*60*1000));
           if (diff >=0 && diff < 12) weeks[11-diff].push(it.key);
         }
         throughputIssues = weeks;
@@ -302,7 +290,7 @@ function addTooltipListeners() {
     async function fetchBoardTeam() {
       boardTeams = [];
       try {
-        const cfgUrl = `https://${jiraDomain}/rest/agile/latest/board/${boardNum}/configuration`;
+        const cfgUrl = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/configuration`;
         const cfgResp = await fetch(cfgUrl, { credentials: "include" });
         if (!cfgResp.ok) return;
         const cfg = await cfgResp.json();
@@ -344,7 +332,7 @@ function addTooltipListeners() {
       let total = null;
 
       while (true) {
-        const url = `https://${jiraDomain}/rest/agile/latest/board/${boardNum}/sprint?maxResults=${maxResults}&startAt=${startAt}`;
+        const url = `https://${jiraDomain}/rest/agile/1.0/board/${boardNum}/sprint?maxResults=${maxResults}&startAt=${startAt}`;
         console.log("Fetching sprints:", url);
         try {
           const resp = await fetch(url, { credentials: "include" });

--- a/src/sim.js
+++ b/src/sim.js
@@ -14,19 +14,12 @@ function weekStart(dt) {
 function calculateWeeklyThroughput(issues, current=new Date()) {
   logger.debug('calculateWeeklyThroughput start', { count: issues.length, current });
   const counts = new Array(12).fill(0);
-  const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-  const currentWeekStart = weekStart(current);
-  const lastCompletedWeekStart = new Date(currentWeekStart);
-  lastCompletedWeekStart.setDate(lastCompletedWeekStart.getDate() - 7);
-  logger.debug('calculateWeeklyThroughput reference week', {
-    currentWeekStart,
-    lastCompletedWeekStart
-  });
+  const currentWeek = weekStart(current);
   issues.forEach(it => {
     const dateStr = it.resolutiondate;
     if (!dateStr) return;
     const w = weekStart(dateStr);
-    const diff = Math.round((lastCompletedWeekStart - w) / WEEK_MS);
+    const diff = Math.floor((currentWeek - w) / (7*24*60*60*1000));
     if (diff >= 0 && diff < 12) counts[11 - diff]++;
   });
   logger.debug('calculateWeeklyThroughput result', counts);


### PR DESCRIPTION
## Summary
- restore the weekly throughput HTML to match the configuration and JQL used before commit 6bf57d4
- revert the Monte Carlo helper to the earlier week-difference calculation

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68ca99e5e5808325b01e44d9d71831c6