### PR TITLE
Adjust weekly throughput to completed weeks

### DIFF
--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -246,12 +246,14 @@ function addTooltipListeners() {
             boardJql = (fd.jql || '').replace(/ORDER BY[\s\S]*$/i, '').trim();
           }
         }
-        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}issuetype in (Story,Bug,Task) AND statusCategory = Done AND resolutiondate >= startOfWeek(-11)`;
+        const jql = `${boardJql ? '('+boardJql+') AND ' : ''}` +
+          `issuetype in (Story,Bug,Task) AND statusCategory = Done ` +
+          `AND resolutiondate >= startOfWeek(-12) AND resolutiondate < startOfWeek()`;
         const enc = encodeURIComponent(jql);
         let startAt = 0;
         let issues = [];
         while (true) {
-          const url = `https://${jiraDomain}/rest/api/3/search?jql=${enc}&fields=key,resolution,resolutiondate&startAt=${startAt}&maxResults=100`;
+          const url = `https://${jiraDomain}/rest/api/3/search?jql=${enc}&fields=key,resolution,resolutiondate,issuetype&startAt=${startAt}&maxResults=100`;
           const resp = await fetch(url, { credentials: "include" });
           if (!resp.ok) break;
           const data = await resp.json();
@@ -260,20 +262,29 @@ function addTooltipListeners() {
           if (startAt >= (data.total || 0)) break;
         }
         const weeks = new Array(12).fill(0).map(()=>[]);
-        const current = weekStart(new Date());
+        const WEEK_MS = 7*24*60*60*1000;
+        const currentWeekStart = weekStart(new Date());
+        const lastCompletedWeekStart = new Date(currentWeekStart);
+        lastCompletedWeekStart.setDate(lastCompletedWeekStart.getDate() - 7);
         throughputWeekNums = [];
         for (let i=0;i<12;i++) {
-          const d = new Date(current);
+          const d = new Date(lastCompletedWeekStart);
           d.setDate(d.getDate() - (11-i)*7);
           throughputWeekNums.push(isoWeekNumber(d));
         }
         for (const it of issues) {
+          const issueType = it.fields && it.fields.issuetype;
+          if (issueType) {
+            const typeName = (issueType.name || '').toLowerCase();
+            if (typeName === 'epic') continue;
+            if (issueType.subtask) continue;
+          }
           const resName = it.fields && it.fields.resolution && it.fields.resolution.name;
           if (!validResolution(resName)) continue;
           const dateStr = it.fields && it.fields.resolutiondate;
           if (!dateStr) continue;
           const w = weekStart(dateStr);
-          const diff = Math.floor((current - w) / (7*24*60*60*1000));
+          const diff = Math.round((lastCompletedWeekStart - w) / WEEK_MS);
           if (diff >=0 && diff < 12) weeks[11-diff].push(it.key);
         }
         throughputIssues = weeks;

--- a/src/sim.js
+++ b/src/sim.js
@@ -14,12 +14,19 @@ function weekStart(dt) {
 function calculateWeeklyThroughput(issues, current=new Date()) {
   logger.debug('calculateWeeklyThroughput start', { count: issues.length, current });
   const counts = new Array(12).fill(0);
-  const currentWeek = weekStart(current);
+  const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+  const currentWeekStart = weekStart(current);
+  const lastCompletedWeekStart = new Date(currentWeekStart);
+  lastCompletedWeekStart.setDate(lastCompletedWeekStart.getDate() - 7);
+  logger.debug('calculateWeeklyThroughput reference week', {
+    currentWeekStart,
+    lastCompletedWeekStart
+  });
   issues.forEach(it => {
     const dateStr = it.resolutiondate;
     if (!dateStr) return;
     const w = weekStart(dateStr);
-    const diff = Math.floor((currentWeek - w) / (7*24*60*60*1000));
+    const diff = Math.round((lastCompletedWeekStart - w) / WEEK_MS);
     if (diff >= 0 && diff < 12) counts[11 - diff]++;
   });
   logger.debug('calculateWeeklyThroughput result', counts);


### PR DESCRIPTION
## Summary
- ensure the weekly throughput query only considers the last 12 completed weeks and filters epics/sub-tasks from the Jira search results
- rebuild weekly labels based on the last completed week and reuse the same week window inside the Monte Carlo helper

## Testing
- node -e "require('./src/sim.js')"


------
https://chatgpt.com/codex/tasks/task_e_68cab2b1961483258ca616b173ea7f86