### PR TITLE
Restore weekly throughput JQL window

### DIFF
--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -248,12 +248,12 @@ function addTooltipListeners() {
         }
         const jql = `${boardJql ? '('+boardJql+') AND ' : ''}` +
           `issuetype in (Story,Bug,Task) AND statusCategory = Done ` +
-          `AND resolutiondate >= startOfWeek(-12) AND resolutiondate < startOfWeek()`;
+          `AND resolutiondate >= startOfWeek(-11)`;
         const enc = encodeURIComponent(jql);
         let startAt = 0;
         let issues = [];
         while (true) {
-          const url = `https://${jiraDomain}/rest/api/3/search?jql=${enc}&fields=key,resolution,resolutiondate,issuetype&startAt=${startAt}&maxResults=100`;
+          const url = `https://${jiraDomain}/rest/api/3/search?jql=${enc}&fields=key,resolution,resolutiondate&startAt=${startAt}&maxResults=100`;
           const resp = await fetch(url, { credentials: "include" });
           if (!resp.ok) break;
           const data = await resp.json();


### PR DESCRIPTION
## Summary
- restore the weekly throughput Jira search to use the original 11-week lookback window
- drop the `resolutiondate < startOfWeek()` upper bound to avoid 410 responses
- request only the original set of fields from the Jira search endpoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d10c90758883258396f35e786fa343