### PR TITLE
Handle Jira search CORS in shared helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,10 @@ document.getElementById('versionSelect').value = 'index.html';
 function switchVersion(page) {
   if (page !== 'index.html') location.href = page;
 }
+// Note: the KPI report fetches data via sprint and issue endpoints only, so it
+// never calls this helper. These dashboards rely on Jira's /search API which
+// triggers a CORS preflight when issued as POST from GitHub Pages. Prefer GET
+// to avoid the failing preflight and fall back to POST for large queries.
 async function jiraSearch(jql, fields = [], options = {}) {
   const searchUrl = `https://${jiraDomain}/rest/api/3/search`;
   const maxResults = options.maxResults || 500;
@@ -172,27 +176,60 @@ async function jiraSearch(jql, fields = [], options = {}) {
   const expandList = Array.isArray(options.expand)
     ? options.expand.filter(Boolean)
     : (options.expand ? [options.expand] : []);
+  let useGet = true;
 
-  while (true) {
+  const buildPayload = () => {
     const payload = { jql, startAt, maxResults };
     if (fieldList.length) payload.fields = fieldList;
     if (expandList.length) payload.expand = expandList;
+    return payload;
+  };
 
+  while (true) {
     let resp;
     try {
-      resp = await fetch(searchUrl, {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-          'X-Atlassian-Token': 'no-check'
-        },
-        body: JSON.stringify(payload)
-      });
+      if (useGet) {
+        const params = new URLSearchParams();
+        params.set('jql', jql);
+        params.set('startAt', String(startAt));
+        params.set('maxResults', String(maxResults));
+        if (fieldList.length) params.set('fields', fieldList.join(','));
+        if (expandList.length) params.set('expand', expandList.join(','));
+        const url = `${searchUrl}?${params.toString()}`;
+        resp = await fetch(url, {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            'Accept': 'application/json'
+          }
+        });
+      } else {
+        const payload = buildPayload();
+        resp = await fetch(searchUrl, {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Atlassian-Token': 'no-check'
+          },
+          body: JSON.stringify(payload)
+        });
+      }
     } catch (err) {
+      if (useGet) {
+        console.warn('Jira search GET request failed, retrying with POST', err);
+        useGet = false;
+        continue;
+      }
       console.error('Jira search request failed', err);
       throw err;
+    }
+
+    if (useGet && [405, 413, 414].includes(resp.status)) {
+      console.warn(`Jira search GET returned status ${resp.status}, retrying with POST.`);
+      useGet = false;
+      continue;
     }
 
     if (!resp.ok) {

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -165,6 +165,10 @@ document.getElementById('versionSelect').value = 'index_throughput.html';
 function switchVersion(page) {
   if (page !== 'index_throughput.html') location.href = page;
 }
+// Note: the KPI report fetches data via sprint and issue endpoints only, so it
+// never calls this helper. These dashboards rely on Jira's /search API which
+// triggers a CORS preflight when issued as POST from GitHub Pages. Prefer GET
+// to avoid the failing preflight and fall back to POST for large queries.
 async function jiraSearch(jql, fields = [], options = {}) {
   const searchUrl = `https://${jiraDomain}/rest/api/3/search`;
   const maxResults = options.maxResults || 500;
@@ -174,27 +178,60 @@ async function jiraSearch(jql, fields = [], options = {}) {
   const expandList = Array.isArray(options.expand)
     ? options.expand.filter(Boolean)
     : (options.expand ? [options.expand] : []);
+  let useGet = true;
 
-  while (true) {
+  const buildPayload = () => {
     const payload = { jql, startAt, maxResults };
     if (fieldList.length) payload.fields = fieldList;
     if (expandList.length) payload.expand = expandList;
+    return payload;
+  };
 
+  while (true) {
     let resp;
     try {
-      resp = await fetch(searchUrl, {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-          'X-Atlassian-Token': 'no-check'
-        },
-        body: JSON.stringify(payload)
-      });
+      if (useGet) {
+        const params = new URLSearchParams();
+        params.set('jql', jql);
+        params.set('startAt', String(startAt));
+        params.set('maxResults', String(maxResults));
+        if (fieldList.length) params.set('fields', fieldList.join(','));
+        if (expandList.length) params.set('expand', expandList.join(','));
+        const url = `${searchUrl}?${params.toString()}`;
+        resp = await fetch(url, {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            'Accept': 'application/json'
+          }
+        });
+      } else {
+        const payload = buildPayload();
+        resp = await fetch(searchUrl, {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Atlassian-Token': 'no-check'
+          },
+          body: JSON.stringify(payload)
+        });
+      }
     } catch (err) {
+      if (useGet) {
+        console.warn('Jira search GET request failed, retrying with POST', err);
+        useGet = false;
+        continue;
+      }
       console.error('Jira search request failed', err);
       throw err;
+    }
+
+    if (useGet && [405, 413, 414].includes(resp.status)) {
+      console.warn(`Jira search GET returned status ${resp.status}, retrying with POST.`);
+      useGet = false;
+      continue;
     }
 
     if (!resp.ok) {

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -166,6 +166,10 @@ document.getElementById('versionSelect').value = 'index_throughput_week.html';
 function switchVersion(page) {
   if (page !== 'index_throughput_week.html') location.href = page;
 }
+// Note: the KPI report fetches data via sprint and issue endpoints only, so it
+// never calls this helper. These dashboards rely on Jira's /search API which
+// triggers a CORS preflight when issued as POST from GitHub Pages. Prefer GET
+// to avoid the failing preflight and fall back to POST for large queries.
 async function jiraSearch(jql, fields = [], options = {}) {
   const searchUrl = `https://${jiraDomain}/rest/api/3/search`;
   const maxResults = options.maxResults || 500;
@@ -175,27 +179,60 @@ async function jiraSearch(jql, fields = [], options = {}) {
   const expandList = Array.isArray(options.expand)
     ? options.expand.filter(Boolean)
     : (options.expand ? [options.expand] : []);
+  let useGet = true;
 
-  while (true) {
+  const buildPayload = () => {
     const payload = { jql, startAt, maxResults };
     if (fieldList.length) payload.fields = fieldList;
     if (expandList.length) payload.expand = expandList;
+    return payload;
+  };
 
+  while (true) {
     let resp;
     try {
-      resp = await fetch(searchUrl, {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-          'X-Atlassian-Token': 'no-check'
-        },
-        body: JSON.stringify(payload)
-      });
+      if (useGet) {
+        const params = new URLSearchParams();
+        params.set('jql', jql);
+        params.set('startAt', String(startAt));
+        params.set('maxResults', String(maxResults));
+        if (fieldList.length) params.set('fields', fieldList.join(','));
+        if (expandList.length) params.set('expand', expandList.join(','));
+        const url = `${searchUrl}?${params.toString()}`;
+        resp = await fetch(url, {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            'Accept': 'application/json'
+          }
+        });
+      } else {
+        const payload = buildPayload();
+        resp = await fetch(searchUrl, {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Atlassian-Token': 'no-check'
+          },
+          body: JSON.stringify(payload)
+        });
+      }
     } catch (err) {
+      if (useGet) {
+        console.warn('Jira search GET request failed, retrying with POST', err);
+        useGet = false;
+        continue;
+      }
       console.error('Jira search request failed', err);
       throw err;
+    }
+
+    if (useGet && [405, 413, 414].includes(resp.status)) {
+      console.warn(`Jira search GET returned status ${resp.status}, retrying with POST.`);
+      useGet = false;
+      continue;
     }
 
     if (!resp.ok) {

--- a/src/jira.js
+++ b/src/jira.js
@@ -136,21 +136,83 @@
         expand: ['changelog']
       };
       const data = await fetchWithDedup(`search:${jiraDomain}:${batch.join(',')}`, async () => {
-        const resp = await fetch(`https://${jiraDomain}/rest/api/3/search`, {
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-            'X-Atlassian-Token': 'no-check'
-          },
-          body: JSON.stringify(payload)
-        });
-        if (!resp.ok) {
-          const text = await resp.text();
-          throw new Error(`Failed to fetch search results ${resp.status} ${text}`);
+        const searchUrl = `https://${jiraDomain}/rest/api/3/search`;
+        const fieldList = payload.fields.filter(Boolean);
+        const expandList = payload.expand.filter(Boolean);
+        let useGet = true;
+
+        const buildQuery = () => {
+          const params = new URLSearchParams();
+          params.set('jql', payload.jql);
+          params.set('startAt', String(payload.startAt));
+          params.set('maxResults', String(payload.maxResults));
+          if (fieldList.length) params.set('fields', fieldList.join(','));
+          if (expandList.length) params.set('expand', expandList.join(','));
+          return params;
+        };
+
+        const buildBody = () => {
+          const body = {
+            jql: payload.jql,
+            startAt: payload.startAt,
+            maxResults: payload.maxResults
+          };
+          if (fieldList.length) body.fields = fieldList;
+          if (expandList.length) body.expand = expandList;
+          return JSON.stringify(body);
+        };
+
+        while (true) {
+          let resp;
+          try {
+            if (useGet) {
+              const params = buildQuery();
+              resp = await fetch(`${searchUrl}?${params.toString()}`, {
+                method: 'GET',
+                credentials: 'include',
+                headers: {
+                  'Accept': 'application/json'
+                }
+              });
+            } else {
+              resp = await fetch(searchUrl, {
+                method: 'POST',
+                credentials: 'include',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Accept': 'application/json',
+                  'X-Atlassian-Token': 'no-check'
+                },
+                body: buildBody()
+              });
+            }
+          } catch (err) {
+            if (useGet) {
+              logger.warn('Jira search GET request failed, retrying with POST', err);
+              useGet = false;
+              continue;
+            }
+            throw err;
+          }
+
+          if (useGet && [405, 413, 414].includes(resp.status)) {
+            logger.warn(`Jira search GET returned status ${resp.status}, retrying with POST.`);
+            useGet = false;
+            continue;
+          }
+
+          if (!resp.ok) {
+            let text = '';
+            try {
+              text = await resp.text();
+            } catch (e) {
+              logger.warn('Failed to read Jira search error response', e);
+            }
+            throw new Error(`Failed to fetch search results ${resp.status} ${text}`);
+          }
+
+          return resp.json();
         }
-        return resp.json();
       });
       (data.issues || []).forEach(issue => {
         const cacheKey = `issue:${jiraDomain}:${issue.key}`;


### PR DESCRIPTION
## Summary
- document in each dashboard why the KPI report is unaffected while the search helper still needs the GET-first workaround
- update the shared Jira.fetchIssuesBatch helper to mirror the GET-first, POST-fallback strategy so KPI consumers avoid the same CORS preflight

## Testing
- node test/fetchIssuesBatch.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1236a3f90832590787c2ab562d77b