### PR TITLE
Update Jira search endpoint to /rest/api/3/search/jql

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@ function switchVersion(page) {
 // triggers a CORS preflight when issued as POST from GitHub Pages. Prefer GET
 // to avoid the failing preflight and fall back to POST for large queries.
 async function jiraSearch(jql, fields = [], options = {}) {
-  const searchUrl = `https://${jiraDomain}/rest/api/3/search`;
+  const searchUrl = `https://${jiraDomain}/rest/api/3/search/jql`;
   const maxResults = options.maxResults || 500;
   let startAt = options.startAt || 0;
   const collected = [];

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -170,7 +170,7 @@ function switchVersion(page) {
 // triggers a CORS preflight when issued as POST from GitHub Pages. Prefer GET
 // to avoid the failing preflight and fall back to POST for large queries.
 async function jiraSearch(jql, fields = [], options = {}) {
-  const searchUrl = `https://${jiraDomain}/rest/api/3/search`;
+  const searchUrl = `https://${jiraDomain}/rest/api/3/search/jql`;
   const maxResults = options.maxResults || 500;
   let startAt = options.startAt || 0;
   const collected = [];

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -171,7 +171,7 @@ function switchVersion(page) {
 // triggers a CORS preflight when issued as POST from GitHub Pages. Prefer GET
 // to avoid the failing preflight and fall back to POST for large queries.
 async function jiraSearch(jql, fields = [], options = {}) {
-  const searchUrl = `https://${jiraDomain}/rest/api/3/search`;
+  const searchUrl = `https://${jiraDomain}/rest/api/3/search/jql`;
   const maxResults = options.maxResults || 500;
   let startAt = options.startAt || 0;
   const collected = [];

--- a/src/jira.js
+++ b/src/jira.js
@@ -136,7 +136,7 @@
         expand: ['changelog']
       };
       const data = await fetchWithDedup(`search:${jiraDomain}:${batch.join(',')}`, async () => {
-        const searchUrl = `https://${jiraDomain}/rest/api/3/search`;
+        const searchUrl = `https://${jiraDomain}/rest/api/3/search/jql`;
         const fieldList = payload.fields.filter(Boolean);
         const expandList = payload.expand.filter(Boolean);
         let useGet = true;


### PR DESCRIPTION
## Summary
- update the Jira search helper to call the new /rest/api/3/search/jql endpoint
- apply the endpoint update to all dashboards and the shared helper so Jira queries succeed again

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1316e41bc8325a40c02a735776e6a