### PR TITLE
Handle missing svg2pdf for weekly throughput export

### DIFF
--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -1322,6 +1322,10 @@ function addTooltipListeners() {
       const restoreExternalStyles = temporarilyRemoveExternalStylesheets();
       const margin = 20;
       try {
+        const svg2pdfFn = window.svg2pdf;
+        if (typeof svg2pdfFn !== 'function') {
+          throw new Error('svg2pdf library not loaded');
+        }
         for (let i=0; i<blocks.length; i++) {
           const svgText = await htmlToImage.toSvg(blocks[i], { skipFonts: true });
           const svgEl = new DOMParser().parseFromString(svgText, 'image/svg+xml').documentElement;
@@ -1334,7 +1338,7 @@ function addTooltipListeners() {
           if (!origH || !isFinite(origH)) origH = rect.height || blocks[i].offsetHeight || 1;
           const height = origH * width / origW;
           if (i>0) pdf.addPage();
-          svg2pdf(svgEl, pdf, { x: margin, y: margin, width, height });
+          svg2pdfFn(svgEl, pdf, { x: margin, y: margin, width, height });
         }
         const dateStr = new Date().toISOString().split('T')[0];
         pdf.save(`Stakeholder_StatusReport_WeeklyThroughput_${dateStr}.pdf`);


### PR DESCRIPTION
## Summary
- guard the weekly throughput PDF export against a missing svg2pdf global
- call the library through window.svg2pdf to avoid ReferenceErrors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d250f4ff988325aa1269551f4061da