### PR TITLE
Fix scope change baseline for active sprint

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,12 +479,15 @@ function addTooltipListeners() {
       if (!boardTeams.length) await fetchBoardTeam();
       let currSprintObj = sprints.find(s => String(s.id) === String(selectedSprintId));
       let currIdx = closedSprintsSorted.findIndex(s => String(s.id) === String(selectedSprintId));
-      let baselineIdx = (currIdx >= 0 && currIdx + 1 < closedSprintsSorted.length)
-        ? currIdx + 1
-        : -1;
-      baselineSprintId = baselineIdx >= 0 && closedSprintsSorted[baselineIdx]
-        ? closedSprintsSorted[baselineIdx].id
-        : '';
+      let baselineSprint = null;
+      if (currIdx >= 0) {
+        if (currIdx + 1 < closedSprintsSorted.length) {
+          baselineSprint = closedSprintsSorted[currIdx + 1];
+        }
+      } else if (closedSprintsSorted.length) {
+        baselineSprint = closedSprintsSorted[0];
+      }
+      baselineSprintId = baselineSprint ? baselineSprint.id : '';
       const sprintFields = [
         'summary',
         'parent',

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -607,12 +607,15 @@ function addTooltipListeners() {
       if (!boardTeams.length) await fetchBoardTeam();
       let currSprintObj = sprints.find(s => String(s.id) === String(selectedSprintId));
       let currIdx = closedSprintsSorted.findIndex(s => String(s.id) === String(selectedSprintId));
-      let baselineIdx = (currIdx >= 0 && currIdx + 1 < closedSprintsSorted.length)
-        ? currIdx + 1
-        : -1;
-      baselineSprintId = baselineIdx >= 0 && closedSprintsSorted[baselineIdx]
-        ? closedSprintsSorted[baselineIdx].id
-        : '';
+      let baselineSprint = null;
+      if (currIdx >= 0) {
+        if (currIdx + 1 < closedSprintsSorted.length) {
+          baselineSprint = closedSprintsSorted[currIdx + 1];
+        }
+      } else if (closedSprintsSorted.length) {
+        baselineSprint = closedSprintsSorted[0];
+      }
+      baselineSprintId = baselineSprint ? baselineSprint.id : '';
       const sprintFields = [
         'summary',
         'parent',

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -658,12 +658,15 @@ function addTooltipListeners() {
       if (!boardTeams.length) await fetchBoardTeam();
       let currSprintObj = sprints.find(s => String(s.id) === String(selectedSprintId));
       let currIdx = closedSprintsSorted.findIndex(s => String(s.id) === String(selectedSprintId));
-      let baselineIdx = (currIdx >= 0 && currIdx + 1 < closedSprintsSorted.length)
-        ? currIdx + 1
-        : -1;
-      baselineSprintId = baselineIdx >= 0 && closedSprintsSorted[baselineIdx]
-        ? closedSprintsSorted[baselineIdx].id
-        : '';
+      let baselineSprint = null;
+      if (currIdx >= 0) {
+        if (currIdx + 1 < closedSprintsSorted.length) {
+          baselineSprint = closedSprintsSorted[currIdx + 1];
+        }
+      } else if (closedSprintsSorted.length) {
+        baselineSprint = closedSprintsSorted[0];
+      }
+      baselineSprintId = baselineSprint ? baselineSprint.id : '';
       const sprintFields = [
         'summary',
         'parent',


### PR DESCRIPTION
## Summary
- ensure the running sprint falls back to the latest closed sprint when determining the baseline for scope calculations
- apply the same baseline selection logic to the throughput report variants so scope change works consistently

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d281ab69088325bc4b93855f92b756