### PR TITLE
Limit sprint deduplication to throughput reports

### DIFF
--- a/index_throughput.html
+++ b/index_throughput.html
@@ -330,6 +330,33 @@ function addTooltipListeners() {
       }
     }
 
+    function dedupeCompletedIssues(entries) {
+      (entries || []).forEach(entry => {
+        const completed = entry.completed || [];
+        if (!completed.length) return;
+        const deduped = new Map();
+        let hasDuplicates = false;
+        completed.forEach(ev => {
+          if (!ev || !ev.key) return;
+          if (deduped.has(ev.key)) {
+            hasDuplicates = true;
+            const existing = deduped.get(ev.key);
+            if (!existing.completedDate && ev.completedDate) {
+              existing.completedDate = ev.completedDate;
+            }
+            if (!existing.resolutionName && ev.resolutionName) {
+              existing.resolutionName = ev.resolutionName;
+            }
+          } else {
+            deduped.set(ev.key, { ...ev });
+          }
+        });
+        if (hasDuplicates) {
+          entry.completed = Array.from(deduped.values());
+        }
+      });
+    }
+
     async function fetchSprintCompletionData(jiraDomain, boardNum, desiredCount) {
       const results = [];
       const boardId = String(boardNum || '').trim();
@@ -419,6 +446,8 @@ function addTooltipListeners() {
           byIndex[i].completed = [];
         }
       }
+
+      dedupeCompletedIssues(byIndex);
 
       const uniqueKeys = Array.from(new Set(
         byIndex.flatMap(entry => entry.completed.map(ev => ev.key)).filter(Boolean)

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -331,6 +331,33 @@ function addTooltipListeners() {
       }
     }
 
+    function dedupeCompletedIssues(entries) {
+      (entries || []).forEach(entry => {
+        const completed = entry.completed || [];
+        if (!completed.length) return;
+        const deduped = new Map();
+        let hasDuplicates = false;
+        completed.forEach(ev => {
+          if (!ev || !ev.key) return;
+          if (deduped.has(ev.key)) {
+            hasDuplicates = true;
+            const existing = deduped.get(ev.key);
+            if (!existing.completedDate && ev.completedDate) {
+              existing.completedDate = ev.completedDate;
+            }
+            if (!existing.resolutionName && ev.resolutionName) {
+              existing.resolutionName = ev.resolutionName;
+            }
+          } else {
+            deduped.set(ev.key, { ...ev });
+          }
+        });
+        if (hasDuplicates) {
+          entry.completed = Array.from(deduped.values());
+        }
+      });
+    }
+
     async function fetchSprintCompletionData(jiraDomain, boardNum, desiredCount) {
       const results = [];
       const boardId = String(boardNum || '').trim();
@@ -420,6 +447,8 @@ function addTooltipListeners() {
           byIndex[i].completed = [];
         }
       }
+
+      dedupeCompletedIssues(byIndex);
 
       const uniqueKeys = Array.from(new Set(
         byIndex.flatMap(entry => entry.completed.map(ev => ev.key)).filter(Boolean)


### PR DESCRIPTION
## Summary
- roll back duplicate sprint event deduplication in the disruption, KPI, topic mix, and test dashboards to restore their original metrics
- add a throughput-specific helper to merge duplicate completed issue records when fetching sprint history
- apply the same deduplication when assembling the weekly throughput report so each issue counts once per week

## Testing
- node test/disruption.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d286ccc780832599c2388645137862