### PR TITLE
Expand resolution keyword checks for weekly throughput

### DIFF
--- a/index_throughput.html
+++ b/index_throughput.html
@@ -1245,12 +1245,17 @@ function addTooltipListeners() {
         'other'
       ];
       if (invalid.some(v => res.includes(v))) return false;
-      const valid = [
+      const validKeywords = [
         'done',
-        'implemented/done', 'implemented done',
-        'fixed', 'resolved', 'complete', 'completed'
+        'implement',
+        'fixed',
+        'resolve',
+        'complete', 'completed',
+        'close',
+        'accept',
+        'release'
       ];
-      return valid.some(v => res.includes(v));
+      return validKeywords.some(v => res.includes(v));
     }
     function statusGroup(s) {
       s = (s||"").toLowerCase();

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -1369,12 +1369,17 @@ function addTooltipListeners() {
         'other'
       ];
       if (invalid.some(v => res.includes(v))) return false;
-      const valid = [
+      const validKeywords = [
         'done',
-        'implemented/done', 'implemented done',
-        'fixed', 'resolved', 'complete', 'completed'
+        'implement',
+        'fixed',
+        'resolve',
+        'complete', 'completed',
+        'close',
+        'accept',
+        'release'
       ];
-      return valid.some(v => res.includes(v));
+      return validKeywords.some(v => res.includes(v));
     }
     function statusGroup(s) {
       s = (s||"").toLowerCase();


### PR DESCRIPTION
## Summary
- allow additional resolution keywords like "closed", "accepted", and "released" to count towards throughput
- apply the broader resolution check across the weekly and standard throughput reports so historical issue counts are accurate

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68d5475f67a48325992716e110624b50