### PR TITLE
Fix duplicate pctx declaration in KPI report

### DIFF
--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -985,14 +985,14 @@ function renderBoardCharts(displaySprints, allSprints, container) {
   const patternCanvas = document.createElement('canvas');
   patternCanvas.width = 6;
   patternCanvas.height = 6;
-  const pctx = patternCanvas.getContext('2d');
-  pctx.fillStyle = '#f59e0b';
-  pctx.fillRect(0, 0, 6, 6);
-  pctx.strokeStyle = '#ffffff';
-  pctx.beginPath();
-  pctx.moveTo(0, 6);
-  pctx.lineTo(6, 0);
-  pctx.stroke();
+  const patternCtx = patternCanvas.getContext('2d');
+  patternCtx.fillStyle = '#f59e0b';
+  patternCtx.fillRect(0, 0, 6, 6);
+  patternCtx.strokeStyle = '#ffffff';
+  patternCtx.beginPath();
+  patternCtx.moveTo(0, 6);
+  patternCtx.lineTo(6, 0);
+  patternCtx.stroke();
   const hatchPattern = dctx.createPattern(patternCanvas, 'repeat');
   const disruptionChart = new Chart(dctx, {
     type: 'bar',


### PR DESCRIPTION
## Summary
- rename the disruption chart pattern context to avoid redeclaring `pctx`
- prevent runtime syntax error when loading `kpi_report_no_initial.html`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd9a72ac883258275c49a53bbd522