### PR TITLE
Ensure embedded PNGs set href attributes for SVG export

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -1242,7 +1242,11 @@ function renderCharts(displaySprints, allSprints) {
     svg.appendChild(rect);
 
     const image = document.createElementNS(svgNS, 'image');
-    image.setAttributeNS(xlinkNS, 'xlink:href', tempCanvas.toDataURL('image/png'));
+    const dataUrl = tempCanvas.toDataURL('image/png');
+    image.setAttributeNS(xlinkNS, 'xlink:href', dataUrl);
+    image.setAttribute('href', dataUrl);
+    image.setAttribute('x', '0');
+    image.setAttribute('y', '0');
     image.setAttribute('width', width);
     image.setAttribute('height', height);
     image.setAttribute('preserveAspectRatio', 'none');

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -1225,7 +1225,11 @@ function renderCharts(displaySprints, allSprints) {
     svg.appendChild(rect);
 
     const image = document.createElementNS(svgNS, 'image');
-    image.setAttributeNS(xlinkNS, 'xlink:href', tempCanvas.toDataURL('image/png'));
+    const dataUrl = tempCanvas.toDataURL('image/png');
+    image.setAttributeNS(xlinkNS, 'xlink:href', dataUrl);
+    image.setAttribute('href', dataUrl);
+    image.setAttribute('x', '0');
+    image.setAttribute('y', '0');
     image.setAttribute('width', width);
     image.setAttribute('height', height);
     image.setAttribute('preserveAspectRatio', 'none');


### PR DESCRIPTION
## Summary
- add explicit href/xlink:href assignments for embedded PNGs in KPI SVG export
- position the embedded image at the canvas origin to avoid renderer quirks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd05ef7d448325a0e54a6295962b86