### PR TITLE
Set HTML backgrounds for report pages to avoid transparent webviews

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -12,6 +12,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
   <script src="https://cdn.jsdelivr.net/npm/svg2pdf.js@2.2.3/dist/svg2pdf.min.js"></script>
   <style>
+    html { background: #f7f8fa; }
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
     .table-wrap { overflow-x: auto; }

--- a/disruption.html
+++ b/disruption.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
   <style>
+    html { background: #f7f8fa; }
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
     .table-wrap { overflow-x: auto; }

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="public/tailwind.css">
   <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
   <style>
+    html { background: #f7f8fa; }
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin: 0; padding: 0; }
     .main { max-width: 950px; margin: 30px auto 40px auto; background: #fff; border-radius: 18px; box-shadow: 0 2px 12px #d1d5db70; padding: 36px 32px; }
     h1 { font-size: 2.3em; margin:0 0 0.7em 0; font-weight: 600; }

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
   <style>
+    html { background: #f7f8fa; }
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
     .table-wrap { overflow-x: auto; }

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="public/tailwind.css">
   <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
   <style>
+    html { background: #f7f8fa; }
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin: 0; padding: 0; }
     .main { max-width: 950px; margin: 30px auto 40px auto; background: #fff; border-radius: 18px; box-shadow: 0 2px 12px #d1d5db70; padding: 36px 32px; }
     h1 { font-size: 2.3em; margin:0 0 0.7em 0; font-weight: 600; }

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="public/tailwind.css">
   <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
   <style>
+    html { background: #f7f8fa; }
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin: 0; padding: 0; }
     .main { max-width: 950px; margin: 30px auto 40px auto; background: #fff; border-radius: 18px; box-shadow: 0 2px 12px #d1d5db70; padding: 36px 32px; }
     h1 { font-size: 2.3em; margin:0 0 0.7em 0; font-weight: 600; }

--- a/index_topicmix.html
+++ b/index_topicmix.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="public/tailwind.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
+    html { background:#f7f8fa; }
     body { background:#f7f8fa; font-family:'Inter',Arial,sans-serif; margin:0;padding:0; }
     .main { max-width:950px; margin:30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
     .btn { background:#6366f1; color:#fff; border:none; border-radius:6px; padding:7px 18px; cursor:pointer; font-size:1em; }

--- a/kpi_report_manual.html
+++ b/kpi_report_manual.html
@@ -8,6 +8,9 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
   <style>
+    html {
+      background: #f7f8fa;
+    }
     body {
       background: #f7f8fa;
       font-family: 'Inter', Arial, sans-serif;

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -12,6 +12,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
   <script src="https://cdn.jsdelivr.net/npm/svg2pdf.js@2.2.3/dist/svg2pdf.min.js"></script>
   <style>
+    html { background: #f7f8fa; }
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
     .table-wrap { overflow-x: auto; }

--- a/test.html
+++ b/test.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
   <style>
+    html { background: #f7f8fa; }
     body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
     .main { max-width: 950px; margin: 30px auto; background:#fff; border-radius:18px; padding:36px 32px; box-shadow:0 2px 12px #d1d5db70; }
     .table-wrap { overflow-x: auto; }


### PR DESCRIPTION
## Summary
- add explicit html background color on each standalone report page
- ensure embedded webviews render the expected light gray backdrop behind the white report cards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0850bf1883259722e6342fc16b4b