### PR TITLE
Switch PDF export back to JPEG snapshots

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
   <title>Stakeholder PI Status Report – MCW with Allocation</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html-to-image/1.11.11/html-to-image.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/svg2pdf.js@2.2.3/dist/svg2pdf.min.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
   <link rel="stylesheet" href="public/tailwind.css">
@@ -1115,16 +1114,33 @@ function addTooltipListeners() {
         .filter(b => b.querySelector('.epic-select-checkbox')?.checked);
       if (!blocks.length) return alert('Select at least one epic for PDF');
       const margin = 20;
+      const pageWidth = pdf.internal.pageSize.getWidth();
+      const pageHeight = pdf.internal.pageSize.getHeight();
+      const maxWidth = pageWidth - margin * 2;
+      const maxHeight = pageHeight - margin * 2;
       for (let i=0; i<blocks.length; i++) {
-        const svgText = await htmlToImage.toSvg(blocks[i]);
-        const svgEl = new DOMParser().parseFromString(svgText, 'image/svg+xml').documentElement;
-        const width = pdf.internal.pageSize.getWidth() - margin*2;
-        const vb = svgEl.viewBox.baseVal;
-        const origW = vb && vb.width ? vb.width : parseFloat(svgEl.getAttribute('width'));
-        const origH = vb && vb.height ? vb.height : parseFloat(svgEl.getAttribute('height'));
-        const height = origH * width / origW;
+        const dataUrl = await htmlToImage.toJpeg(blocks[i], {
+          quality: 0.85,
+          backgroundColor: '#ffffff',
+          pixelRatio: 2,
+          skipFonts: true,
+          cacheBust: true
+        });
+        const props = pdf.getImageProperties(dataUrl);
+        const ratio = Math.min(maxWidth / props.width, maxHeight / props.height, 1);
+        const renderWidth = props.width * ratio;
+        const renderHeight = props.height * ratio;
         if (i>0) pdf.addPage();
-        svg2pdf(svgEl, pdf, { x: margin, y: margin, width, height });
+        pdf.addImage(
+          dataUrl,
+          'JPEG',
+          margin + (maxWidth - renderWidth) / 2,
+          margin,
+          renderWidth,
+          renderHeight,
+          undefined,
+          'FAST'
+        );
       }
       const dateStr = new Date().toISOString().split('T')[0];
       pdf.save(`Stakeholder_StatusReport_Velocity_${dateStr}.pdf`);

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -5,7 +5,6 @@
   <title>Stakeholder PI Status Report – MCW with Allocation</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html-to-image/1.11.11/html-to-image.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/svg2pdf.js@2.2.3/dist/svg2pdf.min.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
   <link rel="stylesheet" href="public/tailwind.css">
@@ -1379,16 +1378,33 @@ function addTooltipListeners() {
         .filter(b => b.querySelector('.epic-select-checkbox')?.checked);
       if (!blocks.length) return alert('Select at least one epic for PDF');
       const margin = 20;
+      const pageWidth = pdf.internal.pageSize.getWidth();
+      const pageHeight = pdf.internal.pageSize.getHeight();
+      const maxWidth = pageWidth - margin * 2;
+      const maxHeight = pageHeight - margin * 2;
       for (let i=0; i<blocks.length; i++) {
-        const svgText = await htmlToImage.toSvg(blocks[i]);
-        const svgEl = new DOMParser().parseFromString(svgText, 'image/svg+xml').documentElement;
-        const width = pdf.internal.pageSize.getWidth() - margin*2;
-        const vb = svgEl.viewBox.baseVal;
-        const origW = vb && vb.width ? vb.width : parseFloat(svgEl.getAttribute('width'));
-        const origH = vb && vb.height ? vb.height : parseFloat(svgEl.getAttribute('height'));
-        const height = origH * width / origW;
+        const dataUrl = await htmlToImage.toJpeg(blocks[i], {
+          quality: 0.85,
+          backgroundColor: '#ffffff',
+          pixelRatio: 2,
+          skipFonts: true,
+          cacheBust: true
+        });
+        const props = pdf.getImageProperties(dataUrl);
+        const ratio = Math.min(maxWidth / props.width, maxHeight / props.height, 1);
+        const renderWidth = props.width * ratio;
+        const renderHeight = props.height * ratio;
         if (i>0) pdf.addPage();
-        svg2pdf(svgEl, pdf, { x: margin, y: margin, width, height });
+        pdf.addImage(
+          dataUrl,
+          'JPEG',
+          margin + (maxWidth - renderWidth) / 2,
+          margin,
+          renderWidth,
+          renderHeight,
+          undefined,
+          'FAST'
+        );
       }
       const dateStr = new Date().toISOString().split('T')[0];
       pdf.save(`Stakeholder_StatusReport_Throughput_${dateStr}.pdf`);


### PR DESCRIPTION
## Summary
- export velocity and throughput summary cards as JPEG snapshots instead of SVG to avoid dark backgrounds
- scale the embedded images within page bounds and drop the unused svg2pdf dependency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd0cb16bf483258208e3268d1e19fd