### PR TITLE
Ensure exported charts use white backgrounds

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -1211,7 +1211,14 @@ function renderCharts(displaySprints, allSprints) {
 
   function canvasToOptimizedDataURL(canvas) {
     // Use native canvas resolution with better compression
-    return canvas.toDataURL('image/jpeg', 0.85);
+    const tmp = document.createElement('canvas');
+    tmp.width = canvas.width;
+    tmp.height = canvas.height;
+    const ctx = tmp.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, tmp.width, tmp.height);
+    ctx.drawImage(canvas, 0, 0);
+    return tmp.toDataURL('image/jpeg', 0.85);
   }
 
   function canvasToSVG(canvas) {

--- a/disruption.html
+++ b/disruption.html
@@ -765,6 +765,8 @@ function renderCharts(displaySprints, allSprints) {
     tmp.width = canvas.width * scale;
     tmp.height = canvas.height * scale;
     const ctx = tmp.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, tmp.width, tmp.height);
     ctx.scale(scale, scale);
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = 'high';

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -768,6 +768,8 @@ function renderCharts(displaySprints, allSprints) {
     tmp.width = canvas.width * scale;
     tmp.height = canvas.height * scale;
     const ctx = tmp.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, tmp.width, tmp.height);
     ctx.scale(scale, scale);
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = 'high';

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -1194,7 +1194,14 @@ function renderCharts(displaySprints, allSprints) {
 
   function canvasToOptimizedDataURL(canvas) {
     // Use native canvas resolution with better compression
-    return canvas.toDataURL('image/jpeg', 0.85);
+    const tmp = document.createElement('canvas');
+    tmp.width = canvas.width;
+    tmp.height = canvas.height;
+    const ctx = tmp.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, tmp.width, tmp.height);
+    ctx.drawImage(canvas, 0, 0);
+    return tmp.toDataURL('image/jpeg', 0.85);
   }
 
   function canvasToSVG(canvas) {

--- a/test.html
+++ b/test.html
@@ -1025,6 +1025,8 @@ function renderCharts(displaySprints, allSprints) {
     tmp.width = canvas.width * scale;
     tmp.height = canvas.height * scale;
     const ctx = tmp.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, tmp.width, tmp.height);
     ctx.scale(scale, scale);
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = 'high';


### PR DESCRIPTION
## Summary
- ensure JPEG exports render charts onto a white canvas before encoding so transparent areas do not turn black
- update PNG export helpers to paint a white background before scaling for PDF generation

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd121c2d8c832586563713d5487450