### PR TITLE
Replace target release dashboard with static HTML implementation

### DIFF
--- a/KPI_Report.html
+++ b/KPI_Report.html
@@ -45,6 +45,7 @@
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
         <option value="KPI_Report.html">KPI Report</option>
+        <option value="target_release_dashboard.html">PI &amp; Target-Release Dashboard</option>
       </select>
     </label>
   </div>

--- a/disruption.html
+++ b/disruption.html
@@ -43,6 +43,7 @@
         <option value="index_throughput.html">Throughput</option>
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
+        <option value="target_release_dashboard.html">PI &amp; Target-Release Dashboard</option>
       </select>
     </label>
   </div>

--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
           <option value="index_disruption.html">Disruption</option>
+          <option value="target_release_dashboard.html">PI &amp; Target-Release Dashboard</option>
         </select>
       </label>
     </div>

--- a/index_disruption.html
+++ b/index_disruption.html
@@ -43,6 +43,7 @@
         <option value="index_throughput.html">Throughput</option>
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
+        <option value="target_release_dashboard.html">PI &amp; Target-Release Dashboard</option>
       </select>
     </label>
   </div>

--- a/index_throughput.html
+++ b/index_throughput.html
@@ -116,10 +116,11 @@
       <label>Version:
         <select id="versionSelect" onchange="switchVersion(this.value)">
           <option value="index.html">Velocity</option>
-          <option value="index_throughput.html">Throughput</option>
-          <option value="index_throughput_week.html">Weekly Throughput</option>
-          <option value="index_disruption.html">Disruption</option>
-        </select>
+        <option value="index_throughput.html">Throughput</option>
+        <option value="index_throughput_week.html">Weekly Throughput</option>
+        <option value="index_disruption.html">Disruption</option>
+        <option value="target_release_dashboard.html">PI &amp; Target-Release Dashboard</option>
+      </select>
       </label>
     </div>
     <div>

--- a/index_throughput_week.html
+++ b/index_throughput_week.html
@@ -119,6 +119,7 @@
           <option value="index_throughput.html">Throughput</option>
           <option value="index_throughput_week.html">Weekly Throughput</option>
           <option value="index_disruption.html">Disruption</option>
+          <option value="target_release_dashboard.html">PI &amp; Target-Release Dashboard</option>
         </select>
       </label>
     </div>

--- a/index_topicmix.html
+++ b/index_topicmix.html
@@ -24,6 +24,7 @@
         <option value="index_throughput.html">Throughput</option>
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
+        <option value="target_release_dashboard.html">PI &amp; Target-Release Dashboard</option>
       </select>
     </label>
   </div>

--- a/kpi_report_no_initial.html
+++ b/kpi_report_no_initial.html
@@ -45,6 +45,7 @@
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
         <option value="KPI_Report.html">KPI Report</option>
+        <option value="target_release_dashboard.html">PI &amp; Target-Release Dashboard</option>
       </select>
     </label>
   </div>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "dependencies": {
+    "chart.js": "^4.4.4",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1"
+  },
   "devDependencies": {
     "tailwindcss": "^3.4.4",
     "postcss": "^8.4.31",

--- a/target_release_dashboard.html
+++ b/target_release_dashboard.html
@@ -1,0 +1,1104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>PI & Target-Release Dashboard</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
+  <link rel="stylesheet" href="public/tailwind.css">
+  <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <style>
+    html { background: #f7f8fa; }
+    body { background: #f7f8fa; font-family: 'Inter', Arial, sans-serif; margin:0; padding:0; }
+    .main { max-width: 1200px; margin: 30px auto 40px auto; background: #fff; border-radius: 18px; box-shadow: 0 2px 12px #d1d5db70; padding: 36px 32px 48px 32px; }
+    h1 { font-size: 2.2em; margin:0 0 0.7em 0; font-weight: 600; }
+    .controls { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; margin-bottom: 20px; }
+    .controls label { display:flex; flex-direction:column; font-size:0.95em; color:#374151; }
+    .controls input, .controls select { padding:7px 10px; border:1px solid #d1d5db; border-radius:8px; font-size:0.95em; }
+    .btn { background:#6366f1; color:#fff; border:none; border-radius:8px; padding:9px 18px; cursor:pointer; font-size:0.95em; font-weight:600; transition: background 0.15s ease; }
+    .btn.secondary { background:#f3f4f6; color:#374151; }
+    .btn:disabled { background:#c4c6f5; cursor: default; }
+    .section-title { font-size: 1.2em; font-weight:600; margin: 30px 0 14px; color:#111827; }
+    .filters { background:#f9fafb; border:1px solid #e5e7eb; border-radius:16px; padding:20px 24px; display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:18px; }
+    .filter-block label { font-size:0.85em; color:#6b7280; margin-bottom:6px; display:block; font-weight:600; text-transform:uppercase; letter-spacing:0.02em; }
+    .filter-block select { width:100%; }
+    .suffix-toggles { display:flex; gap:12px; flex-wrap:wrap; margin-top:8px; }
+    .suffix-toggles label { background:#e0e7ff; color:#4338ca; padding:4px 10px; border-radius:999px; font-size:0.82em; display:flex; align-items:center; gap:6px; font-weight:600; }
+    .suffix-toggles input { margin:0; }
+    .kpi-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap:16px; margin-top:20px; }
+    .kpi-card { background:#f9fafb; border:1px solid #e5e7eb; border-radius:16px; padding:18px 20px; box-shadow: inset 0 1px 0 #fff; }
+    .kpi-label { font-size:0.9em; color:#6b7280; text-transform:uppercase; letter-spacing:0.04em; margin-bottom:6px; font-weight:600; }
+    .kpi-value { font-size:2em; font-weight:600; color:#111827; }
+    .chart-section { margin-top:32px; }
+    .chart-wrapper { background:#fff; border-radius:16px; border:1px solid #e5e7eb; padding:20px; box-shadow: 0 2px 6px #e5e7f070; }
+    .chart-toolbar { display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:12px; margin-bottom:10px; }
+    .chart-toolbar .toggle-group label { margin-right:12px; font-size:0.92em; color:#374151; font-weight:600; }
+    .chart-toolbar .toggle-group input { margin-right:4px; }
+    table { border-collapse:collapse; width:100%; }
+    th, td { border:1px solid #e5e7eb; padding:8px 10px; font-size:0.9em; text-align:left; }
+    th { background:#f3f4f6; text-transform:uppercase; font-size:0.76em; letter-spacing:0.06em; color:#4b5563; }
+    .table-controls { display:flex; justify-content:space-between; align-items:center; margin-bottom:10px; flex-wrap:wrap; gap:10px; }
+    .table-controls input { padding:7px 10px; border:1px solid #d1d5db; border-radius:8px; font-size:0.9em; }
+    .badge { background:#e5e7eb; border-radius:999px; padding:2px 10px; font-size:0.78em; font-weight:600; color:#374151; }
+    .status-pill { border-radius:999px; padding:2px 10px; font-size:0.78em; font-weight:600; color:#fff; display:inline-block; }
+    .status-pill.default { background:#6b7280; }
+    .status-pill.done { background:#10b981; }
+    .status-pill.progress { background:#6366f1; }
+    .status-pill.blocked { background:#ef4444; }
+    .empty-state { background:#f9fafb; border:1px dashed #cbd5f5; border-radius:12px; padding:30px; text-align:center; color:#6b7280; font-size:0.95em; margin-top:20px; }
+    .loading { margin:14px 0; font-weight:600; color:#4338ca; }
+    .error { margin:14px 0; font-weight:600; color:#dc2626; }
+    @media (max-width: 840px) {
+      .controls { flex-direction:column; align-items:flex-start; }
+      .chart-toolbar { flex-direction:column; align-items:flex-start; }
+    }
+  </style>
+</head>
+<body>
+  <div class="main" id="pdfContent">
+    <h1>PI & Target-Release Dashboard</h1>
+    <div style="margin-bottom:14px;">
+      <label>Version:
+        <select id="versionSelect">
+          <option value="index.html">Velocity</option>
+          <option value="index_throughput.html">Throughput</option>
+          <option value="index_throughput_week.html">Weekly Throughput</option>
+          <option value="index_disruption.html">Disruption</option>
+          <option value="KPI_Report.html">KPI Report</option>
+          <option value="target_release_dashboard.html">PI &amp; Target-Release Dashboard</option>
+        </select>
+      </label>
+    </div>
+    <div class="controls">
+      <label>Jira Domain
+        <input id="jiraDomain" value="aldi-sued.atlassian.net" placeholder="your-domain.atlassian.net">
+      </label>
+      <label style="flex:1; min-width:220px;">Boards
+        <select id="boardSelect" multiple></select>
+      </label>
+      <button class="btn" id="loadSprintsBtn">Load Sprints</button>
+      <button class="btn" id="loadDataBtn">Load Data</button>
+      <button class="btn secondary" id="exportBtn">Export as PDF</button>
+    </div>
+    <div id="loadingMessage" class="loading" style="display:none;"></div>
+    <div id="errorMessage" class="error" style="display:none;"></div>
+
+    <div id="filtersSection" style="display:none;">
+      <div class="section-title">Filters</div>
+      <div class="filters">
+        <div class="filter-block">
+          <label for="sprintSelect">Sprints</label>
+          <select id="sprintSelect" multiple></select>
+          <div style="font-size:0.78em; color:#6b7280; margin-top:6px;">Default selects last 12 sprints across chosen boards.</div>
+        </div>
+        <div class="filter-block">
+          <label for="piSelect">Program Increments</label>
+          <select id="piSelect" multiple></select>
+          <div class="suffix-toggles">
+            <label><input type="checkbox" id="suffixCommitted" checked> Committed</label>
+            <label><input type="checkbox" id="suffixPlanned" checked> Planned</label>
+            <label><input type="checkbox" id="suffixSpillover" checked> Spillover</label>
+          </div>
+        </div>
+        <div class="filter-block">
+          <label for="teamSelect">Responsible Teams</label>
+          <select id="teamSelect" multiple></select>
+        </div>
+        <div class="filter-block">
+          <label for="boardFilterSelect">Boards (Filter)</label>
+          <select id="boardFilterSelect" multiple></select>
+        </div>
+      </div>
+    </div>
+
+    <div id="kpiSection" style="display:none;">
+      <div class="section-title">Key Metrics</div>
+      <div class="kpi-grid">
+        <div class="kpi-card">
+          <div class="kpi-label">Total Items</div>
+          <div class="kpi-value" id="kpiTotal">0</div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-label">With Target-Release</div>
+          <div class="kpi-value" id="kpiWith">0</div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-label">Without Target-Release</div>
+          <div class="kpi-value" id="kpiWithout">0</div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-label">% With Target-Release</div>
+          <div class="kpi-value" id="kpiPct">0%</div>
+        </div>
+      </div>
+    </div>
+
+    <div id="chartsSection" style="display:none;">
+      <div class="section-title">Target-Release Coverage</div>
+      <div class="chart-section">
+        <div class="chart-toolbar">
+          <div class="toggle-group">
+            <label><input type="radio" name="stackedDimension" value="sprint" checked> By Sprint</label>
+            <label><input type="radio" name="stackedDimension" value="pi"> By PI</label>
+          </div>
+          <div style="font-size:0.85em; color:#6b7280;">Stacks display with/without target-release per responsible team.</div>
+        </div>
+        <div class="chart-wrapper">
+          <canvas id="stackedChart" height="360"></canvas>
+        </div>
+      </div>
+
+      <div class="chart-section" style="margin-top:36px;">
+        <div class="chart-toolbar">
+          <div class="toggle-group">
+            <label for="distributionMode">Distribution View:</label>
+            <select id="distributionMode">
+              <option value="team">By Team</option>
+              <option value="pi">By PI</option>
+            </select>
+          </div>
+          <div style="font-size:0.85em; color:#6b7280;">Shows ratio of issues with/without target-release.</div>
+        </div>
+        <div class="chart-wrapper">
+          <canvas id="distributionChart" height="360"></canvas>
+        </div>
+      </div>
+    </div>
+
+    <div id="missingSection" style="display:none; margin-top:40px;">
+      <div class="section-title">Items without Target-Release</div>
+      <div class="table-controls">
+        <div style="font-size:0.85em; color:#6b7280;">Displaying issues missing the planning field. Use search to refine.</div>
+        <input id="missingSearch" placeholder="Search by key, summary, team...">
+      </div>
+      <div class="table-wrap" style="overflow-x:auto;">
+        <table>
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Summary</th>
+              <th>Type</th>
+              <th>Status</th>
+              <th>Responsible Team</th>
+              <th>Sprint</th>
+              <th>PI</th>
+              <th>Board</th>
+              <th>Assignee</th>
+              <th>Updated</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody id="missingTableBody"></tbody>
+        </table>
+      </div>
+      <div id="missingEmpty" class="empty-state" style="display:none;">All selected issues have a target-release assigned. Great job!</div>
+    </div>
+  </div>
+
+  <script src="src/logger.js"></script>
+  <script src="src/jira.js"></script>
+  <script>
+    Logger.setLevel('info');
+
+    const state = {
+      domain: '',
+      boards: [],
+      boardsMap: new Map(),
+      allSprints: [],
+      normalizedIssues: [],
+      responsibleFieldKey: 'responsible-team',
+      filteredIssues: [],
+      aggregated: null,
+      loadedSprintIds: new Set(),
+      needsReload: false,
+    };
+
+    let boardChoices, sprintChoices, piChoices, teamChoices, boardFilterChoices;
+    let stackedChart, distributionChart;
+    const teamColorMap = new Map();
+    const palette = ['#6366f1', '#ec4899', '#10b981', '#f97316', '#14b8a6', '#8b5cf6', '#f59e0b', '#ef4444', '#3b82f6', '#22c55e'];
+
+    function initChoices() {
+      boardChoices = new Choices('#boardSelect', { removeItemButton: true, shouldSort: false });
+      sprintChoices = new Choices('#sprintSelect', { removeItemButton: true, shouldSort: false });
+      piChoices = new Choices('#piSelect', { removeItemButton: true, shouldSort: true, placeholder: true, placeholderValue: 'Select PIs' });
+      teamChoices = new Choices('#teamSelect', { removeItemButton: true, shouldSort: true, placeholder: true, placeholderValue: 'All teams' });
+      boardFilterChoices = new Choices('#boardFilterSelect', { removeItemButton: true, shouldSort: false });
+    }
+
+    function setLoading(message) {
+      const el = document.getElementById('loadingMessage');
+      if (message) {
+        el.textContent = message;
+        el.style.display = '';
+      } else {
+        el.textContent = '';
+        el.style.display = 'none';
+      }
+    }
+
+    function setError(message) {
+      const el = document.getElementById('errorMessage');
+      if (message) {
+        el.textContent = message;
+        el.style.display = '';
+      } else {
+        el.textContent = '';
+        el.style.display = 'none';
+      }
+    }
+
+    function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
+
+    async function fetchWithRetry(url, options = {}, retries = 3, baseDelay = 800) {
+      let attempt = 0;
+      while (true) {
+        try {
+          const resp = await fetch(url, { credentials: 'include', ...options });
+          if (resp.status === 429 && attempt < retries) {
+            const retryAfter = Number(resp.headers.get('Retry-After'));
+            const delay = Number.isFinite(retryAfter) ? retryAfter * 1000 : baseDelay * Math.pow(2, attempt);
+            Logger.warn('Rate limited, retrying', url, 'delay', delay);
+            await sleep(delay);
+            attempt++;
+            continue;
+          }
+          if (!resp.ok) {
+            const error = new Error(`Request failed ${resp.status}`);
+            error.status = resp.status;
+            throw error;
+          }
+          return resp;
+        } catch (err) {
+          Logger.error('Request error', url, err);
+          if (attempt >= retries) throw err;
+          await sleep(baseDelay * Math.pow(2, attempt));
+          attempt++;
+        }
+      }
+    }
+
+    const sprintCache = new Map();
+    async function fetchSprintsForBoard(domain, boardId) {
+      const cacheKey = `${domain}:${boardId}`;
+      if (sprintCache.has(cacheKey)) return sprintCache.get(cacheKey);
+
+      const promise = (async () => {
+        const results = [];
+        let startAt = 0;
+        const maxResults = 50;
+        for (let loop = 0; loop < 40; loop++) {
+          const url = `https://${domain}/rest/agile/1.0/board/${boardId}/sprint?state=active,closed,future&startAt=${startAt}&maxResults=${maxResults}`;
+          const resp = await fetchWithRetry(url);
+          const data = await resp.json();
+          const values = data.values || [];
+          values.forEach(v => {
+            const normalized = {
+              id: v.id,
+              name: v.name,
+              state: v.state,
+              startDate: v.startDate,
+              endDate: v.endDate || v.completeDate,
+              boardId: boardId,
+            };
+            results.push(normalized);
+          });
+          startAt += values.length;
+          if (data.isLast || !values.length) break;
+        }
+        return results;
+      })();
+
+      sprintCache.set(cacheKey, promise);
+      return promise;
+    }
+
+    const fieldCache = new Map();
+    async function discoverResponsibleField(domain) {
+      if (fieldCache.has(domain)) return fieldCache.get(domain);
+      const promise = (async () => {
+        const url = `https://${domain}/rest/api/3/field`;
+        const resp = await fetchWithRetry(url);
+        const fields = await resp.json();
+        let fieldKey = 'responsible-team';
+        if (Array.isArray(fields)) {
+          const normalized = fields.map(f => ({
+            key: f.key || f.id,
+            name: (f.name || '').toLowerCase(),
+          }));
+          const exact = normalized.find(f => f.key === 'responsible-team');
+          if (exact) {
+            fieldKey = exact.key;
+          } else {
+            const candidate = normalized.find(f => /responsible[\s-]?team/.test(f.name));
+            if (candidate && candidate.key) {
+              fieldKey = candidate.key;
+            }
+          }
+        }
+        return fieldKey;
+      })();
+      fieldCache.set(domain, promise);
+      return promise;
+    }
+
+    async function fetchIssues(domain, { sprintIds, responsibleField }) {
+      const fields = [
+        'key',
+        'summary',
+        'issuetype',
+        'status',
+        'assignee',
+        'labels',
+        'fixVersions',
+        'target-release',
+        'sprint',
+        'project',
+        'updated',
+        'components',
+      ];
+      if (responsibleField && responsibleField !== 'responsible-team') {
+        fields.push(responsibleField);
+      } else {
+        fields.push('responsible-team');
+      }
+
+      const jqlParts = [];
+      if (sprintIds && sprintIds.length) {
+        const unique = Array.from(new Set(sprintIds.map(id => Number(id)).filter(Boolean)));
+        if (unique.length) {
+          jqlParts.push(`Sprint in (${unique.join(',')})`);
+        }
+      }
+      if (!jqlParts.length) {
+        jqlParts.push('updated >= -365d');
+      }
+      jqlParts.push('issueType != Epic');
+      const jql = jqlParts.join(' AND ');
+
+      const pageSize = 100;
+      const url = `https://${domain}/rest/api/3/search`;
+      let startAt = 0;
+      const all = [];
+      for (let page = 0; page < 100; page++) {
+        const body = JSON.stringify({
+          jql,
+          startAt,
+          maxResults: pageSize,
+          fields,
+        });
+        const resp = await fetchWithRetry(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Atlassian-Token': 'no-check',
+          },
+          body,
+        });
+        const data = await resp.json();
+        const issues = data.issues || [];
+        issues.forEach(issue => all.push(issue));
+        startAt += issues.length;
+        if (startAt >= (data.total || 0) || !issues.length) break;
+        await sleep(120);
+      }
+      return all;
+    }
+
+    const PI_REGEX = /\b(20\d{2})_PI([1-4])(?:_(committed|spillover|planned))?\b/i;
+
+    function extractPis(labels) {
+      const matches = [];
+      const seen = new Set();
+      (labels || []).forEach(label => {
+        if (typeof label !== 'string') return;
+        const match = label.match(PI_REGEX);
+        if (!match) return;
+        const base = `${match[1]}_PI${match[2]}`;
+        const suffix = match[3] ? match[3].toLowerCase() : null;
+        const key = suffix ? `${base}_${suffix}` : base;
+        if (seen.has(key)) return;
+        seen.add(key);
+        matches.push({ base, suffix: suffix === 'committed' || suffix === 'planned' || suffix === 'spillover' ? suffix : null, label: suffix ? `${base}_${suffix}` : base });
+      });
+      return matches;
+    }
+
+    function parseSprintField(raw) {
+      if (!raw) return [];
+      const values = Array.isArray(raw) ? raw : [raw];
+      const seen = new Set();
+      const result = [];
+      values.forEach(value => {
+        let sprint = null;
+        if (typeof value === 'string') {
+          const idMatch = value.match(/id=(\d+)/i);
+          const nameMatch = value.match(/name=([^,\]]+)/i);
+          const stateMatch = value.match(/state=([^,\]]+)/i);
+          if (idMatch && nameMatch) {
+            sprint = { id: Number(idMatch[1]), name: nameMatch[1], state: stateMatch ? stateMatch[1] : undefined };
+          }
+        } else if (typeof value === 'object') {
+          const id = value.id ?? value.sprintId;
+          const name = value.name ?? value.sprintName;
+          if (id !== undefined && name) {
+            sprint = { id: Number(id), name: String(name), state: value.state ? String(value.state) : undefined };
+          }
+        }
+        if (sprint && !seen.has(sprint.id)) {
+          seen.add(sprint.id);
+          result.push(sprint);
+        }
+      });
+      return result;
+    }
+
+    function normalizeIssue(issue, responsibleFieldKey) {
+      const fields = issue.fields || {};
+      const labels = Array.isArray(fields.labels) ? fields.labels : [];
+      const pis = extractPis(labels);
+      const sprintField = fields.sprint || fields.sprints || fields.customfield_10020 || [];
+      const sprints = parseSprintField(sprintField);
+      const boardIds = new Set();
+      const rawSprintValues = Array.isArray(sprintField) ? sprintField : [sprintField];
+      rawSprintValues.forEach(raw => {
+        if (!raw) return;
+        let boardId = null;
+        if (typeof raw === 'string') {
+          const match = raw.match(/boardId=(\d+)/i);
+          if (match) boardId = Number(match[1]);
+        } else if (typeof raw === 'object') {
+          if (raw.originBoardId) boardId = Number(raw.originBoardId);
+          else if (raw.boardId) boardId = Number(raw.boardId);
+        }
+        if (typeof boardId === 'number' && !Number.isNaN(boardId)) {
+          boardIds.add(boardId);
+        }
+      });
+
+      let responsibleTeam;
+      const responsibleValue = fields[responsibleFieldKey] ?? fields['responsible-team'];
+      if (responsibleValue) {
+        if (typeof responsibleValue === 'string') {
+          responsibleTeam = responsibleValue;
+        } else if (Array.isArray(responsibleValue)) {
+          responsibleTeam = responsibleValue.find(val => typeof val === 'string');
+        } else if (typeof responsibleValue === 'object') {
+          responsibleTeam = responsibleValue.value || responsibleValue.name || responsibleValue.title;
+        }
+      }
+
+      let targetRelease;
+      const rawTarget = fields['target-release'];
+      if (rawTarget) {
+        if (typeof rawTarget === 'string') targetRelease = rawTarget;
+        else if (Array.isArray(rawTarget)) {
+          if (rawTarget.length) {
+            const first = rawTarget[0];
+            if (typeof first === 'string') targetRelease = first;
+            else if (typeof first === 'object') targetRelease = first.name || first.value;
+          }
+        } else if (typeof rawTarget === 'object') {
+          targetRelease = rawTarget.name || rawTarget.value;
+        }
+      }
+
+      return {
+        id: String(issue.id || issue.key || ''),
+        key: String(issue.key || ''),
+        summary: String(fields.summary || ''),
+        type: fields.issuetype?.name ? String(fields.issuetype.name) : 'Unknown',
+        status: fields.status?.name ? String(fields.status.name) : 'Unknown',
+        assignee: fields.assignee?.displayName ? String(fields.assignee.displayName) : undefined,
+        sprints,
+        pis,
+        responsibleTeam: responsibleTeam || undefined,
+        boardIds: Array.from(boardIds.values()),
+        hasTargetRelease: Boolean(targetRelease),
+        targetRelease: targetRelease || undefined,
+        updated: fields.updated ? String(fields.updated) : undefined,
+        project: fields.project?.name ? String(fields.project.name) : undefined,
+      };
+    }
+
+    function computePct(withTarget, total) {
+      if (!total) return 0;
+      return Number(((withTarget / total) * 100).toFixed(1));
+    }
+
+    function aggregateIssues(issues) {
+      const fallbackSprint = { key: 'unassigned', label: 'Unassigned Sprint' };
+      const fallbackPi = { key: 'no-pi', label: 'No PI' };
+      const fallbackTeam = 'Unassigned Team';
+
+      function ensureBucket(map, key, label) {
+        if (!map.has(key)) {
+          map.set(key, {
+            key,
+            label,
+            total: 0,
+            withTarget: 0,
+            withoutTarget: 0,
+            pctWith: 0,
+            teams: {},
+          });
+        }
+        return map.get(key);
+      }
+
+      function ensureTeam(bucket, team) {
+        if (!bucket.teams[team]) {
+          bucket.teams[team] = { team, total: 0, withTarget: 0, withoutTarget: 0, pctWith: 0 };
+        }
+        return bucket.teams[team];
+      }
+
+      function addIssue(bucket, issue, teamName) {
+        bucket.total += 1;
+        if (issue.hasTargetRelease) bucket.withTarget += 1; else bucket.withoutTarget += 1;
+        const teamAgg = ensureTeam(bucket, teamName);
+        teamAgg.total += 1;
+        if (issue.hasTargetRelease) teamAgg.withTarget += 1; else teamAgg.withoutTarget += 1;
+      }
+
+      function finalizeBucket(bucket) {
+        bucket.pctWith = computePct(bucket.withTarget, bucket.total);
+        Object.values(bucket.teams).forEach(team => {
+          team.pctWith = computePct(team.withTarget, team.total);
+        });
+      }
+
+      function aggregateBy(key) {
+        const buckets = new Map();
+        let total = 0, withTarget = 0, withoutTarget = 0;
+        issues.forEach(issue => {
+          const teamName = issue.responsibleTeam || fallbackTeam;
+          let dimensions;
+          if (key === 'sprint') {
+            dimensions = issue.sprints.length ? issue.sprints.map(s => ({ key: String(s.id), label: s.name })) : [fallbackSprint];
+          } else {
+            dimensions = issue.pis.length ? issue.pis.map(pi => ({ key: pi.label, label: pi.label })) : [fallbackPi];
+          }
+          const unique = new Map();
+          dimensions.forEach(dim => {
+            if (dim && dim.key && !unique.has(dim.key)) unique.set(dim.key, dim);
+          });
+          unique.forEach(dim => {
+            const bucket = ensureBucket(buckets, dim.key, dim.label);
+            addIssue(bucket, issue, teamName);
+          });
+          total += 1;
+          if (issue.hasTargetRelease) withTarget += 1; else withoutTarget += 1;
+        });
+        const finalBuckets = Array.from(buckets.values()).sort((a, b) => a.label.localeCompare(b.label, undefined, { numeric: true }));
+        finalBuckets.forEach(finalizeBucket);
+        return { total, withTarget, withoutTarget, pctWith: computePct(withTarget, total), buckets: finalBuckets };
+      }
+
+      function aggregateByTeam() {
+        const map = new Map();
+        issues.forEach(issue => {
+          const team = issue.responsibleTeam || fallbackTeam;
+          if (!map.has(team)) {
+            map.set(team, { team, total: 0, withTarget: 0, withoutTarget: 0, pctWith: 0 });
+          }
+          const agg = map.get(team);
+          agg.total += 1;
+          if (issue.hasTargetRelease) agg.withTarget += 1; else agg.withoutTarget += 1;
+        });
+        const arr = Array.from(map.values()).sort((a, b) => a.team.localeCompare(b.team));
+        arr.forEach(agg => { agg.pctWith = computePct(agg.withTarget, agg.total); });
+        return arr;
+      }
+
+      return {
+        bySprint: aggregateBy('sprint'),
+        byPi: aggregateBy('pi'),
+        byTeam: aggregateByTeam(),
+      };
+    }
+
+    function teamColor(team) {
+      if (!teamColorMap.has(team)) {
+        const idx = teamColorMap.size % palette.length;
+        teamColorMap.set(team, palette[idx]);
+      }
+      return teamColorMap.get(team);
+    }
+
+    function colorWithAlpha(hex, alpha) {
+      const clean = hex.replace('#', '');
+      const bigint = parseInt(clean, 16);
+      const r = (bigint >> 16) & 255;
+      const g = (bigint >> 8) & 255;
+      const b = bigint & 255;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+
+    function formatDate(value) {
+      if (!value) return '';
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return value;
+      return date.toLocaleDateString();
+    }
+
+    function getStatusClass(status) {
+      if (!status) return 'default';
+      const lower = status.toLowerCase();
+      if (lower.includes('done') || lower.includes('closed')) return 'done';
+      if (lower.includes('progress') || lower.includes('in progress')) return 'progress';
+      if (lower.includes('block')) return 'blocked';
+      return 'default';
+    }
+
+    function applyFilters() {
+      if (!state.normalizedIssues.length) return;
+      const selectedPiBases = new Set(piChoices.getValue(true));
+      const allowCommitted = document.getElementById('suffixCommitted').checked;
+      const allowPlanned = document.getElementById('suffixPlanned').checked;
+      const allowSpillover = document.getElementById('suffixSpillover').checked;
+      const selectedTeams = new Set(teamChoices.getValue(true));
+      const selectedBoardFilters = new Set(boardFilterChoices.getValue(true));
+      const selectedSprintIds = new Set(sprintChoices.getValue(true).map(String));
+
+      const filtered = state.normalizedIssues.filter(issue => {
+        if (selectedPiBases.size) {
+          let piMatch = false;
+          issue.pis.forEach(pi => {
+            if (selectedPiBases.has('__none__') && (!issue.pis.length || !pi)) {
+              piMatch = true;
+              return;
+            }
+            if (!pi) return;
+            if (!selectedPiBases.has(pi.base)) return;
+            if (pi.suffix === 'committed' && !allowCommitted) return;
+            if (pi.suffix === 'planned' && !allowPlanned) return;
+            if (pi.suffix === 'spillover' && !allowSpillover) return;
+            piMatch = true;
+          });
+          if (!issue.pis.length && selectedPiBases.has('__none__')) {
+            piMatch = true;
+          }
+          if (!piMatch) return false;
+        }
+
+        if (selectedTeams.size) {
+          const team = issue.responsibleTeam || 'Unassigned Team';
+          if (!selectedTeams.has(team)) return false;
+        }
+
+        if (selectedBoardFilters.size) {
+          const boards = issue.boardIds.length ? issue.boardIds.map(String) : ['__unassigned__'];
+          if (!boards.some(id => selectedBoardFilters.has(id))) return false;
+        }
+
+        if (selectedSprintIds.size) {
+          const sprintIds = issue.sprints.length ? issue.sprints.map(s => String(s.id)) : ['__none__'];
+          if (!sprintIds.some(id => selectedSprintIds.has(id))) return false;
+        }
+
+        return true;
+      });
+
+      state.filteredIssues = filtered;
+      state.aggregated = aggregateIssues(filtered);
+      renderKpis();
+      updateCharts();
+      renderMissingTable();
+      if (state.needsReload) {
+        setLoading('Some selected sprints were not part of the last fetch. Reload data to include them.');
+      } else if (!filtered.length) {
+        setLoading('No issues match the current filter selection.');
+      } else {
+        setLoading('');
+      }
+    }
+
+    function renderKpis() {
+      const total = state.filteredIssues.length;
+      const withTarget = state.filteredIssues.filter(i => i.hasTargetRelease).length;
+      const withoutTarget = total - withTarget;
+      const pct = total ? ((withTarget / total) * 100).toFixed(1) : '0.0';
+      document.getElementById('kpiTotal').textContent = total;
+      document.getElementById('kpiWith').textContent = withTarget;
+      document.getElementById('kpiWithout').textContent = withoutTarget;
+      document.getElementById('kpiPct').textContent = `${pct}%`;
+      document.getElementById('kpiSection').style.display = '';
+      document.getElementById('chartsSection').style.display = state.filteredIssues.length ? '' : 'none';
+      document.getElementById('missingSection').style.display = '';
+    }
+
+    function buildStackedData(dimension) {
+      const distribution = dimension === 'pi' ? state.aggregated.byPi : state.aggregated.bySprint;
+      const labels = distribution.buckets.map(b => b.label);
+      const teamNames = new Set();
+      distribution.buckets.forEach(bucket => {
+        Object.keys(bucket.teams).forEach(team => teamNames.add(team));
+      });
+      const datasets = [];
+      Array.from(teamNames.values()).sort().forEach(team => {
+        const color = teamColor(team);
+        datasets.push({
+          label: `${team} – With Target`,
+          data: distribution.buckets.map(bucket => (bucket.teams[team]?.withTarget || 0)),
+          backgroundColor: colorWithAlpha(color, 0.85),
+          stack: team,
+          borderRadius: 4,
+        });
+        datasets.push({
+          label: `${team} – Without Target`,
+          data: distribution.buckets.map(bucket => (bucket.teams[team]?.withoutTarget || 0)),
+          backgroundColor: colorWithAlpha(color, 0.45),
+          stack: team,
+          borderRadius: 4,
+        });
+      });
+      return { labels, datasets };
+    }
+
+    function buildDistributionData(mode) {
+      if (mode === 'team') {
+        const labels = state.aggregated.byTeam.map(t => t.team);
+        return {
+          labels,
+          datasets: [
+            {
+              label: 'With Target',
+              data: state.aggregated.byTeam.map(t => t.withTarget),
+              backgroundColor: '#10b981',
+              stack: 'total',
+              borderRadius: 4,
+            },
+            {
+              label: 'Without Target',
+              data: state.aggregated.byTeam.map(t => t.withoutTarget),
+              backgroundColor: '#f97316',
+              stack: 'total',
+              borderRadius: 4,
+            }
+          ]
+        };
+      }
+      const labels = state.aggregated.byPi.buckets.map(b => b.label);
+      return {
+        labels,
+        datasets: [
+          {
+            label: 'With Target',
+            data: state.aggregated.byPi.buckets.map(b => b.withTarget),
+            backgroundColor: '#3b82f6',
+            stack: 'total',
+            borderRadius: 4,
+          },
+          {
+            label: 'Without Target',
+            data: state.aggregated.byPi.buckets.map(b => b.withoutTarget),
+            backgroundColor: '#ef4444',
+            stack: 'total',
+            borderRadius: 4,
+          }
+        ]
+      };
+    }
+
+    function updateCharts() {
+      if (!state.aggregated) return;
+      const stackedDimension = document.querySelector('input[name="stackedDimension"]:checked').value;
+      const stackedData = buildStackedData(stackedDimension);
+      const distributionMode = document.getElementById('distributionMode').value;
+      const distributionData = buildDistributionData(distributionMode);
+
+      const stackedCtx = document.getElementById('stackedChart').getContext('2d');
+      if (!stackedChart) {
+        stackedChart = new Chart(stackedCtx, {
+          type: 'bar',
+          data: stackedData,
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: { stacked: true, ticks: { autoSkip: false, maxRotation: 45, minRotation: 0 } },
+              y: { stacked: true, beginAtZero: true }
+            },
+            plugins: {
+              legend: { position: 'top' },
+              tooltip: { mode: 'index', intersect: false }
+            }
+          }
+        });
+      } else {
+        stackedChart.data = stackedData;
+        stackedChart.update();
+      }
+
+      const distributionCtx = document.getElementById('distributionChart').getContext('2d');
+      if (!distributionChart) {
+        distributionChart = new Chart(distributionCtx, {
+          type: 'bar',
+          data: distributionData,
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            indexAxis: 'y',
+            scales: {
+              x: { stacked: true, beginAtZero: true },
+              y: { stacked: true }
+            },
+            plugins: {
+              legend: { position: 'top' },
+              tooltip: { mode: 'index', intersect: false }
+            }
+          }
+        });
+      } else {
+        distributionChart.data = distributionData;
+        distributionChart.update();
+      }
+    }
+
+    function renderMissingTable() {
+      const tbody = document.getElementById('missingTableBody');
+      const search = document.getElementById('missingSearch').value.trim().toLowerCase();
+      const rows = state.filteredIssues.filter(issue => !issue.hasTargetRelease).filter(issue => {
+        if (!search) return true;
+        const values = [issue.key, issue.summary, issue.responsibleTeam, issue.type, issue.status].join(' ').toLowerCase();
+        return values.includes(search);
+      });
+      tbody.innerHTML = '';
+      if (!rows.length) {
+        document.getElementById('missingEmpty').style.display = '';
+        return;
+      }
+      document.getElementById('missingEmpty').style.display = 'none';
+      const domain = state.domain;
+      rows.slice(0, 1500).forEach(issue => {
+        const sprintNames = issue.sprints.length ? issue.sprints.map(s => s.name).join(', ') : '—';
+        const piLabels = issue.pis.length ? issue.pis.map(p => p.label).join(', ') : '—';
+        const boards = issue.boardIds.length ? issue.boardIds.map(id => state.boardsMap.get(Number(id))?.name || `Board ${id}`).join(', ') : '—';
+        const team = issue.responsibleTeam || 'Unassigned Team';
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td><a href="https://${domain}/browse/${issue.key}" target="_blank" rel="noopener">${issue.key}</a></td>
+          <td>${issue.summary || '—'}</td>
+          <td><span class="badge">${issue.type}</span></td>
+          <td><span class="status-pill ${getStatusClass(issue.status)}">${issue.status}</span></td>
+          <td>${team}</td>
+          <td>${sprintNames}</td>
+          <td>${piLabels}</td>
+          <td>${boards}</td>
+          <td>${issue.assignee || '—'}</td>
+          <td>${formatDate(issue.updated)}</td>
+          <td><a href="https://${domain}/browse/${issue.key}" target="_blank" rel="noopener">Open</a></td>
+        `;
+        tbody.appendChild(row);
+      });
+    }
+
+    function updateFilterOptions() {
+      const allPis = new Map();
+      const teams = new Set();
+      const boardOptions = new Map();
+
+      state.normalizedIssues.forEach(issue => {
+        if (!issue.pis.length) {
+          if (!allPis.has('__none__')) allPis.set('__none__', { value: '__none__', label: 'No PI' });
+        }
+        issue.pis.forEach(pi => {
+          if (!allPis.has(pi.base)) {
+            allPis.set(pi.base, { value: pi.base, label: pi.base });
+          }
+        });
+        const team = issue.responsibleTeam || 'Unassigned Team';
+        teams.add(team);
+        issue.boardIds.forEach(id => {
+          if (!boardOptions.has(String(id))) {
+            boardOptions.set(String(id), { value: String(id), label: state.boardsMap.get(Number(id))?.name || `Board ${id}` });
+          }
+        });
+      });
+
+      const piChoicesData = Array.from(allPis.values()).sort((a, b) => a.label.localeCompare(b.label));
+      piChoices.clearChoices();
+      piChoices.setChoices(piChoicesData.length ? piChoicesData : [{ value: '__none__', label: 'No PI' }], 'value', 'label', true);
+
+      const teamChoicesData = Array.from(teams.values()).sort().map(team => ({ value: team, label: team }));
+      teamChoices.clearChoices();
+      teamChoices.setChoices(teamChoicesData, 'value', 'label', true);
+
+      boardFilterChoices.clearChoices();
+      const boardValues = Array.from(boardOptions.values());
+      boardValues.push({ value: '__unassigned__', label: 'No Board' });
+      boardFilterChoices.setChoices(boardValues, 'value', 'label', true);
+    }
+
+    function defaultSprintSelection() {
+      const sorted = state.allSprints.slice().sort((a, b) => {
+        const dateA = a.endDate ? new Date(a.endDate).getTime() : (a.startDate ? new Date(a.startDate).getTime() : 0);
+        const dateB = b.endDate ? new Date(b.endDate).getTime() : (b.startDate ? new Date(b.startDate).getTime() : 0);
+        return dateB - dateA;
+      });
+      const defaultIds = sorted.slice(0, 12).map(s => String(s.id));
+      sprintChoices.removeActiveItems();
+      sprintChoices.setChoiceByValue(defaultIds);
+    }
+
+    async function loadBoards() {
+      const domain = document.getElementById('jiraDomain').value.trim();
+      if (!domain) return;
+      state.domain = domain;
+      try {
+        setLoading('Loading boards...');
+        const boards = await Jira.fetchBoardsByJql(domain);
+        state.boards = boards;
+        state.boardsMap = new Map(boards.map(b => [Number(b.id), b]));
+        boardChoices.clearChoices();
+        boardChoices.setChoices(boards.map(b => ({ value: String(b.id), label: `${b.name} (${b.id})` })), 'value', 'label', true);
+        boardFilterChoices.clearChoices();
+        boardFilterChoices.setChoices(boards.map(b => ({ value: String(b.id), label: `${b.name} (${b.id})` })), 'value', 'label', true);
+        setLoading('');
+      } catch (err) {
+        Logger.error('Failed to load boards', err);
+        setError('Could not load boards. Check your Jira session.');
+        setLoading('');
+      }
+    }
+
+    async function loadSprints() {
+      const domain = document.getElementById('jiraDomain').value.trim();
+      const boardIds = boardChoices.getValue(true);
+      if (!domain || !boardIds.length) {
+        setError('Please select at least one board.');
+        return;
+      }
+      state.domain = domain;
+      setError('');
+      try {
+        setLoading('Loading sprints...');
+        const sprints = [];
+        await Promise.all(boardIds.map(async boardId => {
+          try {
+            const values = await fetchSprintsForBoard(domain, boardId);
+            values.forEach(v => sprints.push(v));
+          } catch (err) {
+            Logger.error('Failed to load sprints for board', boardId, err);
+          }
+        }));
+        const unique = new Map();
+        sprints.forEach(s => {
+          if (!unique.has(s.id)) unique.set(s.id, s);
+        });
+        state.allSprints = Array.from(unique.values());
+        sprintChoices.clearChoices();
+        sprintChoices.setChoices(state.allSprints.map(s => ({ value: String(s.id), label: `${s.name} (${s.boardId})` })), 'value', 'label', true);
+        defaultSprintSelection();
+        document.getElementById('filtersSection').style.display = '';
+        setLoading('Sprints loaded. Ready to fetch issues.');
+        setTimeout(() => setLoading(''), 2000);
+      } catch (err) {
+        Logger.error('Failed to load sprints', err);
+        setError('Could not load sprints.');
+        setLoading('');
+      }
+    }
+
+    async function loadData() {
+      const domain = document.getElementById('jiraDomain').value.trim();
+      const sprintIds = sprintChoices.getValue(true);
+      if (!domain) {
+        setError('Jira domain is required.');
+        return;
+      }
+      if (!sprintIds.length) {
+        setError('Select at least one sprint to query.');
+        return;
+      }
+      setError('');
+      state.domain = domain;
+      try {
+        setLoading('Discovering fields...');
+        const responsibleField = await discoverResponsibleField(domain);
+        state.responsibleFieldKey = responsibleField;
+        setLoading('Fetching issues...');
+        const rawIssues = await fetchIssues(domain, { sprintIds, responsibleField });
+        setLoading(`Fetched ${rawIssues.length} issues. Normalizing...`);
+        teamColorMap.clear();
+        state.normalizedIssues = rawIssues.map(issue => normalizeIssue(issue, responsibleField));
+        state.loadedSprintIds = new Set(sprintIds.map(String));
+        state.needsReload = false;
+        updateFilterOptions();
+        document.getElementById('filtersSection').style.display = '';
+        document.getElementById('kpiSection').style.display = '';
+        document.getElementById('chartsSection').style.display = '';
+        document.getElementById('missingSection').style.display = '';
+        setLoading('Applying filters...');
+        applyFilters();
+        setLoading('');
+      } catch (err) {
+        Logger.error('Failed to load dashboard data', err);
+        setError('Could not fetch issues. Verify your Jira permissions and filters.');
+        setLoading('');
+      }
+    }
+
+    async function exportPDF() {
+      const content = document.getElementById('pdfContent');
+      const canvas = await html2canvas(content, { scale: 2, useCORS: true });
+      const { jsPDF } = window.jspdf;
+      const pdf = new jsPDF({ orientation: 'landscape', unit: 'pt', format: 'a4' });
+      const pageWidth = pdf.internal.pageSize.getWidth();
+      const pageHeight = pdf.internal.pageSize.getHeight();
+      const imgData = canvas.toDataURL('image/png');
+      const ratio = Math.min(pageWidth / canvas.width, pageHeight / canvas.height);
+      const imgWidth = canvas.width * ratio;
+      const imgHeight = canvas.height * ratio;
+      pdf.addImage(imgData, 'PNG', (pageWidth - imgWidth) / 2, 20, imgWidth, imgHeight);
+      pdf.save('pi-target-release-dashboard.pdf');
+    }
+
+    function switchVersion(page) {
+      if (!page) return;
+      window.location.href = page;
+    }
+
+    function initVersionSelect() {
+      const select = document.getElementById('versionSelect');
+      if (!select) return;
+      select.value = 'target_release_dashboard.html';
+      select.addEventListener('change', (event) => switchVersion(event.target.value));
+    }
+
+    document.getElementById('loadSprintsBtn').addEventListener('click', loadSprints);
+    document.getElementById('loadDataBtn').addEventListener('click', loadData);
+    document.getElementById('exportBtn').addEventListener('click', exportPDF);
+    document.getElementById('jiraDomain').addEventListener('change', loadBoards);
+    document.getElementById('missingSearch').addEventListener('input', () => renderMissingTable());
+    document.querySelectorAll('input[name="stackedDimension"]').forEach(input => input.addEventListener('change', updateCharts));
+    document.getElementById('distributionMode').addEventListener('change', updateCharts);
+    ['suffixCommitted', 'suffixPlanned', 'suffixSpillover'].forEach(id => {
+      document.getElementById(id).addEventListener('change', applyFilters);
+    });
+
+    function setupFilterReactivity() {
+      ['teamSelect', 'boardFilterSelect', 'piSelect', 'sprintSelect'].forEach(id => {
+        const el = document.getElementById(id);
+        el.addEventListener('change', () => {
+          if (id === 'sprintSelect') {
+            const values = sprintChoices.getValue(true).map(String);
+            state.needsReload = values.some(v => !state.loadedSprintIds.has(v));
+          }
+          applyFilters();
+        });
+      });
+    }
+
+    initVersionSelect();
+    initChoices();
+    setupFilterReactivity();
+    loadBoards();
+  </script>
+</body>
+</html>

--- a/test.html
+++ b/test.html
@@ -42,6 +42,7 @@
         <option value="index_throughput.html">Throughput</option>
         <option value="index_throughput_week.html">Weekly Throughput</option>
         <option value="index_disruption.html">Disruption</option>
+        <option value="target_release_dashboard.html">PI &amp; Target-Release Dashboard</option>
       </select>
     </label>
   </div>


### PR DESCRIPTION
## Summary
- replace the previous React-based target release dashboard with a standalone HTML page that matches the repo’s existing tooling patterns, including filters, charts, and PDF export
- update navigation drop-downs across existing reports to link to the new dashboard and remove unused React dependencies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd131dbf40832587bb7915b44bc42c