### PR TITLE
Include child issues in target release timeline

### DIFF
--- a/target_release_dashboard.html
+++ b/target_release_dashboard.html
@@ -52,6 +52,20 @@
     .timeline-dates { display:flex; flex-wrap:wrap; gap:12px; font-size:0.9em; color:#4b5563; }
     .timeline-dates span { display:flex; align-items:center; gap:6px; }
     .timeline-date-label { font-weight:600; text-transform:uppercase; font-size:0.75em; letter-spacing:0.08em; color:#6b7280; }
+    .timeline-issues { margin-top:12px; display:flex; flex-direction:column; gap:10px; }
+    .timeline-issue { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:10px 12px; display:flex; flex-direction:column; gap:6px; }
+    .timeline-issue.no-target { background:#fef2f2; border-color:#fecaca; }
+    .timeline-issue-header { display:flex; flex-wrap:wrap; gap:8px; align-items:center; font-weight:600; color:#1f2937; }
+    .timeline-issue-header a { color:#4338ca; text-decoration:none; }
+    .timeline-issue-header a:hover { text-decoration:underline; }
+    .timeline-issue-summary { flex:1; color:#374151; font-weight:500; }
+    .timeline-issue-meta { display:flex; flex-wrap:wrap; gap:8px; font-size:0.82em; color:#4b5563; align-items:center; }
+    .timeline-issue-meta .badge { background:#e0e7ff; color:#3730a3; }
+    .timeline-issue-meta .issue-team { background:#f1f5f9; border-radius:999px; padding:2px 8px; font-weight:600; }
+    .timeline-issue-meta span.issue-epic { display:flex; align-items:center; gap:6px; }
+    .timeline-issue-meta span.issue-epic a { color:#4338ca; text-decoration:none; font-weight:600; }
+    .timeline-issue-meta span.issue-epic a:hover { text-decoration:underline; }
+    .timeline-no-issues { margin-top:12px; padding:14px; border-radius:12px; background:#f8fafc; color:#6b7280; font-size:0.9em; border:1px dashed #cbd5f5; text-align:center; }
     .timeline-empty { background:#f9fafb; border:1px dashed #cbd5f5; border-radius:12px; padding:30px; text-align:center; color:#6b7280; font-size:0.95em; margin-top:20px; }
     .badge { background:#e5e7eb; border-radius:999px; padding:2px 10px; font-size:0.78em; font-weight:600; color:#374151; }
     .status-pill { border-radius:999px; padding:2px 10px; font-size:0.78em; font-weight:600; color:#fff; display:inline-block; }
@@ -62,6 +76,13 @@
     .empty-state { background:#f9fafb; border:1px dashed #cbd5f5; border-radius:12px; padding:30px; text-align:center; color:#6b7280; font-size:0.95em; margin-top:20px; }
     .loading { margin:14px 0; font-weight:600; color:#4338ca; }
     .error { margin:14px 0; font-weight:600; color:#dc2626; }
+    details.collapsible { margin-top:30px; }
+    details.collapsible[open] { margin-bottom:10px; }
+    summary.collapsible-summary { list-style:none; cursor:pointer; font-size:1.2em; font-weight:600; color:#111827; display:flex; align-items:center; justify-content:space-between; padding:0; }
+    summary.collapsible-summary::marker { display:none; }
+    summary.collapsible-summary::after { content:'\25BC'; font-size:0.8em; transition:transform 0.2s ease; color:#6b7280; }
+    details[open] > summary.collapsible-summary::after { transform:rotate(180deg); }
+    summary.collapsible-summary::-webkit-details-marker { display:none; }
     @media (max-width: 840px) {
       .controls { flex-direction:column; align-items:flex-start; }
       .chart-toolbar { flex-direction:column; align-items:flex-start; }
@@ -157,30 +178,32 @@
     </div>
 
     <div id="epicSection" style="display:none;">
-      <div class="section-title">Open Epics</div>
-      <div class="table-controls">
-        <div style="font-size:0.85em; color:#6b7280;">Epics grouped by target version for the selected boards.</div>
-        <input id="epicSearch" placeholder="Search by epic, summary, target version...">
-      </div>
-      <div class="table-wrap" style="overflow-x:auto;">
-        <table>
-          <thead>
-            <tr>
-              <th>Epic</th>
-              <th>Summary</th>
-              <th>Target Version</th>
-              <th>Responsible Team</th>
-              <th>Product Increments</th>
-              <th>Child Items</th>
-              <th>With Target</th>
-              <th>Coverage</th>
-              <th>Boards</th>
-            </tr>
-          </thead>
-          <tbody id="epicTableBody"></tbody>
-        </table>
-      </div>
-      <div id="epicEmpty" class="empty-state" style="display:none;">No epics match the current filters.</div>
+      <details id="epicDetails" class="collapsible" open>
+        <summary class="collapsible-summary">Open Epics</summary>
+        <div class="table-controls">
+          <div style="font-size:0.85em; color:#6b7280;">Epics grouped by target version for the selected boards.</div>
+          <input id="epicSearch" placeholder="Search by epic, summary, target version...">
+        </div>
+        <div class="table-wrap" style="overflow-x:auto;">
+          <table>
+            <thead>
+              <tr>
+                <th>Epic</th>
+                <th>Summary</th>
+                <th>Target Version</th>
+                <th>Responsible Team</th>
+                <th>Product Increments</th>
+                <th>Child Items</th>
+                <th>With Target</th>
+                <th>Coverage</th>
+                <th>Boards</th>
+              </tr>
+            </thead>
+            <tbody id="epicTableBody"></tbody>
+          </table>
+        </div>
+        <div id="epicEmpty" class="empty-state" style="display:none;">No epics match the current filters.</div>
+      </details>
     </div>
 
     <div id="chartsSection" style="display:none;">
@@ -214,36 +237,6 @@
           <canvas id="distributionChart" height="360"></canvas>
         </div>
       </div>
-    </div>
-
-    <div id="childSection" style="display:none; margin-top:40px;">
-      <div class="section-title">Child Items</div>
-      <div class="table-controls">
-        <div style="font-size:0.85em; color:#6b7280;">Displaying child issues for the filtered epics. Use search to refine.</div>
-        <input id="childSearch" placeholder="Search by key, summary, epic, team...">
-      </div>
-      <div class="table-wrap" style="overflow-x:auto;">
-        <table>
-          <thead>
-            <tr>
-              <th>Key</th>
-              <th>Summary</th>
-              <th>Epic</th>
-              <th>Type</th>
-              <th>Status</th>
-              <th>Responsible Team</th>
-              <th>Epic Target Version</th>
-              <th>Issue Target Version</th>
-              <th>Boards</th>
-              <th>Assignee</th>
-              <th>Updated</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody id="childTableBody"></tbody>
-        </table>
-      </div>
-      <div id="childEmpty" class="empty-state" style="display:none;">No child items match the current filters.</div>
     </div>
   </div>
 
@@ -1045,7 +1038,6 @@
         state.aggregated = aggregateIssues([]);
         renderKpis();
         renderEpicTable();
-        renderChildTable();
         renderReleasesTimeline();
         setLoading('No epics found for the selected boards.');
         return;
@@ -1105,7 +1097,6 @@
       renderKpis();
       updateCharts();
       renderEpicTable();
-      renderChildTable();
       renderReleasesTimeline();
 
       if (!filteredEpics.length) {
@@ -1134,56 +1125,204 @@
       });
     }
 
+    function buildTimelineIssueHtml(issue) {
+      const domain = state.domain;
+      const team = issue.responsibleTeam || 'Unassigned Team';
+      const boards = issue.boardIds && issue.boardIds.size
+        ? Array.from(issue.boardIds).map(id => state.boardsMap.get(Number(id))?.name || `Board ${id}`).join(', ')
+        : '';
+      const updated = formatDate(issue.updated);
+      const metaParts = [
+        `<span class="badge">${issue.type}</span>`,
+        `<span class="status-pill ${getStatusClass(issue.status)}">${issue.status}</span>`,
+        `<span class="issue-team">Team: ${team}</span>`,
+      ];
+      if (issue.parentKey) {
+        const epicSummary = issue.parentSummary ? ` – ${issue.parentSummary}` : '';
+        metaParts.push(`<span class="issue-epic">Epic <a href="https://${domain}/browse/${issue.parentKey}" target="_blank" rel="noopener">${issue.parentKey}</a>${epicSummary}</span>`);
+      }
+      metaParts.push(`<span>Target: ${issue.targetVersion}</span>`);
+      if (boards) metaParts.push(`<span>Boards: ${boards}</span>`);
+      if (issue.assignee) metaParts.push(`<span>Assignee: ${issue.assignee}</span>`);
+      if (updated) metaParts.push(`<span>Updated ${updated}</span>`);
+
+      return `
+        <div class="timeline-issue ${issue.hasTargetVersion ? '' : 'no-target'}">
+          <div class="timeline-issue-header">
+            <a href="https://${domain}/browse/${issue.key}" target="_blank" rel="noopener">${issue.key}</a>
+            <span class="timeline-issue-summary">${issue.summary || '—'}</span>
+          </div>
+          <div class="timeline-issue-meta">
+            ${metaParts.join('')}
+          </div>
+        </div>
+      `;
+    }
+
     function renderReleasesTimeline() {
       const container = document.getElementById('releasesTimeline');
       if (!container) return;
+      const searchInput = document.getElementById('releaseSearch');
+      const search = searchInput ? searchInput.value.trim().toLowerCase() : '';
+
       const releases = getUpcomingReleases();
-      const search = document.getElementById('releaseSearch').value.trim().toLowerCase();
-
-      if (!releases.length) {
-        container.innerHTML = '';
-        document.getElementById('releasesSection').style.display = 'none';
-        document.getElementById('releasesEmpty').style.display = '';
-        return;
-      }
-
-      document.getElementById('releasesSection').style.display = '';
-      document.getElementById('releasesEmpty').style.display = 'none';
-
-      const filtered = releases.filter(release => {
-        if (!search) return true;
-        const boardName = state.boardsMap.get(Number(release.boardId))?.name || `Board ${release.boardId}`;
-        const projectName = release.projectName || '';
-        const projectKey = release.projectKey || '';
-        const haystack = [
-          release.name,
-          boardName,
-          projectName,
-          projectKey,
-        ].join(' ').toLowerCase();
-        return haystack.includes(search);
+      const releaseBuckets = new Map();
+      releases.forEach(release => {
+        releaseBuckets.set(release.uniqueKey, {
+          type: 'release',
+          key: release.uniqueKey,
+          label: release.name,
+          release,
+          issues: [],
+        });
       });
 
+      const orphanBuckets = new Map();
+      const ensureOrphanBucket = (key, issue) => {
+        if (orphanBuckets.has(key)) return orphanBuckets.get(key);
+        let label = issue?.targetVersion || 'Unmapped Target Version';
+        let type = issue?.targetSource === 'target-release' ? 'manual' : 'unmapped';
+        if (key === '__none__' || !issue?.hasTargetVersion) {
+          label = 'No Target Version';
+          type = 'none';
+        } else if (issue?.targetSource === 'target-release' && key.startsWith('target:')) {
+          label = issue?.targetVersion || key.slice('target:'.length);
+          type = 'manual';
+        }
+        const bucket = { type, key, label, release: null, issues: [] };
+        orphanBuckets.set(key, bucket);
+        return bucket;
+      };
+
+      state.filteredIssues.forEach(issue => {
+        const key = issue.targetVersionKey || '__none__';
+        const bucket = releaseBuckets.get(key) || ensureOrphanBucket(key, issue);
+        bucket.issues.push(issue);
+      });
+
+      const releaseList = Array.from(releaseBuckets.values()).sort((a, b) => {
+        const aDate = a.release?.releaseDate ? new Date(a.release.releaseDate).getTime() : Number.MAX_SAFE_INTEGER;
+        const bDate = b.release?.releaseDate ? new Date(b.release.releaseDate).getTime() : Number.MAX_SAFE_INTEGER;
+        if (aDate === bDate) return a.label.localeCompare(b.label, undefined, { numeric: true });
+        return aDate - bDate;
+      });
+      const orphanList = Array.from(orphanBuckets.values()).sort((a, b) => {
+        if (a.type === 'none' && b.type !== 'none') return 1;
+        if (b.type === 'none' && a.type !== 'none') return -1;
+        return a.label.localeCompare(b.label, undefined, { numeric: true });
+      });
+      const buckets = [...releaseList, ...orphanList];
+
+      const matchesSearch = (bucket) => {
+        if (!search) return true;
+        const values = [bucket.label || ''];
+        if (bucket.release) {
+          values.push(bucket.release.name || '');
+          if (bucket.release.projectName) values.push(bucket.release.projectName);
+          if (bucket.release.projectKey) values.push(bucket.release.projectKey);
+          if (bucket.release.boardId !== undefined) {
+            const boardName = state.boardsMap.get(Number(bucket.release.boardId))?.name || `Board ${bucket.release.boardId}`;
+            values.push(boardName);
+          }
+        } else if (bucket.type === 'none') {
+          values.push('no target version');
+        } else if (bucket.type === 'manual') {
+          values.push('target release');
+        } else {
+          values.push('fix version');
+        }
+        bucket.issues.forEach(issue => {
+          values.push(
+            issue.key,
+            issue.summary,
+            issue.responsibleTeam,
+            issue.status,
+            issue.type,
+            issue.targetVersion,
+            issue.assignee,
+            issue.parentKey,
+            issue.parentSummary,
+          );
+          if (issue.boardIds && issue.boardIds.size) {
+            issue.boardIds.forEach(id => {
+              values.push(state.boardsMap.get(Number(id))?.name || `Board ${id}`);
+            });
+          }
+        });
+        return values.some(value => value && String(value).toLowerCase().includes(search));
+      };
+
       container.innerHTML = '';
-      if (!filtered.length) {
+      document.getElementById('releasesSection').style.display = '';
+
+      const filteredBuckets = buckets.filter(matchesSearch);
+      if (!filteredBuckets.length) {
         document.getElementById('releasesEmpty').style.display = '';
         return;
       }
       document.getElementById('releasesEmpty').style.display = 'none';
 
-      filtered.forEach(release => {
+      const collectBoardNames = (issues) => {
+        const names = new Set();
+        issues.forEach(issue => {
+          if (!issue.boardIds || !issue.boardIds.size) return;
+          issue.boardIds.forEach(id => {
+            names.add(state.boardsMap.get(Number(id))?.name || `Board ${id}`);
+          });
+        });
+        return Array.from(names.values());
+      };
+
+      filteredBuckets.forEach(bucket => {
         const item = document.createElement('div');
         item.className = 'timeline-item';
-        const startDate = release.startDate ? formatDate(release.startDate) : 'Not set';
-        const releaseDate = release.releaseDate ? formatDate(release.releaseDate) : 'Not set';
+        const issueCount = bucket.issues.length;
+        let metaSpans = [];
+        if (bucket.release) {
+          const startDate = bucket.release.startDate ? formatDate(bucket.release.startDate) : 'Not set';
+          const releaseDate = bucket.release.releaseDate ? formatDate(bucket.release.releaseDate) : 'Not set';
+          const boardName = bucket.release.boardId !== undefined
+            ? state.boardsMap.get(Number(bucket.release.boardId))?.name || `Board ${bucket.release.boardId}`
+            : '';
+          const projectDisplay = bucket.release.projectName
+            ? bucket.release.projectKey
+              ? `${bucket.release.projectName} (${bucket.release.projectKey})`
+              : bucket.release.projectName
+            : (bucket.release.projectKey || '');
+          metaSpans = [
+            `<span><span class="timeline-date-label">Start</span> ${startDate}</span>`,
+            `<span><span class="timeline-date-label">Release</span> ${releaseDate}</span>`,
+            `<span><span class="timeline-date-label">Issues</span> ${issueCount}</span>`,
+          ];
+          if (boardName) metaSpans.push(`<span><span class="timeline-date-label">Board</span> ${boardName}</span>`);
+          if (projectDisplay) metaSpans.push(`<span><span class="timeline-date-label">Project</span> ${projectDisplay}</span>`);
+        } else {
+          const boardNames = collectBoardNames(bucket.issues);
+          metaSpans = [
+            `<span><span class="timeline-date-label">Issues</span> ${issueCount}</span>`,
+          ];
+          if (bucket.type === 'none') {
+            metaSpans.push(`<span><span class="timeline-date-label">Status</span> No Target Version</span>`);
+          } else if (bucket.type === 'manual') {
+            metaSpans.push(`<span><span class="timeline-date-label">Source</span> Target Release Field</span>`);
+          } else {
+            metaSpans.push(`<span><span class="timeline-date-label">Source</span> Fix Version</span>`);
+          }
+          if (boardNames.length) {
+            metaSpans.push(`<span><span class="timeline-date-label">Boards</span> ${boardNames.join(', ')}</span>`);
+          }
+        }
+
+        const issuesHtml = issueCount
+          ? `<div class="timeline-issues">${bucket.issues.map(buildTimelineIssueHtml).join('')}</div>`
+          : '<div class="timeline-no-issues">No child items match the current filters.</div>';
+
         item.innerHTML = `
           <div class="timeline-marker"></div>
           <div class="timeline-content">
-            <div class="timeline-title">${release.name}</div>
-            <div class="timeline-dates">
-              <span><span class="timeline-date-label">Start</span> ${startDate}</span>
-              <span><span class="timeline-date-label">Release</span> ${releaseDate}</span>
-            </div>
+            <div class="timeline-title">${bucket.label}</div>
+            <div class="timeline-dates">${metaSpans.join('')}</div>
+            ${issuesHtml}
           </div>
         `;
         container.appendChild(item);
@@ -1203,7 +1342,6 @@
       document.getElementById('kpiSection').style.display = '';
       document.getElementById('chartsSection').style.display = state.filteredIssues.length ? '' : 'none';
       document.getElementById('epicSection').style.display = '';
-      document.getElementById('childSection').style.display = '';
     }
 
     function buildStackedData(dimension) {
@@ -1333,64 +1471,6 @@
         distributionChart.data = distributionData;
         distributionChart.update();
       }
-    }
-
-    function renderChildTable() {
-      const tbody = document.getElementById('childTableBody');
-      const searchInput = document.getElementById('childSearch');
-      const search = searchInput ? searchInput.value.trim().toLowerCase() : '';
-      const rows = state.filteredIssues.filter(issue => {
-        if (!search) return true;
-        const values = [
-          issue.key,
-          issue.summary,
-          issue.responsibleTeam,
-          issue.type,
-          issue.status,
-          issue.parentKey || '',
-          issue.parentSummary || '',
-          issue.targetVersion || '',
-          issue.parentTargetVersion || ''
-        ].join(' ').toLowerCase();
-        return values.includes(search);
-      });
-      tbody.innerHTML = '';
-      if (!rows.length) {
-        document.getElementById('childEmpty').style.display = '';
-        return;
-      }
-      document.getElementById('childEmpty').style.display = 'none';
-      const domain = state.domain;
-      rows.slice(0, 1500).forEach(issue => {
-        const boards = issue.boardIds && issue.boardIds.size
-          ? Array.from(issue.boardIds).map(id => state.boardsMap.get(Number(id))?.name || `Board ${id}`).join(', ')
-          : '—';
-        const team = issue.responsibleTeam || 'Unassigned Team';
-        const parentDisplay = issue.parentKey
-          ? `<a href="https://${domain}/browse/${issue.parentKey}" target="_blank" rel="noopener">${issue.parentKey}</a>${issue.parentSummary ? ` – ${issue.parentSummary}` : ''}`
-          : '—';
-        const targetDisplay = issue.hasTargetVersion ? issue.targetVersion : '—';
-        const parentTarget = issue.parentTargetVersion || 'No Target Version';
-        const row = document.createElement('tr');
-        if (!issue.hasTargetVersion) {
-          row.style.background = '#fff7ed';
-        }
-        row.innerHTML = `
-          <td><a href="https://${domain}/browse/${issue.key}" target="_blank" rel="noopener">${issue.key}</a></td>
-          <td>${issue.summary || '—'}</td>
-          <td>${parentDisplay}</td>
-          <td><span class="badge">${issue.type}</span></td>
-          <td><span class="status-pill ${getStatusClass(issue.status)}">${issue.status}</span></td>
-          <td>${team}</td>
-          <td>${parentTarget}</td>
-          <td>${targetDisplay}</td>
-          <td>${boards}</td>
-          <td>${issue.assignee || '—'}</td>
-          <td>${formatDate(issue.updated)}</td>
-          <td><a href="https://${domain}/browse/${issue.key}" target="_blank" rel="noopener">Open</a></td>
-        `;
-        tbody.appendChild(row);
-      });
     }
 
     function renderEpicTable() {
@@ -1570,11 +1650,9 @@
               });
             }
           }));
-          document.getElementById('releasesSection').style.display = '';
-        } else {
-          document.getElementById('releasesSection').style.display = 'none';
-          document.getElementById('releasesEmpty').style.display = '';
         }
+        document.getElementById('releasesSection').style.display = '';
+        document.getElementById('releasesEmpty').style.display = 'none';
 
         setLoading('Fetching epics...');
         const epicMap = new Map();
@@ -1644,7 +1722,6 @@
         document.getElementById('kpiSection').style.display = '';
         document.getElementById('chartsSection').style.display = state.normalizedIssues.length ? '' : 'none';
         document.getElementById('epicSection').style.display = '';
-        document.getElementById('childSection').style.display = '';
 
         setLoading('Applying filters...');
         state.filteredEpics = state.epics.slice();
@@ -1690,7 +1767,6 @@
     document.getElementById('exportBtn').addEventListener('click', exportPDF);
     document.getElementById('jiraDomain').addEventListener('change', loadBoards);
     document.getElementById('epicSearch').addEventListener('input', () => renderEpicTable());
-    document.getElementById('childSearch').addEventListener('input', () => renderChildTable());
     document.getElementById('releaseSearch').addEventListener('input', () => renderReleasesTimeline());
     document.querySelectorAll('input[name="stackedDimension"]').forEach(input => input.addEventListener('change', updateCharts));
     document.getElementById('distributionMode').addEventListener('change', updateCharts);


### PR DESCRIPTION
## Summary
- display child items directly within the releases timeline, including buckets for issues without a target version
- add timeline issue styling and metadata along with improved search support for release and target buckets
- convert the epics table into a collapsible section and remove the standalone child items table

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de38eb91a08325bf601f38ee9cec6e