### PR TITLE
Hide target version metadata for tasks

### DIFF
--- a/target_release_dashboard.html
+++ b/target_release_dashboard.html
@@ -1219,6 +1219,7 @@
       const timelineTarget = issue.timelineTargetVersion || issue.targetVersion;
       const timelineSource = issue.timelineTargetSource || issue.targetSource;
       const targetSuffix = timelineSource === 'inherited' ? ' (from epic)' : '';
+      const issueType = (issue.type || '').toLowerCase();
       const metaParts = [
         `<span class="${badgeClass}">${issue.type}</span>`,
         `<span class="status-pill ${getStatusClass(issue.status)}">${issue.status}</span>`,
@@ -1228,7 +1229,10 @@
         const epicSummary = issue.parentSummary ? ` – ${issue.parentSummary}` : '';
         metaParts.push(`<span class="issue-epic">Epic <a href="https://${domain}/browse/${issue.parentKey}" target="_blank" rel="noopener">${issue.parentKey}</a>${epicSummary}</span>`);
       }
-      metaParts.push(`<span>Target: ${timelineTarget}${targetSuffix}</span>`);
+      const shouldShowTarget = issue.isEpic || issueType !== 'task';
+      if (shouldShowTarget) {
+        metaParts.push(`<span>Target: ${timelineTarget}${targetSuffix}</span>`);
+      }
       if (boards) metaParts.push(`<span>Boards: ${boards}</span>`);
       if (issue.assignee) metaParts.push(`<span>Assignee: ${issue.assignee}</span>`);
       if (updated) metaParts.push(`<span>Updated ${updated}</span>`);


### PR DESCRIPTION
## Summary
- avoid showing target version details on timeline entries for Task issues since they never carry target/fix versions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de46b536e48325a8438b1568297aca