### PR TITLE
Stop counting tasks in release timeline

### DIFF
--- a/target_release_dashboard.html
+++ b/target_release_dashboard.html
@@ -1496,6 +1496,10 @@
       const timelineItems = [];
 
       state.filteredIssues.forEach(issue => {
+        const issueType = (issue.type || '').toLowerCase();
+        if (issueType === 'task') {
+          return;
+        }
         const baseItem = {
           ...issue,
           boardIds: issue.boardIds && issue.boardIds.size ? new Set(issue.boardIds) : new Set(),


### PR DESCRIPTION
## Summary
- skip task-type issues when preparing release timeline items so they no longer count toward release groupings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de48d20b148325a7863dea186b3f76