### PR TITLE
Improve target version prioritization

### DIFF
--- a/target_release_dashboard.html
+++ b/target_release_dashboard.html
@@ -878,41 +878,55 @@
       const targets = [];
       const seen = new Set();
 
-      const addTarget = (key, label, source, hasValue = true) => {
+      const addTarget = (key, label, source, hasValue = true, priority = 0) => {
         if (!key) return;
         const finalKey = key || '__none__';
-        if (seen.has(finalKey)) return;
+        if (seen.has(finalKey)) {
+          // Update existing target if new source has higher priority
+          const existing = targets.find(t => t.key === finalKey);
+          if (existing && priority > (existing.priority || 0)) {
+            existing.source = source;
+            existing.priority = priority;
+            existing.hasValue = hasValue;
+          }
+          return;
+        }
         seen.add(finalKey);
         targets.push({
           key: finalKey,
           label: label || 'No Target Version',
           hasValue,
           source,
+          priority,
         });
       };
 
-      if (Array.isArray(fixVersions) && fixVersions.length) {
-        fixVersions.forEach(version => {
-          if (!version) return;
-          const key = version.key || (version.name ? `name:${version.name}` : undefined) || '__none__';
-          const label = version.name || 'Unnamed Release';
-          addTarget(key, label, 'fixVersion', key !== '__none__');
-        });
-      }
-
+      // Priority: target-release field (3) > fixVersion (2) > none (1)
       if (Array.isArray(targetReleases) && targetReleases.length) {
         targetReleases.forEach(value => {
           const label = value || 'No Target Version';
           const key = value ? `target:${value}` : '__none__';
-          addTarget(key, label, value ? 'target-release' : 'none', Boolean(value));
+          addTarget(key, label, value ? 'target-release' : 'none', Boolean(value), value ? 3 : 1);
+        });
+      }
+
+      if (Array.isArray(fixVersions) && fixVersions.length) {
+        fixVersions.forEach(version => {
+          if (!version) return;
+          const key = version.key || version.id || (version.name ? `name:${version.name}` : undefined) || '__none__';
+          const label = version.name || 'Unnamed Release';
+          addTarget(key, label, 'fixVersion', key !== '__none__', 2);
         });
       }
 
       if (!targets.length) {
-        addTarget('__none__', 'No Target Version', 'none', false);
+        addTarget('__none__', 'No Target Version', 'none', false, 1);
       }
 
-      const primary = targets.find(target => target.hasValue) || targets[0];
+      // Select primary: highest priority with value, or highest priority overall
+      const withValue = targets.filter(t => t.hasValue).sort((a, b) => (b.priority || 0) - (a.priority || 0));
+      const primary = withValue[0] || targets.sort((a, b) => (b.priority || 0) - (a.priority || 0))[0];
+      
       return {
         primary,
         targets,


### PR DESCRIPTION
## Summary
- update determineTargetVersions to use priority-aware handling of fix versions and target releases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de68e7d3588325a4fd01bc5a0acd76