### PR TITLE
Show missing target version tag for inherited issues

### DIFF
--- a/target_release_dashboard.html
+++ b/target_release_dashboard.html
@@ -65,6 +65,7 @@
     .timeline-issue-meta .badge { background:#e0e7ff; color:#3730a3; }
     .timeline-issue-meta .badge.epic-badge { background:#fef3c7; color:#b45309; }
     .timeline-issue-meta .badge.missing-fix-version { background:#fee2e2; color:#b91c1c; border:1px solid #fecaca; }
+    .timeline-issue-meta .badge.missing-target-version { background:#fef3c7; color:#92400e; border:1px solid #fde68a; }
     .timeline-issue-meta .badge.inherited-parent { background:#ede9fe; color:#5b21b6; border:1px solid #ddd6fe; }
     .timeline-issue-meta .issue-team { background:#f1f5f9; border-radius:999px; padding:2px 8px; font-weight:600; }
     .timeline-issue-meta span.issue-epic { display:flex; align-items:center; gap:6px; }
@@ -1655,6 +1656,9 @@
       }
       if (!issue.hasTargetVersion && timelineSource === 'inherited') {
         metaParts.push('<span class="badge inherited-parent" title="Issue inherits its release from the parent">Parent Target</span>');
+      }
+      if (!issue.hasTargetVersion) {
+        metaParts.push('<span class="badge missing-target-version" title="Issue has no target version of its own">No Target Version</span>');
       }
       if (shouldShowTarget) {
         metaParts.push(`<span>Target: ${timelineTarget}${targetSuffix}</span>`);


### PR DESCRIPTION
## Summary
- add a dedicated badge to highlight when an issue lacks its own target version
- style the new badge so inherited issues missing a target remain easy to spot alongside their parent tag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e37eaa13c883258c5febbd90f9f070