### PR TITLE
Align responsible team with selected boards

### DIFF
--- a/target_release_dashboard.html
+++ b/target_release_dashboard.html
@@ -1015,6 +1015,8 @@
       const targetPrimary = targetInfo.primary;
       const targetVersions = targetInfo.targets;
       const responsibleTeam = extractResponsibleTeam(fields, responsibleFieldKey);
+      const boardName = state.boardsMap.get(Number(boardId))?.name;
+      const normalizedTeam = boardName || responsibleTeam || undefined;
 
       return {
         id: String(issue.id || issue.key || ''),
@@ -1022,7 +1024,7 @@
         summary: String(fields.summary || ''),
         status: fields.status?.name ? String(fields.status.name) : 'Unknown',
         assignee: fields.assignee?.displayName ? String(fields.assignee.displayName) : undefined,
-        responsibleTeam: responsibleTeam || undefined,
+        responsibleTeam: normalizedTeam,
         boardIds: new Set([Number(boardId)]),
         fixVersions,
         targetRelease: targetReleases[0] || undefined,
@@ -1078,7 +1080,9 @@
       const targetInfo = determineTargetVersions(targetReleases);
       const targetPrimary = targetInfo.primary;
       const targetVersions = targetInfo.targets;
-      const responsibleTeam = parent?.responsibleTeam || extractResponsibleTeam(fields, responsibleFieldKey);
+      const extractedTeam = extractResponsibleTeam(fields, responsibleFieldKey);
+      const boardName = state.boardsMap.get(Number(boardId))?.name;
+      const responsibleTeam = parent?.responsibleTeam || boardName || extractedTeam;
 
       const parentTargetVersion = parent?.targetVersion || targetPrimary.label || 'No Target Version';
       const parentTargetVersionKey = parent?.targetVersionKey || targetPrimary.key || '__none__';
@@ -1630,7 +1634,6 @@
 
     function buildTimelineIssueHtml(issue) {
       const domain = state.domain;
-      const team = issue.responsibleTeam || 'Unassigned Team';
       const boards = issue.boardIds && issue.boardIds.size
         ? Array.from(issue.boardIds).map(id => state.boardsMap.get(Number(id))?.name || `Board ${id}`).join(', ')
         : '';
@@ -1645,7 +1648,6 @@
       const metaParts = [
         `<span class="${badgeClass}">${issue.type}</span>`,
         `<span class="status-pill ${statusClass}">${issue.status}</span>`,
-        `<span class="issue-team">Team: ${team}</span>`,
       ];
       if (issue.parentKey) {
         const epicSummary = issue.parentSummary ? ` – ${issue.parentSummary}` : '';


### PR DESCRIPTION
## Summary
- derive responsible team labels from the selected board instead of the Jira field
- remove the team badge from issue metadata to avoid conflicting information

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e38c0356b88325af27262b7f92719c