### PR TITLE
Filter dashboard epics without valid PIX target releases

### DIFF
--- a/target_release_dashboard.html
+++ b/target_release_dashboard.html
@@ -945,6 +945,14 @@
       return primaryValues;
     }
 
+    function filterPixTargetReleases(values) {
+      if (!Array.isArray(values) || !values.length) return [];
+      const pattern = /^\d{4}_pi\d{1,2}_(?:committed|commited|candidate)$/i;
+      return values
+        .map(value => typeof value === 'string' ? value.trim() : String(value || '').trim())
+        .filter(value => value && pattern.test(value));
+    }
+
     function resolveTargetReleaseValue(fields, targetReleaseField) {
       if (!fields || typeof fields !== 'object') return undefined;
       const keys = Array.isArray(targetReleaseField)
@@ -1063,7 +1071,8 @@
       const fixVersions = parseFixVersions(fields.fixVersions);
       const targetReleaseField = targetReleaseFieldKey || 'target-release';
       const targetReleaseValue = resolveTargetReleaseValue(fields, targetReleaseField);
-      const targetReleases = parseTargetReleaseValues(targetReleaseValue);
+      const targetReleasesRaw = parseTargetReleaseValues(targetReleaseValue);
+      const targetReleases = filterPixTargetReleases(targetReleasesRaw);
       const targetInfo = determineTargetVersions(targetReleases);
       const targetPrimary = targetInfo.primary;
       const targetVersions = targetInfo.targets;
@@ -1096,6 +1105,7 @@
         childWithTarget: 0,
         childWithoutTarget: 0,
         coveragePct: 0,
+        hasValidPixTarget: targetReleases.length > 0,
       };
     }
 
@@ -2177,6 +2187,10 @@
             totalEpicsFetched += items.length;
             items.forEach(({ issue, boardId }) => {
               const normalized = normalizeEpic(issue, boardId, responsibleField, state.targetReleaseFieldKeys);
+              if (!normalized.hasValidPixTarget) {
+                Logger.debug(`Skipping epic ${normalized.key} – missing YEAR_PIx_(committed|candidate) target release.`);
+                return;
+              }
               if (epicMap.has(normalized.key)) {
                 const existing = epicMap.get(normalized.key);
                 normalized.boardIds.forEach(id => existing.boardIds.add(id));


### PR DESCRIPTION
## Summary
- ensure epic target releases are restricted to YEAR_PIx committed or candidate values
- skip epics lacking a valid PIX target release when populating the dashboard

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e394ac5cdc83258b2822d7f3c9f2fd