### PR TITLE
Handle PI planning labels on PI dashboard

### DIFF
--- a/target_release_dashboard.html
+++ b/target_release_dashboard.html
@@ -135,7 +135,7 @@
           <select id="piSelect" multiple></select>
           <div class="suffix-toggles">
             <label><input type="checkbox" id="suffixCommitted" checked> Committed</label>
-            <label><input type="checkbox" id="suffixPlanned" checked> Planned</label>
+            <label><input type="checkbox" id="suffixPlanned" checked> Planned / Candidate</label>
             <label><input type="checkbox" id="suffixSpillover" checked> Spillover</label>
           </div>
         </div>
@@ -861,6 +861,43 @@
 
     // Planning helpers will be defined below.
 
+    const PI_PLANNING_PATTERN = /^(\d{4})[_-]?pi(\d{1,2})(?:[_-](committed|commited|planned|spillover|candidate))?$/i;
+    const LEGACY_PI_PATTERN = /^(pi\d{1,2})(?:[_-](committed|commited|planned|spillover|candidate))?$/i;
+
+    function normalizePiPlanningLabel(value) {
+      if (typeof value !== 'string') return null;
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      const match = trimmed.match(PI_PLANNING_PATTERN);
+      if (!match) return null;
+      const year = match[1];
+      const piNumber = match[2];
+      let suffix = match[3] ? match[3].toLowerCase() : null;
+      if (suffix === 'commited') suffix = 'committed';
+      const base = `${year}_PI${piNumber}`;
+      const label = suffix ? `${base}_${suffix}` : base;
+      return { base, suffix, label };
+    }
+
+    function parsePiLabel(value) {
+      if (typeof value !== 'string') return null;
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+
+      const planning = normalizePiPlanningLabel(trimmed);
+      if (planning) {
+        return { base: planning.base, suffix: planning.suffix, label: planning.label };
+      }
+
+      const legacyMatch = trimmed.match(LEGACY_PI_PATTERN);
+      if (!legacyMatch) return null;
+      const base = legacyMatch[1].toUpperCase();
+      let suffix = legacyMatch[2] ? legacyMatch[2].toLowerCase() : null;
+      if (suffix === 'commited') suffix = 'committed';
+      const label = suffix ? `${base}_${suffix}` : base;
+      return { base, suffix, label };
+    }
+
     function parseTargetReleaseValues(raw) {
       if (!raw) return [];
       const seenValues = new Set();
@@ -952,10 +989,18 @@
 
     function filterPixTargetReleases(values) {
       if (!Array.isArray(values) || !values.length) return [];
-      const pattern = /^\d{4}_pi\d{1,2}_(?:committed|commited|candidate)$/i;
-      return values
+      const seen = new Set();
+      const results = [];
+      values
         .map(value => typeof value === 'string' ? value.trim() : String(value || '').trim())
-        .filter(value => value && pattern.test(value));
+        .forEach(value => {
+          const normalized = normalizePiPlanningLabel(value);
+          if (!normalized || !normalized.suffix) return;
+          if (seen.has(normalized.label)) return;
+          seen.add(normalized.label);
+          results.push(normalized.label);
+        });
+      return results;
     }
 
     function resolveTargetReleaseValue(fields, targetReleaseField) {
@@ -1027,16 +1072,12 @@
       const matches = [];
       const seen = new Set();
       labels.forEach(label => {
-        if (typeof label !== 'string') return;
-        const trimmed = label.trim();
-        const match = trimmed.match(/^(pi\d{2})(?:[_-](committed|planned|spillover))?$/i);
-        if (!match) return;
-        const base = match[1].toLowerCase();
-        const suffix = match[2] ? match[2].toLowerCase() : null;
-        const key = suffix ? `${base}_${suffix}` : base;
+        const parsed = parsePiLabel(label);
+        if (!parsed) return;
+        const key = parsed.label.toLowerCase();
         if (seen.has(key)) return;
         seen.add(key);
-        matches.push({ base, suffix: suffix === 'committed' || suffix === 'planned' || suffix === 'spillover' ? suffix : null, label: suffix ? `${base}_${suffix}` : base });
+        matches.push({ base: parsed.base, suffix: parsed.suffix, label: parsed.label });
       });
       return matches;
     }
@@ -1483,7 +1524,7 @@
             if (!pi || !pi.base) return;
             if (!selectedPiBases.has(pi.base)) return;
             if (pi.suffix === 'committed' && !allowCommitted) return;
-            if (pi.suffix === 'planned' && !allowPlanned) return;
+            if ((pi.suffix === 'planned' || pi.suffix === 'candidate') && !allowPlanned) return;
             if (pi.suffix === 'spillover' && !allowSpillover) return;
             piMatch = true;
           });
@@ -1526,7 +1567,7 @@
             if (!pi || !pi.base) return;
             if (!selectedPiBases.has(pi.base)) return;
             if (pi.suffix === 'committed' && !allowCommitted) return;
-            if (pi.suffix === 'planned' && !allowPlanned) return;
+            if ((pi.suffix === 'planned' || pi.suffix === 'candidate') && !allowPlanned) return;
             if (pi.suffix === 'spillover' && !allowSpillover) return;
             piMatch = true;
           });
@@ -2276,7 +2317,7 @@
             items.forEach(({ issue, boardId }) => {
               const normalized = normalizeEpic(issue, boardId, responsibleField, state.targetReleaseFieldKeys);
               if (!normalized.hasValidPixTarget) {
-                Logger.debug(`Skipping epic ${normalized.key} – missing YEAR_PIx_(committed|candidate) target release.`);
+                Logger.debug(`Skipping epic ${normalized.key} – missing YEAR_PIx_(committed|planned|spillover|candidate) target release.`);
                 return;
               }
               if (epicMap.has(normalized.key)) {
@@ -2289,8 +2330,14 @@
                     const source = (normalized.pis || []).find(pi => pi.label === label)
                       || (existing.pis || []).find(pi => pi.label === label);
                     if (source) return { ...source };
-                    const [base, suffix] = label.split('_');
-                    return { base: base || label, suffix: suffix || null, label };
+                    const parsed = parsePiLabel(label);
+                    if (parsed) {
+                      return { base: parsed.base, suffix: parsed.suffix, label: parsed.label };
+                    }
+                    const parts = label.split('_');
+                    const suffix = parts.length > 1 ? parts.pop() : null;
+                    const base = parts.join('_') || label;
+                    return { base, suffix, label };
                   });
               } else {
                 epicMap.set(normalized.key, normalized);


### PR DESCRIPTION
## Summary
- normalize PI planning labels from target release fields, supporting committed, planned, spillover, and candidate suffixes with year-prefixed patterns
- update epic parsing, filtering, and UI toggles so candidate items are treated alongside planned work and PI selections stay consistent

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e396f10a74832580b29a228c6b5e87