### PR TITLE
Remove start date from release timeline metadata

### DIFF
--- a/target_release_dashboard.html
+++ b/target_release_dashboard.html
@@ -1962,7 +1962,6 @@
         const issueCount = bucket.issues.length;
         let metaSpans = [];
         if (bucket.release) {
-          const startDate = bucket.release.startDate ? formatDate(bucket.release.startDate) : 'Not set';
           const releaseDate = bucket.release.releaseDate ? formatDate(bucket.release.releaseDate) : 'Not set';
           const boardName = bucket.release.boardId !== undefined
             ? state.boardsMap.get(Number(bucket.release.boardId))?.name || `Board ${bucket.release.boardId}`
@@ -1973,7 +1972,6 @@
               : bucket.release.projectName
             : (bucket.release.projectKey || '');
           metaSpans = [
-            `<span><span class="timeline-date-label">Start</span> ${startDate}</span>`,
             `<span><span class="timeline-date-label">Release</span> ${releaseDate}</span>`,
             `<span><span class="timeline-date-label">Issues</span> ${issueCount}</span>`,
           ];


### PR DESCRIPTION
## Summary
- remove the release start date metadata from timeline items so the UI no longer shows a constant "Not set" entry

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3a06e8e848325a824da4d7f4093ae