### PR TITLE
Fix Kanban simulation horizon to respect target date

### DIFF
--- a/team_progression_mock.html
+++ b/team_progression_mock.html
@@ -1087,11 +1087,14 @@
       return Math.ceil(backlogItems / targetWeeks);
     }
 
-    function getTargetWeeksFromDates(startDateText, targetDateText) {
+    function getWeeksUntilTargetDate(targetDateText, referenceDate = new Date()) {
       if (!targetDateText) return 8;
-      const start = toTimeValue(`${startDateText || KANBAN_DEFAULT_START_DATE}T00:00:00.000Z`);
       const target = toTimeValue(`${targetDateText}T00:00:00.000Z`);
-      if (start === null || target === null || target <= start) return 1;
+      if (target === null) return 8;
+      const referenceStart = new Date(referenceDate);
+      referenceStart.setUTCHours(0, 0, 0, 0);
+      const start = referenceStart.getTime();
+      if (target <= start) return 1;
       const days = Math.ceil((target - start) / (1000 * 60 * 60 * 24));
       return Math.max(1, Math.ceil(days / 7));
     }
@@ -1150,7 +1153,7 @@
       const filteredIssues = kanbanIssues.filter(issue => selectedEpicSet.has(issue.fields?.parent?.key || 'UNASSIGNED'));
       const throughputStartDate = kanbanDateFromInput.value || KANBAN_DEFAULT_START_DATE;
       const throughput = calculateWeeklyThroughputFromIssues(filteredIssues, { startDate: throughputStartDate });
-      const targetWeeks = getTargetWeeksFromDates(throughputStartDate, kanbanTargetDateInput.value);
+      const targetWeeks = getWeeksUntilTargetDate(kanbanTargetDateInput.value);
 
         const nonZero = throughput.buckets.filter(v => v > 0);
         const med = median(nonZero.length ? nonZero : throughput.buckets);


### PR DESCRIPTION
### Motivation
- The Kanban Monte Carlo simulation and "required issues/week" metric were effectively using a fixed/default horizon (or the throughput start date) instead of the remaining time until the selected target date, so the target date did not influence forecasts.

### Description
- Replaced `getTargetWeeksFromDates` with `getWeeksUntilTargetDate(targetDateText, referenceDate)` which computes the week horizon from a reference date (defaults to today at UTC midnight) to the provided target date, updated `renderKanbanReportView` to call `getWeeksUntilTargetDate(kanbanTargetDateInput.value)`, and preserved safe fallbacks for missing/invalid/past dates (returns `8` as a fallback or clamps to `1` week for past targets).

### Testing
- Validated the change with repository checks including `rg` to locate `getWeeksUntilTargetDate`, `git diff` to inspect the patch, and committed the updated `team_progression_mock.html`; the searches and diff confirmed the helper and its usage in the Kanban rendering path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b13d5e792c83258c069a9f421a35fb)